### PR TITLE
[New] `no-namespace`: Add `ignore` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Added
 - [`no-dynamic-require`]: add option `esmodule` ([#1223], thanks [@vikr01])
 - [`named`]: add `commonjs` option ([#1222], thanks [@vikr01])
+- [`no-namespace`]: Add `ignore` option ([#2112], thanks [@aberezkin])
 
 ### Fixed
 - [`no-duplicates`]: ensure autofix avoids excessive newlines ([#2028], thanks [@ertrzyiks])
@@ -822,6 +823,7 @@ for info on changes for earlier releases.
 [#2146]: https://github.com/benmosher/eslint-plugin-import/pull/2146
 [#2138]: https://github.com/benmosher/eslint-plugin-import/pull/2138
 [#2121]: https://github.com/benmosher/eslint-plugin-import/pull/2121
+[#2112]: https://github.com/benmosher/eslint-plugin-import/pull/2112
 [#2099]: https://github.com/benmosher/eslint-plugin-import/pull/2099
 [#2097]: https://github.com/benmosher/eslint-plugin-import/pull/2097
 [#2090]: https://github.com/benmosher/eslint-plugin-import/pull/2090
@@ -1252,6 +1254,7 @@ for info on changes for earlier releases.
 [@1pete]: https://github.com/1pete
 [@3nuc]: https://github.com/3nuc
 [@aamulumi]: https://github.com/aamulumi
+[@aberezkin]: https://github.com/aberezkin
 [@adamborowski]: https://github.com/adamborowski
 [@adjerbetian]: https://github.com/adjerbetian
 [@ai]: https://github.com/ai

--- a/docs/rules/no-namespace.md
+++ b/docs/rules/no-namespace.md
@@ -5,6 +5,12 @@ Enforce a convention of not using namespace (a.k.a. "wildcard" `*`) imports.
 +(fixable) The `--fix` option on the [command line] automatically fixes problems reported by this rule, provided that the namespace object is only used for direct member access, e.g. `namespace.a`.
 The `--fix` functionality for this rule requires ESLint 5 or newer.
 
+### Options
+
+This rule supports the following options:
+
+- `ignore`: array of glob strings for modules that should be ignored by the rule.
+
 ## Rule Details
 
 Valid:
@@ -13,6 +19,11 @@ Valid:
 import defaultExport from './foo'
 import { a, b }  from './bar'
 import defaultExport, { a, b }  from './foobar'
+```
+
+```js
+/* eslint import/no-namespace: ["error", {ignore: ['*.ext']] */
+import * as bar from './ignored-module.ext';
 ```
 
 Invalid:

--- a/tests/src/rules/no-namespace.js
+++ b/tests/src/rules/no-namespace.js
@@ -78,6 +78,7 @@ ruleTester.run('no-namespace', require('rules/no-namespace'), {
     { code: 'import { a, b } from \'./foo\';', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
     { code: 'import bar from \'bar\';', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
     { code: 'import bar from \'./bar\';', parserOptions: { ecmaVersion: 2015, sourceType: 'module' } },
+    { code: 'import * as bar from \'./ignored-module.ext\';', parserOptions: { ecmaVersion: 2015, sourceType: 'module' }, options: [{ ignore: ['*.ext'] }] },
   ],
 
   invalid: [


### PR DESCRIPTION
Closes #1916
Closes #1903

Hi, we want to use the rule `no-namespace` in our project but we have a `i18n` codegen tool that forces us to use wildcard imports for certain files that follow some pattern (`\S+\.i18n`, to be precise). Also I've seen that there's people with similar issue.

I thought that we can implement something similar to `argsIgnorePattern/varsIgnorePattern` in [core eslint rules](https://github.com/eslint/eslint/blob/master/lib/rules/no-unused-vars.js#L107). 

I made a test for that case and updated the docs as well. Please let me know if there's something else I should do to get this merged.