### PR TITLE
`no-restricted-paths` support glob patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Added
 - [`no-unused-modules`]: add eslint v8 support ([#2194], thanks [@coderaiser])
+- [`no-restricted-paths`]: add/restore glob pattern support ([#2219], thanks [@stropho])
 
 ## [2.24.2] - 2021-08-24
 
@@ -903,6 +904,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2219]: https://github.com/import-js/eslint-plugin-import/pull/2219
 [#2196]: https://github.com/import-js/eslint-plugin-import/pull/2196
 [#2194]: https://github.com/import-js/eslint-plugin-import/pull/2194
 [#2184]: https://github.com/import-js/eslint-plugin-import/pull/2184

--- a/docs/rules/no-restricted-paths.md
+++ b/docs/rules/no-restricted-paths.md
@@ -9,8 +9,18 @@ In order to prevent such scenarios this rule allows you to define restricted zon
 
 This rule has one option. The option is an object containing the definition of all restricted `zones` and the optional `basePath` which is used to resolve relative paths within.
 The default value for `basePath` is the current working directory.
-Each zone consists of the `target` path and a `from` path. The `target` is the path where the restricted imports should be applied. The `from` path defines the folder that is not allowed to be used in an import. An optional `except` may be defined for a zone, allowing exception paths that would otherwise violate the related `from`. Note that `except` is relative to `from` and cannot backtrack to a parent directory.
-You may also specify an optional `message` for a zone, which will be displayed in case of the rule violation.
+
+Each zone consists of the `target` path, a `from` path, and an optional `except` and `message` attribute.
+- `target` is the path where the restricted imports should be applied. It can be expressed by
+    - directory string path that matches all its containing files
+    - glob pattern matching all the targeted files
+- `from` path defines the folder that is not allowed to be used in an import.  It can be expressed by
+    - directory string path that matches all its containing files
+    - glob pattern matching all the files restricted to be imported
+- `except` may be defined for a zone, allowing exception paths that would otherwise violate the related `from`. Note that it does not alter the behaviour of `target` in any way.
+    - in case `from` is a glob pattern, `except` must be an array of glob patterns as well
+    - in case `from` is a directory path, `except` is relative to `from` and cannot backtrack to a parent directory.
+- `message` - will be displayed in case of the rule violation.
 
 ### Examples
 
@@ -77,4 +87,40 @@ The following pattern is not considered a problem:
 
 ```js
 import b from './b'
+
+```
+
+---------------
+
+Given the following folder structure:
+
+```
+my-project
+├── client
+    └── foo.js
+    └── sub-module
+        └── bar.js
+        └── baz.js
+
+```
+
+and the current configuration is set to:
+
+```
+{ "zones": [ {
+    "target": "./tests/files/restricted-paths/client/!(sub-module)/**/*",
+    "from": "./tests/files/restricted-paths/client/sub-module/**/*",
+} ] }
+```
+
+The following import is considered a problem in `my-project/client/foo.js`:
+
+```js
+import a from './sub-module/baz'
+```
+
+The following import is not considered a problem in `my-project/client/sub-module/bar.js`:
+
+```js
+import b from './baz'
 ```

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "find-up": "^2.0.0",
     "has": "^1.0.3",
     "is-core-module": "^2.6.0",
+    "is-glob": "^4.0.1",
     "minimatch": "^3.0.4",
     "object.values": "^1.1.4",
     "pkg-up": "^2.0.0",

--- a/tests/src/rules/no-restricted-paths.js
+++ b/tests/src/rules/no-restricted-paths.js
@@ -15,6 +15,23 @@ ruleTester.run('no-restricted-paths', rule, {
       } ],
     }),
     test({
+      code: 'import a from "../client/a.js"',
+      filename: testFilePath('./restricted-paths/server/b.js'),
+      options: [ {
+        zones: [ { target: '**/*', from: './tests/files/restricted-paths/other' } ],
+      } ],
+    }),
+    test({
+      code: 'import a from "../client/a.js"',
+      filename: testFilePath('./restricted-paths/client/b.js'),
+      options: [ {
+        zones: [ {
+          target: './tests/files/restricted-paths/!(client)/**/*',
+          from: './tests/files/restricted-paths/client/**/*',
+        } ],
+      } ],
+    }),
+    test({
       code: 'const a = require("../client/a.js")',
       filename: testFilePath('./restricted-paths/server/b.js'),
       options: [ {
@@ -61,7 +78,17 @@ ruleTester.run('no-restricted-paths', rule, {
         } ],
       } ],
     }),
-
+    test({
+      code: 'import A from "../two/a.js"',
+      filename: testFilePath('./restricted-paths/server/one/a.js'),
+      options: [ {
+        zones: [ {
+          target: '**/*',
+          from: './tests/files/restricted-paths/server/**/*',
+          except: ['**/a.js'],
+        } ],
+      } ],
+    }),
 
     // irrelevant function calls
     test({ code: 'notrequire("../server/b.js")' }),
@@ -86,6 +113,18 @@ ruleTester.run('no-restricted-paths', rule, {
       filename: testFilePath('./restricted-paths/client/a.js'),
       options: [ {
         zones: [ { target: './tests/files/restricted-paths/client', from: './tests/files/restricted-paths/server' } ],
+      } ],
+      errors: [ {
+        message: 'Unexpected path "../server/b.js" imported in restricted zone.',
+        line: 1,
+        column: 15,
+      } ],
+    }),
+    test({
+      code: 'import b from "../server/b.js"',
+      filename: testFilePath('./restricted-paths/client/a.js'),
+      options: [ {
+        zones: [ { target: './tests/files/restricted-paths/client/**/*', from: './tests/files/restricted-paths/server' } ],
       } ],
       errors: [ {
         message: 'Unexpected path "../server/b.js" imported in restricted zone.',
@@ -186,6 +225,37 @@ ruleTester.run('no-restricted-paths', rule, {
       errors: [ {
         message: 'Restricted path exceptions must be descendants of the configured ' +
           '`from` path for that zone.',
+        line: 1,
+        column: 15,
+      } ],
+    }),
+    test({
+      code: 'import A from "../two/a.js"',
+      filename: testFilePath('./restricted-paths/server/one/a.js'),
+      options: [ {
+        zones: [ {
+          target: '**/*',
+          from: './tests/files/restricted-paths/server/**/*',
+        } ],
+      } ],
+      errors: [ {
+        message: 'Unexpected path "../two/a.js" imported in restricted zone.',
+        line: 1,
+        column: 15,
+      } ],
+    }),
+    test({
+      code: 'import A from "../two/a.js"',
+      filename: testFilePath('./restricted-paths/server/one/a.js'),
+      options: [ {
+        zones: [ {
+          target: '**/*',
+          from: './tests/files/restricted-paths/server/**/*',
+          except: ['a.js'],
+        } ],
+      } ],
+      errors: [ {
+        message: 'Restricted path exceptions must be glob patterns when`from` is a glob pattern',
         line: 1,
         column: 15,
       } ],


### PR DESCRIPTION
Connected to https://github.com/import-js/eslint-plugin-import/issues/2123

Added support for glob patterns. More details in `docs/rules/no-restricted-paths.md` in this PR

Although it would be easier to replace the rule so it works with globs only, I tried to don't make any breaking changes 🤞 