### PR TITLE
[Docs] `order`:  improve the documentation for the `pathGroupsExcludedImportTypes` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Changed
 - [Docs] `extensions`: removed incorrect cases ([#2138], thanks [@wenfangdu])
 - [Tests] `order`: add tests for `pathGroupsExcludedImportTypes: ['type']` ([#2158], thanks [@atav32])
+- [Docs] `order`:  improve the documentation for the `pathGroupsExcludedImportTypes` option ([#2156], thanks [@liby])
 
 ## [2.23.4] - 2021-05-29
 
@@ -812,6 +813,7 @@ for info on changes for earlier releases.
 
 [#2160]: https://github.com/benmosher/eslint-plugin-import/pull/2160
 [#2158]: https://github.com/benmosher/eslint-plugin-import/pull/2158
+[#2156]: https://github.com/benmosher/eslint-plugin-import/pull/2156
 [#2138]: https://github.com/benmosher/eslint-plugin-import/pull/2138
 [#2121]: https://github.com/benmosher/eslint-plugin-import/pull/2121
 [#2099]: https://github.com/benmosher/eslint-plugin-import/pull/2099
@@ -1347,6 +1349,7 @@ for info on changes for earlier releases.
 [@lencioni]: https://github.com/lencioni
 [@leonardodino]: https://github.com/leonardodino
 [@Librazy]: https://github.com/Librazy
+[@liby]: https://github.com/liby
 [@lilling]: https://github.com/lilling
 [@ljharb]: https://github.com/ljharb
 [@ljqx]: https://github.com/ljqx

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -148,6 +148,27 @@ Example:
   }]
 }
 ```
+
+You can also use `patterns`(e.g., `react`, `react-router-dom`, etc).
+
+Example:
+```json
+{
+  "import/order": [
+    "error",
+    {
+      "pathGroups": [
+        {
+          "pattern": "react",
+          "group": "builtin",
+          "position": "before"
+        }
+      ],
+      "pathGroupsExcludedImportTypes": ["react"]
+    }
+  ]
+}
+```
 The default value is `["builtin", "external"]`.
 
 ### `newlines-between: [ignore|always|always-and-inside-groups|never]`:


### PR DESCRIPTION
Motivation: #1665

> I think there's an opportunity to improve the documentation for the pathGroupsExcludedImportTypes option. The documentation made me think the allowed values for pathGroupsExcludedImportTypes were only groups (e.g., builtin, external, etc.) and not patterns (e.g., react, react-router-dom, etc).

I think this paragraph makes a lot of sense, and for a while, I couldn't figure out how to configure this option.