### PR TITLE
[Fix] `order`: Fix import ordering in TypeScript module declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 - [`no-unresolved`]: ignore type-only imports ([#2220], thanks [@jablko])
+- [`order`]: fix sorting imports inside TypeScript module declarations ([#2226], thanks [@remcohaszing])
 
 ### Changed
 - [Refactor] switch to an internal replacement for `pkg-up` and `read-pkg-up` ([#2047], thanks [@mgwalker])
@@ -913,6 +914,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2226]: https://github.com/import-js/eslint-plugin-import/pull/2226
 [#2220]: https://github.com/import-js/eslint-plugin-import/pull/2220
 [#2219]: https://github.com/import-js/eslint-plugin-import/pull/2219
 [#2212]: https://github.com/import-js/eslint-plugin-import/pull/2212
@@ -1520,6 +1522,7 @@ for info on changes for earlier releases.
 [@ramasilveyra]: https://github.com/ramasilveyra
 [@randallreedjr]: https://github.com/randallreedjr
 [@redbugz]: https://github.com/redbugz
+[@remcohaszing]: https://github.com/remcohaszing
 [@rfermann]: https://github.com/rfermann
 [@rhettlivingston]: https://github.com/rhettlivingston
 [@rhys-vdw]: https://github.com/rhys-vdw

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -2462,6 +2462,24 @@ context('TypeScript', function () {
               },
             ],
           }),
+          // Imports inside module declaration
+          test({
+            code: `
+              import type { CopyOptions } from 'fs';
+              import type { ParsedPath } from 'path';
+
+              declare module 'my-module' {
+                import type { CopyOptions } from 'fs';
+                import type { ParsedPath } from 'path';
+              }
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: { order: 'asc' },
+              },
+            ],
+          }),
         ],
         invalid: [
           // Option alphabetize: {order: 'asc'}
@@ -2654,6 +2672,38 @@ context('TypeScript', function () {
               message: '`./local` import should occur after import of `global3`',
             }],
             options: [{ warnOnUnassignedImports: true }],
+          }),
+          // Imports inside module declaration
+          test({
+            code: `
+              import type { ParsedPath } from 'path';
+              import type { CopyOptions } from 'fs';
+
+              declare module 'my-module' {
+                import type { ParsedPath } from 'path';
+                import type { CopyOptions } from 'fs';
+              }
+            `,
+            output: `
+              import type { CopyOptions } from 'fs';
+              import type { ParsedPath } from 'path';
+
+              declare module 'my-module' {
+                import type { CopyOptions } from 'fs';
+                import type { ParsedPath } from 'path';
+              }
+            `,
+            errors: [{
+              message: '`fs` import should occur before import of `path`',
+            },{
+              message: '`fs` import should occur before import of `path`',
+            }],
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: { order: 'asc' },
+              },
+            ],
           }),
         ],
       });


### PR DESCRIPTION
Without this, `import/order` checks if all imports in a file are sorted. The autofix would then move all imports to the type of the file, breaking TypeScript module declarations.

Closes #2217