### PR TITLE
[New] give resolvers access to parserServices

### DIFF
--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -431,7 +431,7 @@ ExportMap.parse = function (path, content, context) {
   const namespaces = new Map();
 
   function remotePath(value) {
-    return resolve.relative(value, path, context.settings);
+    return resolve.relative(value, path, context);
   }
 
   function resolveImport(value) {


### PR DESCRIPTION
Is there a way for resolvers to access [parserServices](https://eslint.org/docs/developer-guide/working-with-rules#the-context-object)? If not, what do you think about enabling it, maybe like so?