### PR TITLE
[Fix] ExportMap: Add default export when esModuleInterop is true and anything is exported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## [Unreleased]
 
+### Fixe
+- `ExportMap`: Add default export when esModuleInterop is true and anything is exported ([#2184], thanks [@Maxim-Mazurok])
+
 ## [2.24.0] - 2021-08-08
 
 ### Added
@@ -822,6 +825,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2184]: https://github.com/import-js/eslint-plugin-import/pull/2184
 [#2179]: https://github.com/import-js/eslint-plugin-import/pull/2179
 [#2160]: https://github.com/import-js/eslint-plugin-import/pull/2160
 [#2158]: https://github.com/import-js/eslint-plugin-import/pull/2158

--- a/tests/files/typescript-export-react-test-renderer/index.d.ts
+++ b/tests/files/typescript-export-react-test-renderer/index.d.ts
@@ -1,0 +1,19 @@
+// case from @types/react-test-renderer
+
+export {};
+
+export interface ReactTestRendererJSON {
+    type: string;
+    props: { [propName: string]: any };
+    children: null | ReactTestRendererNode[];
+}
+export type ReactTestRendererNode = ReactTestRendererJSON | string;
+export interface ReactTestRendererTree extends ReactTestRendererJSON {
+    nodeType: 'component' | 'host';
+    instance: any;
+    rendered: null | ReactTestRendererTree | ReactTestRendererTree[];
+}
+
+export function create(nextElement: any, options?: any): any;
+
+export function act(callback: () => Promise<any>): Promise<undefined>;

--- a/tests/files/typescript-export-react-test-renderer/tsconfig.json
+++ b/tests/files/typescript-export-react-test-renderer/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "esModuleInterop": true
+    }
+}

--- a/tests/src/rules/default.js
+++ b/tests/src/rules/default.js
@@ -221,6 +221,17 @@ context('TypeScript', function () {
           },
         }),
         test({
+          code: `import Foo from "./typescript-export-react-test-renderer"`,
+          parser: parser,
+          settings: {
+            'import/parsers': { [parser]: ['.ts'] },
+            'import/resolver': { 'eslint-import-resolver-typescript': true },
+          },
+          parserOptions: {
+            tsconfigRootDir: path.resolve(__dirname, '../../files/typescript-export-react-test-renderer/'),
+          },
+        }),
+        test({
           code: `import foobar from "./typescript-export-assign-property"`,
           parser: parser,
           settings: {


### PR DESCRIPTION
This PR aims to fix #2183 by adding default export if anything is exported and `esModuleInterop` is set to true.

This probably should've been done in #1689 that I originally opened to add `esModuleInterop` support.
