### PR TITLE
Handle nested main packages as main packages.

### DIFF
--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -34,7 +34,7 @@ function isExternalPath(path, name, settings) {
 }
 
 const externalModuleRegExp = /^\w/
-function isExternalModule(name, settings, path) {
+export function isExternalModule(name, settings, path) {
   return externalModuleRegExp.test(name) && isExternalPath(path, name, settings)
 }
 

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -1,7 +1,7 @@
 import path from 'path'
 
 import resolve from 'eslint-module-utils/resolve'
-import { isBuiltIn, isExternalModuleMain, isScopedMain } from '../core/importType'
+import { isBuiltIn, isExternalModule, isScopedMain } from '../core/importType'
 import docsUrl from '../docsUrl'
 
 const enumValues = { enum: [ 'always', 'ignorePackages', 'never' ] }
@@ -144,7 +144,7 @@ module.exports = {
       const extension = path.extname(resolvedPath || importPath).substring(1)
 
       // determine if this is a module
-      const isPackageMain = isExternalModuleMain(importPath, context.settings)
+      const isPackageMain = isExternalModule(importPath, context.settings)
         || isScopedMain(importPath)
 
       if (!extension || !importPath.endsWith(`.${extension}`)) {

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -301,10 +301,6 @@ ruleTester.run('extensions', rule, {
           message: 'Missing file extension for "./Component"',
           line: 4,
           column: 31,
-        }, {
-          message: 'Missing file extension for "foo/baz"',
-          line: 5,
-          column: 25,
         },
       ],
     }),


### PR DESCRIPTION
There are cases like "redux-saga/effects" or "lodash/get" where you cannot or don't want to put extensions. Theoretically all folders of a package can have 'package.json' with `main` clause.

In the case of *redux-saga/effects* it also conflicts with rule `import/no-unresolved`.