### PR TITLE
Fix test cases of no-amd and no-commonjs

### DIFF
--- a/tests/src/rules/no-amd.js
+++ b/tests/src/rules/no-amd.js
@@ -2,7 +2,7 @@ import { RuleTester } from 'eslint';
 import eslintPkg from 'eslint/package.json';
 import semver from 'semver';
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015, sourceType: 'module' } });
 
 ruleTester.run('no-amd', require('rules/no-amd'), {
   valid: [

--- a/tests/src/rules/no-commonjs.js
+++ b/tests/src/rules/no-commonjs.js
@@ -5,7 +5,7 @@ import semver from 'semver';
 const EXPORT_MESSAGE = 'Expected "export" or "export default"';
 const IMPORT_MESSAGE = 'Expected "import" instead of "require()"';
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015, sourceType: 'module' } });
 
 ruleTester.run('no-commonjs', require('rules/no-commonjs'), {
   valid: [


### PR DESCRIPTION
This PR fixes the no-amd and no-commonjs rule test cases.
See https://github.com/import-js/eslint-plugin-import/pull/2191#discussion_r689245594.

Previous test cases depended on the babel-eslint v8 patch to work. The following command fails because the babel-eslint v8 patch is not used.

```bash
npx cross-env BABEL_ENV=test nyc -s mocha tests/src/rules/no-amd.js
npx cross-env BABEL_ENV=test nyc -s mocha tests/src/rules/no-commonjs.js
```

With this PR, the test cases will work even with the above command.