### PR TITLE
[WIP]: add custom groups 

### DIFF
--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -349,10 +349,6 @@ function convertGroupsToRanks(groups) {
       group = [group]
     }
     group.forEach(function(groupItem) {
-      if (types.indexOf(groupItem) === -1) {
-        throw new Error('Incorrect configuration of the rule: Unknown type `' +
-          JSON.stringify(groupItem) + '`')
-      }
       if (res[groupItem] !== undefined) {
         throw new Error('Incorrect configuration of the rule: `' + groupItem + '` is duplicated')
       }

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -2057,6 +2057,23 @@ ruleTester.run('order', rule, {
         message: '`..` import should occur before import of `../a`',
       }],
     }),
+    test({
+      code: `
+        import a from 'namespace-1/a'
+        import c from 'namespace-2/c',
+        import b from 'namespace-1/b'
+        import d from 'namespace-2/d'
+      `,
+      output: `
+        import a from 'namespace-1/a'
+        import b from 'namespace-1/b'
+        import c from 'namespace-2/c',
+        import d from 'namespace-2/d'
+      `,
+      options: [{
+        groups: ['namespace-1/**/*', 'namespace-2/**/*'],
+      }],
+    }),
     // Alphabetize with require
     ...semver.satisfies(eslintPkg.version, '< 3.0.0') ? [] : [
       test({


### PR DESCRIPTION
[DARFT]

Based on issue: https://github.com/benmosher/eslint-plugin-import/issues/1015
Adds a possibility to pass custom glob pattern as a custom group

Usage example
```
"groups": [
	"builtin",
	"external",
	"consts/**/*",
	"utils/**/*",
	"sibling",
]
```