### PR TITLE
[Refactor] switch to an internal replacement for `pkg-up` and `read-pkg-up`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [Unreleased]
 
+### Changed
+- [Refactor] switch to an internal replacement for `pkg-up` and `read-pkg-up` ([#2047], [@mgwalker])
+
 ### Added
 - [`no-unresolved`]: add `caseSensitiveStrict` option ([#1262], thanks [@sergei-startsev])
 - [`no-unused-modules`]: add eslint v8 support ([#2194], thanks [@coderaiser])
@@ -915,7 +918,7 @@ for info on changes for earlier releases.
 [#2160]: https://github.com/import-js/eslint-plugin-import/pull/2160
 [#2158]: https://github.com/import-js/eslint-plugin-import/pull/2158
 [#2156]: https://github.com/import-js/eslint-plugin-import/pull/2156
-[#2149]: https://github.com/benmosher/eslint-plugin-import/pull/2149
+[#2149]: https://github.com/import-js/eslint-plugin-import/pull/2149
 [#2146]: https://github.com/import-js/eslint-plugin-import/pull/2146
 [#2140]: https://github.com/import-js/eslint-plugin-import/pull/2140
 [#2138]: https://github.com/import-js/eslint-plugin-import/pull/2138
@@ -928,6 +931,7 @@ for info on changes for earlier releases.
 [#2083]: https://github.com/import-js/eslint-plugin-import/pull/2083
 [#2075]: https://github.com/import-js/eslint-plugin-import/pull/2075
 [#2071]: https://github.com/import-js/eslint-plugin-import/pull/2071
+[#2047]: https://github.com/import-js/eslint-plugin-import/pull/2047
 [#2034]: https://github.com/import-js/eslint-plugin-import/pull/2034
 [#2028]: https://github.com/import-js/eslint-plugin-import/pull/2028
 [#2026]: https://github.com/import-js/eslint-plugin-import/pull/2026
@@ -1172,8 +1176,8 @@ for info on changes for earlier releases.
 [#2161]: https://github.com/import-js/eslint-plugin-import/issues/2161
 [#2118]: https://github.com/import-js/eslint-plugin-import/issues/2118
 [#2067]: https://github.com/import-js/eslint-plugin-import/issues/2067
-[#2056]: https://github.com/import-js/eslint-plugin-import/issues/2056
 [#2063]: https://github.com/import-js/eslint-plugin-import/issues/2063
+[#2056]: https://github.com/import-js/eslint-plugin-import/issues/2056
 [#1998]: https://github.com/import-js/eslint-plugin-import/issues/1998
 [#1965]: https://github.com/import-js/eslint-plugin-import/issues/1965
 [#1924]: https://github.com/import-js/eslint-plugin-import/issues/1924
@@ -1492,6 +1496,7 @@ for info on changes for earlier releases.
 [@Maxim-Mazurok]: https://github.com/Maxim-Mazurok
 [@maxkomarychev]: https://github.com/maxkomarychev
 [@maxmalov]: https://github.com/maxmalov
+[@mgwalker]: https://github.com/mgwalker
 [@MikeyBeLike]: https://github.com/MikeyBeLike
 [@mplewis]: https://github.com/mplewis
 [@nickofthyme]: https://github.com/nickofthyme

--- a/package.json
+++ b/package.json
@@ -104,14 +104,11 @@
     "doctrine": "^2.1.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-module-utils": "^2.6.2",
-    "find-up": "^2.0.0",
     "has": "^1.0.3",
     "is-core-module": "^2.6.0",
     "is-glob": "^4.0.1",
     "minimatch": "^3.0.4",
     "object.values": "^1.1.4",
-    "pkg-up": "^2.0.0",
-    "read-pkg-up": "^3.0.0",
     "resolve": "^1.20.0",
     "tsconfig-paths": "^3.11.0"
   }

--- a/src/core/packagePath.js
+++ b/src/core/packagePath.js
@@ -1,6 +1,6 @@
 import { dirname } from 'path';
-import findUp from 'find-up';
-import readPkgUp from 'read-pkg-up';
+import pkgUp from 'eslint-module-utils/pkgUp';
+import readPkgUp from 'eslint-module-utils/readPkgUp';
 
 
 export function getContextPackagePath(context) {
@@ -8,12 +8,12 @@ export function getContextPackagePath(context) {
 }
 
 export function getFilePackagePath(filePath) {
-  const fp = findUp.sync('package.json', { cwd: filePath });
+  const fp = pkgUp({ cwd: filePath });
   return dirname(fp);
 }
 
 export function getFilePackageName(filePath) {
-  const { pkg, path } = readPkgUp.sync({ cwd: filePath, normalize: false });
+  const { pkg, path } = readPkgUp({ cwd: filePath, normalize: false });
   if (pkg) {
     // recursion in case of intermediate esm package.json without name found
     return pkg.name || getFilePackageName(dirname(dirname(path)));

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs';
-import readPkgUp from 'read-pkg-up';
+import readPkgUp from 'eslint-module-utils/readPkgUp';
 import minimatch from 'minimatch';
 import resolve from 'eslint-module-utils/resolve';
 import moduleVisitor from 'eslint-module-utils/moduleVisitor';
@@ -69,7 +69,7 @@ function getDependencies(context, packageDir) {
       Object.assign(
         packageContent,
         extractDepFields(
-          readPkgUp.sync({ cwd: context.getPhysicalFilename ? context.getPhysicalFilename() : context.getFilename(), normalize: false }).pkg
+          readPkgUp({ cwd: context.getPhysicalFilename ? context.getPhysicalFilename() : context.getFilename(), normalize: false }).pkg
         )
       );
     }

--- a/src/rules/no-import-module-exports.js
+++ b/src/rules/no-import-module-exports.js
@@ -1,9 +1,9 @@
 import minimatch from 'minimatch';
 import path from 'path';
-import pkgUp from 'pkg-up';
+import pkgUp from 'eslint-module-utils/pkgUp';
 
 function getEntryPoint(context) {
-  const pkgPath = pkgUp.sync(context.getPhysicalFilename ? context.getPhysicalFilename() : context.getFilename());
+  const pkgPath = pkgUp({ cwd: context.getPhysicalFilename ? context.getPhysicalFilename() : context.getFilename() });
   try {
     return require.resolve(path.dirname(pkgPath));
   } catch (error) {

--- a/src/rules/no-relative-packages.js
+++ b/src/rules/no-relative-packages.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import readPkgUp from 'read-pkg-up';
+import readPkgUp from 'eslint-module-utils/readPkgUp';
 
 import resolve from 'eslint-module-utils/resolve';
 import moduleVisitor, { makeOptionsSchema } from 'eslint-module-utils/moduleVisitor';
@@ -7,7 +7,7 @@ import importType from '../core/importType';
 import docsUrl from '../docsUrl';
 
 function findNamedPackage(filePath) {
-  const found = readPkgUp.sync({ cwd: filePath, normalize: false });
+  const found = readPkgUp({ cwd: filePath });
   if (found.pkg && !found.pkg.name) {
     return findNamedPackage(path.join(found.path, '../..'));
   }

--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -10,7 +10,7 @@ import resolve from 'eslint-module-utils/resolve';
 import visit from 'eslint-module-utils/visit';
 import docsUrl from '../docsUrl';
 import { dirname, join } from 'path';
-import readPkgUp from 'read-pkg-up';
+import readPkgUp from 'eslint-module-utils/readPkgUp';
 import values from 'object.values';
 import includes from 'array-includes';
 
@@ -352,7 +352,7 @@ const newDefaultImportExists = specifiers =>
   specifiers.some(({ type }) => type === IMPORT_DEFAULT_SPECIFIER);
 
 const fileIsInPkg = file => {
-  const { path, pkg } = readPkgUp.sync({ cwd: file, normalize: false });
+  const { path, pkg } = readPkgUp({ cwd: file });
   const basePath = dirname(path);
 
   const checkPkgFieldString = pkgField => {

--- a/tests/files/package.json
+++ b/tests/files/package.json
@@ -12,7 +12,7 @@
     "esm-package": "^1.0.0",
     "jquery": "^3.1.0",
     "lodash.cond": "^4.3.0",
-    "pkg-up": "^1.0.0",
+    "find-up": "^1.0.0",
     "rxjs": "^1.0.0"
   },
   "optionalDependencies": {

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -8,6 +8,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Added
 - `fileExistsWithCaseSync`: add `strict` argument ([#1262], thanks [@sergei-startsev])
 - add `visit`, to support dynamic imports ([#1660], [#2212], thanks [@maxkomarychev], [@aladdin-add], [@Hypnosphi])
+- create internal replacement for `pkg-up` and `read-pkg-up` ([#2047], [@mgwalker])
 
 ## v2.6.2 - 2021-08-08
 
@@ -96,6 +97,7 @@ Yanked due to critical issue with cache key resulting from #839.
 
 [#2212]: https://github.com/import-js/eslint-plugin-import/pull/2212
 [#2160]: https://github.com/import-js/eslint-plugin-import/pull/2160
+[#2047]: https://github.com/import-js/eslint-plugin-import/pull/2047
 [#2026]: https://github.com/import-js/eslint-plugin-import/pull/2026
 [#1786]: https://github.com/import-js/eslint-plugin-import/pull/1786
 [#1671]: https://github.com/import-js/eslint-plugin-import/pull/1671
@@ -121,15 +123,15 @@ Yanked due to critical issue with cache key resulting from #839.
 [@brettz9]: https://github.com/brettz9
 [@christophercurrie]: https://github.com/christophercurrie
 [@hulkish]: https://github.com/hulkish
+[@Hypnosphi]: https://github.com/Hypnosphi
 [@iamnapo]: https://github.com/iamnapo
 [@JounQin]: https://github.com/JounQin
 [@kaiyoma]: https://github.com/kaiyoma
 [@manuth]: https://github.com/manuth
+[@maxkomarychev]: https://github.com/maxkomarychev
+[@mgwalker]: https://github.com/mgwalker
 [@pmcelhaney]: https://github.com/pmcelhaney
 [@sergei-startsev]: https://github.com/sergei-startsev
 [@sompylasar]: https://github.com/sompylasar
 [@timkraut]: https://github.com/timkraut
 [@vikr01]: https://github.com/vikr01
-[@maxkomarychev]: https://github.com/maxkomarychev
-[@aladdin-add]: https://github.com/aladdin-add
-[@Hypnosphi]: https://github.com/Hypnosphi

--- a/utils/package.json
+++ b/utils/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/import-js/eslint-plugin-import#readme",
   "dependencies": {
     "debug": "^3.2.7",
+    "find-up": "^2.1.0",
     "pkg-dir": "^2.0.0"
   }
 }

--- a/utils/pkgUp.js
+++ b/utils/pkgUp.js
@@ -1,0 +1,8 @@
+'use strict';
+exports.__esModule = true;
+
+const findUp = require('find-up');
+
+exports.default = function pkgUp(opts) {
+  return findUp.sync('package.json', opts);
+};

--- a/utils/readPkgUp.js
+++ b/utils/readPkgUp.js
@@ -35,7 +35,7 @@ function stripBOM(str) {
  * THE SOFTWARE.
  */
 exports.default = function readPkgUp(opts) {
-  const fp = pkgUp(opts.cwd);
+  const fp = pkgUp(opts);
 
   if (!fp) {
     return {};

--- a/utils/readPkgUp.js
+++ b/utils/readPkgUp.js
@@ -1,0 +1,52 @@
+'use strict';
+exports.__esModule = true;
+
+const fs = require('fs');
+const pkgUp = require('./pkgUp').default;
+
+function stripBOM(str) {
+  return str.replace(/^\uFEFF/, '');
+}
+
+/**
+ * Derived significantly from read-pkg-up@2.0.0. See license below.
+ * 
+ * @copyright Sindre Sorhus
+ * MIT License
+ *
+ * Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+exports.default = function readPkgUp(opts) {
+  const fp = pkgUp(opts.cwd);
+
+  if (!fp) {
+    return {};
+  }
+
+  try {
+    return {
+      pkg: JSON.parse(stripBOM(fs.readFileSync(fp, { encoding: 'utf-8' }))),
+      path: fp,
+    };
+  } catch (e) {
+    return {};
+  }
+};


### PR DESCRIPTION
Inspired by #2046, I dug into what [`read-pkg-up`](https://github.com/sindresorhus/read-pkg-up/tree/v2.0.0) provides and found it to be very simple, for this particular case. Its downstream dependencies build in some safety and options that aren't necessary when you already know you're working with a `package.json`, and in this library's case, when you know you don't want to "normalize" it. Since `read-pkg-up` drags several libraries along with it, at least two of which don't actually add any functionality to `eslint-plugin-import`, and its use here is pretty straightforward, it seemed moderately reasonable to me to reproduce the functionality internally.