### PR TITLE
Allow mapping of expected extensions in import/extension rule

### DIFF
--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -24,6 +24,7 @@ function buildProperties(context) {
     defaultConfig: 'never',
     pattern: {},
     ignorePackages: false,
+    extensionMap: [],
   };
 
   context.options.forEach(obj => {
@@ -31,6 +32,11 @@ function buildProperties(context) {
     // If this is a string, set defaultConfig to its value
     if (typeof obj === 'string') {
       result.defaultConfig = obj;
+      return;
+    }
+
+    if (obj.extensionMap !== undefined) {
+      result.extensionMap = obj.extensionMap;
       return;
     }
 
@@ -49,6 +55,7 @@ function buildProperties(context) {
     if (obj.ignorePackages !== undefined) {
       result.ignorePackages = obj.ignorePackages;
     }
+
   });
 
   if (result.defaultConfig === 'ignorePackages') {
@@ -135,6 +142,10 @@ module.exports = {
       return false;
     }
 
+    function mapExtension(extension, extensionMap) {
+      return extensionMap && extensionMap[extension] ? extensionMap[extension] : extension;
+    }
+
     function checkFileExtension(source) {
       // bail if the declaration doesn't have a source, e.g. "export { foo };"
       if (!source) return;
@@ -154,7 +165,9 @@ module.exports = {
 
       // get extension from resolved path, if possible.
       // for unresolved, use source value.
-      const extension = path.extname(resolvedPath || importPath).substring(1);
+      let extension = path.extname(resolvedPath || importPath).substring(1);
+
+      extension = mapExtension(extension, props.extensionMap);
 
       // determine if this is a module
       const isPackage = isExternalModule(

--- a/tests/files/typescript-import-js-extension/file.ts
+++ b/tests/files/typescript-import-js-extension/file.ts
@@ -1,0 +1,1 @@
+export const helloWorld = 'helloWorld';

--- a/tests/files/typescript-import-js-extension/tsconfig.json
+++ b/tests/files/typescript-import-js-extension/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "baseUrl": "."
+    }
+}

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -1,6 +1,7 @@
 import { RuleTester } from 'eslint';
+import path from 'path';
 import rule from 'rules/extensions';
-import { test, testFilePath } from '../utils';
+import { getTSParsers, test, testFilePath } from '../utils';
 
 const ruleTester = new RuleTester();
 
@@ -586,4 +587,68 @@ ruleTester.run('extensions', rule, {
       ],
     }),
   ],
+});
+
+
+context('TypeScript', function () {
+  getTSParsers().forEach((parser) => {
+    ruleTester.run(`extensions`, rule, {
+      valid: [
+        test({
+          code: 'import { helloWorld } from "./typescript-import-js-extension/file.js"',
+          parser: parser,
+          options: ['always', { 'extensionMap': { 'ts': 'js' } }],
+          settings: {
+            'import/parsers': { [parser]: ['.ts'] },
+            'typescript': { 'extensions': ['.ts'], 'directory': path.resolve(__dirname, '../../files/typescript-import-js-extension/') },
+          },
+        }),
+        test({
+          code: 'import { helloWorld } from "./typescript-import-js-extension/file.ts"',
+          options: ['always', { 'extensionMap': { 'json': 'jsonx' } }],
+          settings: {
+            'import/resolver': {
+              'typescript': { 'extensions': ['.ts'], 'directory': path.resolve(__dirname, '../../files/typescript-import-js-extension/') },
+            },
+          },
+        }),
+      ],
+      invalid: [
+        test({
+          code: 'import { helloWorld } from "./typescript-import-js-extension/file.ts"',
+          options: ['always', { 'extensionMap': { 'ts': 'js' } }],
+          settings: {
+            'import/resolver': {
+              'typescript': { 'extensions': ['.ts'], 'directory': path.resolve(__dirname, '../../files/typescript-import-js-extension/') },
+            },
+          },
+          errors: [
+            {
+              message: 'Missing file extension "js" for "./typescript-import-js-extension/file.ts"',
+              line: 1,
+              column: 28,
+            },
+          ],
+        }),
+
+        test({
+          code: 'import { helloWorld } from "./typescript-import-js-extension/file"',
+          filename: testFilePath('./any/typescript/file.ts'),
+          options: ['always', { 'extensionMap': { 'ts': 'js' } }],
+          settings: {
+            'import/resolver': {
+              'typescript': { 'extensions': ['.ts'], 'directory': path.resolve(__dirname, '../../files/typescript-import-js-extension/') },
+            },
+          },
+          errors: [
+            {
+              message: 'Missing file extension for "./typescript-import-js-extension/file"',
+              line: 1,
+              column: 28,
+            },
+          ],
+        }),
+      ],
+    });
+  });
 });


### PR DESCRIPTION
Because all of the following requirements are true:
- [nodejs requires file extensions when using relative paths](https://nodejs.org/api/esm.html#esm_mandatory_file_extensions)
- [typescript only supports "top-level await" when transpiling to ESM](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#top-level-await)
- [nodejs modules (CJS) don't support "top-level await"](https://github.com/nodejs/node/issues/21267)

Then if someone wants to use Typescript to gereate nodejs apps that use "top-level await", it makes sens to start usiung nodejs's
newly supported ESM. (this is also probably going to apply to more and more module functionalities). To do so, while developping, people have to make sure that all relative imports comply with nodejs's requirement to specify the trailing ".js" file extension.

Typescript has no functionality to enforce ".js" file extensions. Because tslint was deprecated in favor of eslint, I feel
this eslint plugin would make a lot of people happy in filling out the gap.

__Note this is currently a draft which more work__
- [x] implement feature/fix bug
- [ ] write tests
- [ ] update docs
- [ ] make a note in change log

fixes https://github.com/benmosher/eslint-plugin-import/issues/2030