### PR TITLE
Document `ignoreTypeImports` option for max-dependencies rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 - `ExportMap`: Add default export when esModuleInterop is true and anything is exported ([#2184], thanks [@Maxim-Mazurok])
 
+### Changed
+- [Docs] `max-dependencies`: 📖 Document `ignoreTypeImports` option ([#2196], thanks [@himynameisdave])
+
 ## [2.24.0] - 2021-08-08
 
 ### Added
@@ -887,6 +890,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2196]: https://github.com/import-js/eslint-plugin-import/pull/2196
 [#2184]: https://github.com/import-js/eslint-plugin-import/pull/2184
 [#2179]: https://github.com/import-js/eslint-plugin-import/pull/2179
 [#2160]: https://github.com/import-js/eslint-plugin-import/pull/2160
@@ -1401,6 +1405,7 @@ for info on changes for earlier releases.
 [@grit96]: https://github.com/grit96
 [@guillaumewuip]: https://github.com/guillaumewuip
 [@hayes]: https://github.com/hayes
+[@himynameisdave]: https://github.com/himynameisdave
 [@hulkish]: https://github.com/hulkish
 [@Hypnosphi]: https://github.com/Hypnosphi
 [@isiahmeadows]: https://github.com/isiahmeadows

--- a/docs/rules/max-dependencies.md
+++ b/docs/rules/max-dependencies.md
@@ -6,20 +6,20 @@ This is a useful rule because a module with too many dependencies is a code smel
 
 Importing multiple named exports from a single module will only count once (e.g. `import {x, y, z} from './foo'` will only count as a single dependency).
 
-### Options
+## Options
 
-This rule takes the following option:
-
-`max`: The maximum number of dependencies allowed. Anything over will trigger the rule. **Default is 10** if the rule is enabled and no `max` is specified.
-
-You can set the option like this:
+This rule has the following options, with these defaults:
 
 ```js
-"import/max-dependencies": ["error", {"max": 10}]
+"import/max-dependencies": ["error", {
+  "max": 10,
+  "ignoreTypeImports": false,
+}]
 ```
 
+### `max`
 
-## Example
+This option sets the maximum number of dependencies allowed. Anything over will trigger the rule. **Default is 10** if the rule is enabled and no `max` is specified.
 
 Given a max value of `{"max": 2}`:
 
@@ -37,6 +37,28 @@ import c from './c'; // 3 - exceeds max!
 import a from './a'; // 1
 const anotherA = require('./a'); // still 1
 import {x, y, z} from './foo'; // 2
+```
+
+### `ignoreTypeImports`
+
+Ignores `type` imports. Type imports are a feature released in TypeScript 3.8, you can [read more here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export). Defaults to `false`.
+
+Given `{"max": 2, "ignoreTypeImports": true}`:
+
+### Fail
+
+```ts
+import a from './a';
+import b from './b';
+import c from './c';
+```
+
+### Pass
+
+```ts
+import a from './a';
+import b from './b';
+import type c from './c'; // Doesn't count against max
 ```
 
 ## When Not To Use It


### PR DESCRIPTION
Adds documentation for the `ignoreTypeImports` option which was introduced here: https://github.com/import-js/eslint-plugin-import/pull/1847

