### PR TITLE
[New] add `sort-by-length` option to order rule

### DIFF
--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -260,7 +260,7 @@ Sort the order within each group in import string length based on **import path*
 Example setting:
 ```js
 'sort-by-length': {
-  order: 'desc', /* sort in ascending order. Options: ['ignore', 'asc', 'desc'] */
+  order: 'asc', /* sort in ascending order. Options: ['ignore', 'asc', 'desc'] */
 }
 ```
 

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -253,6 +253,41 @@ import React, { PureComponent } from 'react';
 import { compose, apply } from 'xcompose';
 ```
 
+### `sort-by-length: {order: asc|desc|ignore, caseInsensitive: true|false}`:
+
+Sort the order within each group in import string length based on **import path**:
+
+Example setting:
+```js
+'sort-by-length': {
+  order: 'desc', /* sort in ascending order. Options: ['ignore', 'asc', 'desc'] */
+}
+```
+
+This will fail the rule check:
+
+```js
+/* eslint import/order: ["error", {"sort-by-length": {"order": "desc"}}] */
+import React, { PureComponent } from 'react';
+import aTypes from 'prop-types';
+import { compose, apply } from 'xcompose';
+import * as classnames from 'classnames';
+import blist from 'BList';
+```
+
+While this will pass:
+
+```js
+/* eslint import/order: ["error", {"sort-by-length": {"order": "desc"}}] */
+import React, { PureComponent } from 'react';
+import { compose, apply } from 'xcompose';
+import * as classnames from 'classnames';
+import aTypes from 'prop-types';
+import blist from 'BList';
+```
+
+**NOTE**: Do not use this rule with `alphabetize`
+
 ## Related
 
 - [`import/external-module-folders`] setting

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -706,6 +706,63 @@ ruleTester.run('order', rule, {
         },
       ],
     }),
+    // Option sort-by-length: {order: 'ignore'}
+    test({
+      code: `
+        import longModule from 'long-module-name';
+        import short from 'short-module';
+
+        import index from './';
+      `,
+      options: [{
+        groups: ['external', 'index'],
+        'sort-by-length': { order: 'ignore' },
+      }],
+    }),
+    // Option sort-by-length: {order: 'asc'}
+    test({
+      code: `
+        import short from 'short-module';
+        import longModule from 'long-module-name';
+
+        import index from './';
+      `,
+      options: [{
+        groups: ['external', 'index'],
+        'sort-by-length': { order: 'asc' },
+      }],
+    }),
+    // Option sort-by-length: {order: 'desc'}
+    test({
+      code: `
+        import longModule from 'long-module-name';
+        import short from 'short-module';
+
+        import index from './';
+      `,
+      options: [{
+        groups: ['external', 'index'],
+        'sort-by-length': { order: 'desc' },
+      }],
+    }),
+    // Sort by length with different import types
+    test({
+      code: `
+        import { foo , bar } from 'module-name/path/to/specific/un-exported/file';
+        import { export1 as alias } from 'module-name-1';
+        import { export1, export2 } from 'module-name-2';
+        import defaultExport from 'module-name-3';
+        import { export3 } from 'module-4';
+        import * as name from 'module-5';
+
+        import index from './';
+        import './module';
+      `,
+      options: [{
+        groups: ['external', 'index'],
+        'sort-by-length': { order: 'desc' },
+      }],
+    }),
     ...flatMap(getTSParsers, parser => [
       // Order of the `import ... = require(...)` syntax
       test({
@@ -854,10 +911,10 @@ ruleTester.run('order', rule, {
     test({
       code:
         `/* comment0 */  /* comment1 */  var async = require('async'); /* comment2 */` + `\r\n` +
-        `/* comment3 */  var fs = require('fs'); /* comment4 */` + `\r\n`,      
+        `/* comment3 */  var fs = require('fs'); /* comment4 */` + `\r\n`,
       output:
         `/* comment3 */  var fs = require('fs'); /* comment4 */` + `\r\n` +
-        `/* comment0 */  /* comment1 */  var async = require('async'); /* comment2 */` + `\r\n`,      
+        `/* comment0 */  /* comment1 */  var async = require('async'); /* comment2 */` + `\r\n`,
       errors: [{
         message: '`fs` import should occur before import of `async`',
       }],


### PR DESCRIPTION
Add option to `import/order` rule for sorting imports by length.

For example:

```js
// { groups: ['external', 'index'], 'sort-by-length': { order: 'desc' } }

import { foo , bar } from 'module-name/path/to/specific/un-exported/file';
import { export1 as alias } from 'module-name-1';
import { export1, export2 } from 'module-name-2';
import defaultExport from 'module-name-3';
import { export3 } from 'module-4';
import * as name from 'module-5';

import index from './';
import './module';
```