### PR TITLE
Handle unresolved JS import when type is exported with the same name

### DIFF
--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -533,9 +533,12 @@ ExportMap.parse = function (path, content, context) {
         case 'TSTypeAliasDeclaration':
         case 'TSInterfaceDeclaration':
         case 'TSAbstractClassDeclaration':
-        case 'TSModuleDeclaration':
-          m.namespace.set(n.declaration.id.name, captureDoc(source, docStyleParsers, n));
+        case 'TSModuleDeclaration': {
+          const meta = captureDoc(docStyleParsers, n);
+          meta.exportKind = n.exportKind;
+          m.namespace.set(n.declaration.id.name, meta);
           break;
+        }
         case 'VariableDeclaration':
           n.declaration.declarations.forEach((d) =>
             recursivePatternCapture(d.id,

--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -50,7 +50,14 @@ module.exports = {
               `${im[key].name} not found via ${deepPath}`);
           } else {
             context.report(im[key],
-              im[key].name + ' not found in \'' + node.source.value + '\'');
+              `${im[key].name} not found in '${node.source.value}'`);
+          }
+        } else if (node.importKind === 'value') {
+          const meta = deepLookup.path[deepLookup.path.length - 1].namespace.get(im[key].name);
+          const wrongType = meta && meta.exportKind !== undefined && meta.exportKind !== 'value';
+          if (wrongType) {
+            context.report(im[key],
+              `${im[key].name} not found in '${node.source.value}'`);
           }
         }
       });

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -216,6 +216,22 @@ ruleTester.run('named', rule, {
       parser: require.resolve('babel-eslint'),
       errors: ["MyMissingClass not found in './flowtypes'"],
     }),
+    test({
+      code: 'import { MyType } from "./flowtypes"',
+      parser: require.resolve('babel-eslint'),
+      errors: [{
+        message: "MyType not found in './flowtypes'",
+        type: 'Identifier',
+      }],
+    }),
+    test({
+      code: 'import type { MissingType } from "./flowtypes"',
+      parser: require.resolve('babel-eslint'),
+      errors: [{
+        message: "MissingType not found in './flowtypes'",
+        type: 'Identifier',
+      }],
+    }),
 
     // jsnext
     test({


### PR DESCRIPTION
This was not giving any error

```
// fileA.js
export type MyType = {};

// fileB.js
import { MyType } from './fileA.js' 
```

P.S. Some specs are failing in master?
```
1) ExportMap does not return a cached copy after modification:
2) exports-last valid
        const foo = 'bar'
        export default function foo () {
          const very = 'multiline'
        }
        export const bar = true
      :
```