### PR TITLE
Updated debug library version to avoid vulnerabilities scan error

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "dependencies": {
     "array-includes": "^3.1.3",
     "array.prototype.flat": "^1.2.4",
-    "debug": "^2.6.9",
+    "debug": "^4.3.2",
     "doctrine": "^2.1.0",
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-module-utils": "^2.6.1",


### PR DESCRIPTION
Debug Library < 4.1.1 in package.json was being detected as Vulnerable 

Updated Library to >4.1.3 that is considered to be non vulnerable