### PR TITLE
Add `allowAliasing` option to import/no-default-export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Added
 - [`import/default`]: support default export in TSExportAssignment ([#1528], thanks [@joaovieira])
 - [`no-cycle`]: add `ignoreExternal` option ([#1681], thanks [@sveyret])
+- [`import/no-default-export`]: add an `allowAliasing` option ([#1767], thanks [@k-yle])
 
 ### Fixed
 - [`group-exports`]: Flow type export awareness ([#1702], thanks [@ernestostifano])
@@ -675,6 +676,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#1767]: https://github.com/benmosher/eslint-plugin-import/pull/1767
 [#1726]: https://github.com/benmosher/eslint-plugin-import/issues/1726
 [#1724]: https://github.com/benmosher/eslint-plugin-import/issues/1724
 [#1722]: https://github.com/benmosher/eslint-plugin-import/issues/1722

--- a/docs/rules/no-default-export.md
+++ b/docs/rules/no-default-export.md
@@ -58,6 +58,17 @@ export { foo, bar }
 export * from './other-module'
 ```
 
+### `allowAliasing` option
+
+If `allowAliasing` is true, then aliased default exports are allowed.
+
+The following patterns are not considered warnings (if `allowAliasing: true`):
+
+```javascript
+export { foo as default } from "./foo";
+```
+
+
 ## When Not To Use It
 
 If you don't care if default imports are used, or if you prefer default imports over named imports.

--- a/src/rules/no-default-export.js
+++ b/src/rules/no-default-export.js
@@ -1,8 +1,15 @@
+const schema = {
+  'type': 'object',
+  'properties': {
+    'allowAliasing': { 'type': 'boolean' },
+  },
+  'additionalProperties': false,
+}
 module.exports = {
   meta: {
     type: 'suggestion',
     docs: {},
-    schema: [],
+    schema: [schema],
   },
 
   create(context) {
@@ -16,6 +23,8 @@ module.exports = {
       `Do not alias \`${local.name}\` as \`default\`. Just export ` +
       `\`${local.name}\` itself instead.`
 
+    const { allowAliasing } = context.options[0];
+
     return {
       ExportDefaultDeclaration(node) {
         context.report({node, message: preferNamed})
@@ -27,7 +36,8 @@ module.exports = {
               specifier.exported.name === 'default') {
             context.report({node, message: preferNamed})
           } else if (specifier.type === 'ExportSpecifier' &&
-              specifier.exported.name === 'default') {
+              specifier.exported.name === 'default' && 
+              !allowAliasing) {
             context.report({node, message: noAliasDefault(specifier)})
           }
         })

--- a/src/rules/no-default-export.js
+++ b/src/rules/no-default-export.js
@@ -23,7 +23,7 @@ module.exports = {
       `Do not alias \`${local.name}\` as \`default\`. Just export ` +
       `\`${local.name}\` itself instead.`
 
-    const { allowAliasing } = context.options[0] || {};
+    const { allowAliasing } = context.options[0] || {}
 
     return {
       ExportDefaultDeclaration(node) {

--- a/src/rules/no-default-export.js
+++ b/src/rules/no-default-export.js
@@ -23,7 +23,7 @@ module.exports = {
       `Do not alias \`${local.name}\` as \`default\`. Just export ` +
       `\`${local.name}\` itself instead.`
 
-    const { allowAliasing } = context.options[0];
+    const { allowAliasing } = context.options[0] || {};
 
     return {
       ExportDefaultDeclaration(node) {

--- a/tests/src/rules/no-default-export.js
+++ b/tests/src/rules/no-default-export.js
@@ -84,6 +84,12 @@ ruleTester.run('no-default-export', rule, {
       code: `export Memory, { MemoryValue } from './Memory'`,
       parser: require.resolve('babel-eslint'),
     }),
+
+    // acceptable if allowAliasing is true
+    test({
+      code: 'export { foo as default } from "./foo";',
+      options: [{ allowAliasing: true }],
+    }),
   ],
   invalid: [
     test({
@@ -117,6 +123,15 @@ ruleTester.run('no-default-export', rule, {
         type: 'ExportNamedDeclaration',
         message: 'Prefer named exports.',
       }],
+    }),
+    // still errors if allowAliasing=true
+    test({
+      code: 'export default function bar() {};',
+      errors: [{
+        type: 'ExportDefaultDeclaration',
+        message: 'Prefer named exports.',
+      }],
+      options: [{ allowAliasing: true }],
     }),
   ],
 })


### PR DESCRIPTION
The `import/no-default-export` rule has two parts 

- banning syntax like `export default function () {}` and `export default foo;`
- banning aliased default exports (e.g. `export { foo as default } from "./foot";`)

In our use case, we only want to ban the first syntax, but allow aliased importing. This is because we use React lazy/suspense which requires default exports to be used.

This PR adds an `allowAliasing` option to allow just aliased exports

Hope this PR is okay. Haven't worked with eslint plugins much  