### PR TITLE
[Refactor] `no-unresolved`, `no-extraneous-dependencies`: moduleVisitor usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Changed
 - [Refactor] switch to an internal replacement for `pkg-up` and `read-pkg-up` ([#2047], thanks [@mgwalker])
 - [patch] TypeScript config: remove `.d.ts` from [`import/parsers` setting] and [`import/extensions` setting] ([#2220], thanks [@jablko])
+- [Refactor] [`no-unresolved`], [`no-extraneous-dependencies`]: moduleVisitor usage ([#2233], thanks [@jablko])
 
 ## [2.24.2] - 2021-08-24
 
@@ -914,6 +915,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2233]: https://github.com/import-js/eslint-plugin-import/pull/2233
 [#2226]: https://github.com/import-js/eslint-plugin-import/pull/2226
 [#2220]: https://github.com/import-js/eslint-plugin-import/pull/2220
 [#2219]: https://github.com/import-js/eslint-plugin-import/pull/2219

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -162,7 +162,6 @@ function reportIfMissing(context, deps, depsOptions, node, name) {
   // Do not report when importing types
   if (
     node.importKind === 'type' ||
-    (node.parent && node.parent.importKind === 'type') ||
     node.importKind === 'typeof'
   ) {
     return;

--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -26,9 +26,9 @@ module.exports = {
   create(context) {
     const options = context.options[0] || {};
 
-    function checkSourceValue(source) {
+    function checkSourceValue(source, node) {
       // ignore type-only imports
-      if (source.parent && source.parent.importKind === 'type') {
+      if (node.importKind === 'type') {
         return;
       }
 


### PR DESCRIPTION
I overlooked the second moduleVisitor callback parameter (the ImportDeclaration/ImportExpression) in #2220. Doesn't make a functional difference, just tidier than recovering `node` from `node.source`: https://github.com/import-js/eslint-plugin-import/blob/4f0f560544b4d6dcd2d1b7d5880bd5238099f979/utils/moduleVisitor.js#L34