### PR TITLE
[Fix] correct recognize external modules in pnp mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,24 @@ settings:
   import/internal-regex: ^@scope/
 ```
 
+#### `import/pnp`
+
+Enable Plug'n'Play resolution. Set `true` if you are using `yarn berry` or `pnpm`.
+
+```yaml
+# .eslintrc.yml
+settings:
+  import/pnp: true
+```
+
+Also, you can provide custom cache folder if you are using non-standard path. Default value is `.yarn/cache`
+
+```yaml
+# .eslintrc.yml
+settings:
+  import/pnp:
+    cacheFolder: .yarn/cache
+```
 
 ## SublimeLinter-eslint
 

--- a/src/core/importType.js
+++ b/src/core/importType.js
@@ -41,11 +41,14 @@ function isExternalPath(name, settings, path, packagePath) {
   if (internalScope && new RegExp(internalScope).test(name)) {
     return false;
   }
-
   if (!path || relative(packagePath, path).startsWith('..')) {
     return true;
   }
 
+  const isPnpEnabled = !!(settings && settings['import/pnp']);
+  if (path && isPnpEnabled && path.startsWith(packagePath + '/.yarn')) {
+    return true;
+  }
   const folders = (settings && settings['import/external-module-folders']) || ['node_modules'];
   return folders.some((folder) => {
     const folderPath = nodeResolve(packagePath, folder);


### PR DESCRIPTION
PR should fix this issue #2176 

I created a repository https://github.com/KostyaZgara/eslint-plugin-import-berry-issue-example to reproduce an error.

The problem was `external` module was recognized only when `path` is not resolved (undefined) and the `isExternalPath` function tries to find a module in `node_modules` or provided external module folders, but not found cuz with PnP mode `node_modules` doesn't exist.

So, the issue was resolved by adding new setting `import/pnp` (check README to see usage) and searching cache entry in resolved path