### PR TITLE
[Tests] `no-cycles` Add failing tests for commonjs imports 

### DIFF
--- a/tests/files/cycles/cjs/depth-one.js
+++ b/tests/files/cycles/cjs/depth-one.js
@@ -1,0 +1,2 @@
+var foo = require("../depth-zero")
+module.exports = { foo }

--- a/tests/files/cycles/cjs/depth-three-indirect.js
+++ b/tests/files/cycles/cjs/depth-three-indirect.js
@@ -1,0 +1,5 @@
+require('./depth-two')
+
+module.exports = function bar() {
+    return "side effects???"
+}

--- a/tests/files/cycles/cjs/depth-three-star.js
+++ b/tests/files/cycles/cjs/depth-three-star.js
@@ -1,0 +1,2 @@
+var two = require("./depth-two")
+module.exports = { two }

--- a/tests/files/cycles/cjs/depth-two.js
+++ b/tests/files/cycles/cjs/depth-two.js
@@ -1,0 +1,2 @@
+var { foo } = require("./depth-one")
+module.exports = { foo }

--- a/tests/src/rules/no-cycle.js
+++ b/tests/src/rules/no-cycle.js
@@ -12,7 +12,7 @@ const test = def => _test(Object.assign(def, {
   filename: testFilePath('./cycles/depth-zero.js'),
 }));
 
-const testDialects = ['es6'];
+const testDialects = ['es6', 'cjs'];
 
 ruleTester.run('no-cycle', rule, {
   valid: [].concat(


### PR DESCRIPTION
As part of https://github.com/benmosher/eslint-plugin-import/issues/1056

This is expected to break the build, as at the moment ["the infrastructure only registers import statements in dependencies, so cycles created by require within imported modules may not be detected."](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-cycle.md).