### PR TITLE
[New] `no-duplicates`: add `combineTypeImports` option to de-duplicate flow type imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`no-unused-modules`]: add eslint v8 support ([#2194], thanks [@coderaiser])
 - [`no-restricted-paths`]: add/restore glob pattern support ([#2219], thanks [@stropho])
 - [`no-unused-modules`]: support dynamic imports ([#1660], [#2212], thanks [@maxkomarychev], [@aladdin-add], [@Hypnosphi])
+- [`no-duplicates`]: add `combineTypeImports` option to de-duplicate flow type imports ([#2229], thanks [@christianvuerings])
 
 ## [2.24.2] - 2021-08-24
 
@@ -906,6 +907,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2229]: https://github.com/import-js/eslint-plugin-import/pull/2229
 [#2219]: https://github.com/import-js/eslint-plugin-import/pull/2219
 [#2212]: https://github.com/import-js/eslint-plugin-import/pull/2212
 [#2196]: https://github.com/import-js/eslint-plugin-import/pull/2196

--- a/docs/rules/no-duplicates.md
+++ b/docs/rules/no-duplicates.md
@@ -14,12 +14,11 @@ is different in two key ways:
 Valid:
 ```js
 import SomeDefaultClass, * as names from './mod'
-// Flow `type` import from same module is fine
+// By default the flow `type` import from same module is fine (see combineTypeImports)
 import type SomeType from './mod'
 ```
 
-...whereas here, both `./mod` imports will be reported:
-
+Invalid:
 ```js
 import SomeDefaultClass from './mod'
 
@@ -36,7 +35,8 @@ The motivation is that this is likely a result of two developers importing diffe
 names from the same module at different times (and potentially largely different
 locations in the file.) This rule brings both (or n-many) to attention.
 
-### Query Strings
+## Options
+### considerQueryString
 
 By default, this rule ignores query strings (i.e. paths followed by a question mark), and thus imports from `./mod?a` and `./mod?b` will be considered as duplicates. However you can use the option `considerQueryString` to handle them as different (primarily because browsers will resolve those imports differently).
 
@@ -59,6 +59,25 @@ import SomeDefaultClass from './mod?minify'
 
 // This is invalid, assuming `./mod` and `./mod.js` are the same target:
 import * from './mod.js?minify'
+```
+
+### combineTypeImports
+
+By default, this rule ignores flow & typescript type imports. However you can use the option `combineTypeImports` to combine type imports with regular imports.
+
+Currently only `flow` is supported.
+
+Valid:
+```js
+/*eslint import/no-unresolved: [2, { combineTypeImports: "flow" }]*/
+import x, { type y } from './foo'
+```
+
+Invalid:
+```js
+/*eslint import/no-unresolved: [2, { combineTypeImports: "flow" }]*/
+import { type y } from './foo' // reported since './foo' is imported twice
+import { x } from './foo'
 ```
 
 ## When Not To Use It

--- a/tests/src/rules/no-duplicates.js
+++ b/tests/src/rules/no-duplicates.js
@@ -412,6 +412,51 @@ import {x,y} from './foo'
       output: "import Bar, { Foo } from './foo';\nexport const value = {}",
       errors: ['\'./foo\' imported multiple times.', '\'./foo\' imported multiple times.'],
     }),
+
+    // #2229 add option to de-duplicate flow type imports
+    test({
+      code: "import { x } from './foo'; import type { y } from './foo'",
+      output: "import { x ,type y} from './foo'; ",
+      errors: ['\'./foo\' imported multiple times.', '\'./foo\' imported multiple times.'],
+      options: [{ 'combineTypeImports': 'flow' }],
+      parser: require.resolve('babel-eslint'),
+    }),
+
+    // #2229 add option to de-duplicate flow type imports
+    test({
+      code: "import { x } from './foo'; import type {y} from './foo'",
+      output: "import { x ,type y} from './foo'; ",
+      errors: ['\'./foo\' imported multiple times.', '\'./foo\' imported multiple times.'],
+      options: [{ 'combineTypeImports': 'flow' }],
+      parser: require.resolve('babel-eslint'),
+    }),
+
+    // #2229 add option to de-duplicate flow type imports
+    test({
+      code: "import { type x } from './foo'; import { y } from './foo'",
+      output: "import { type x , y } from './foo'; ",
+      errors: ['\'./foo\' imported multiple times.', '\'./foo\' imported multiple times.'],
+      options: [{ 'combineTypeImports': 'flow' }],
+      parser: require.resolve('babel-eslint'),
+    }),
+
+    // #2229 add option to de-duplicate flow type imports
+    test({
+      code: "import { type x } from './foo'; import type { y } from './foo'",
+      output: "import { type x ,type y} from './foo'; ",
+      errors: ['\'./foo\' imported multiple times.', '\'./foo\' imported multiple times.'],
+      options: [{ 'combineTypeImports': 'flow' }],
+      parser: require.resolve('babel-eslint'),
+    }),
+
+    // #2229 add option to de-duplicate flow type imports
+    test({
+      code: "import { type x } from './foo'; import type { y } from './foo'; import type { z } from './foo'",
+      output: "import { type x ,type y,type z} from './foo';  ",
+      errors: ['\'./foo\' imported multiple times.', '\'./foo\' imported multiple times.', '\'./foo\' imported multiple times.'],
+      options: [{ 'combineTypeImports': 'flow' }],
+      parser: require.resolve('babel-eslint'),
+    }),
   ],
 });
 
@@ -429,7 +474,7 @@ context('TypeScript', function () {
 
       ruleTester.run('no-duplicates', rule, {
         valid: [
-        // #1667: ignore duplicate if is a typescript type import
+          // #1667: ignore duplicate if is a typescript type import
           test({
             code: "import type { x } from './foo'; import y from './foo'",
             ...parserConfig,


### PR DESCRIPTION
## Description

[#334](https://github.com/import-js/eslint-plugin-import/pull/334) always duplicated flow type imports. In this diff we add the `combineTypeImports` option to be able to de-duplicate flow type imports.

TypeScript support can be added later, for now we only support combining regular & flow type imports.

Fixes: #909

## Related PRs / Issues

- https://github.com/import-js/eslint-plugin-import/pull/334: Check duplicates for normal imports and flow type imports separately
- https://github.com/import-js/eslint-plugin-import/issues/909: Request: option to let no-duplicates force type & normal imports to be de-duplicated
