### PR TITLE
Resolve extended TypeScript configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 - [`no-unresolved`]: ignore type-only imports ([#2220], thanks [@jablko])
 - [`order`]: fix sorting imports inside TypeScript module declarations ([#2226], thanks [@remcohaszing])
+- [`default`], `ExportMap`: Resolve extended TypeScript configuration files ([#2240], thanks [@mrmckeb])
 
 ### Changed
 - [Refactor] switch to an internal replacement for `pkg-up` and `read-pkg-up` ([#2047], thanks [@mgwalker])
@@ -915,6 +916,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2240]: https://github.com/import-js/eslint-plugin-import/pull/2240
 [#2233]: https://github.com/import-js/eslint-plugin-import/pull/2233
 [#2226]: https://github.com/import-js/eslint-plugin-import/pull/2226
 [#2220]: https://github.com/import-js/eslint-plugin-import/pull/2220
@@ -1509,6 +1511,7 @@ for info on changes for earlier releases.
 [@mgwalker]: https://github.com/mgwalker
 [@MikeyBeLike]: https://github.com/MikeyBeLike
 [@mplewis]: https://github.com/mplewis
+[@mrmckeb]: https://github.com/mrmckeb
 [@nickofthyme]: https://github.com/nickofthyme
 [@nicolashenry]: https://github.com/nicolashenry
 [@noelebrun]: https://github.com/noelebrun

--- a/tests/files/typescript-extended-config/index.d.ts
+++ b/tests/files/typescript-extended-config/index.d.ts
@@ -1,0 +1,3 @@
+export = FooBar;
+
+declare namespace FooBar {}

--- a/tests/files/typescript-extended-config/tsconfig.base.json
+++ b/tests/files/typescript-extended-config/tsconfig.base.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}

--- a/tests/files/typescript-extended-config/tsconfig.json
+++ b/tests/files/typescript-extended-config/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {}
+}

--- a/tests/src/rules/default.js
+++ b/tests/src/rules/default.js
@@ -232,6 +232,17 @@ context('TypeScript', function () {
           },
         }),
         test({
+          code: `import Foo from "./typescript-extended-config"`,
+          parser,
+          settings: {
+            'import/parsers': { [parser]: ['.ts'] },
+            'import/resolver': { 'eslint-import-resolver-typescript': true },
+          },
+          parserOptions: {
+            tsconfigRootDir: path.resolve(__dirname, '../../files/typescript-extended-config/'),
+          },
+        }),
+        test({
           code: `import foobar from "./typescript-export-assign-property"`,
           parser,
           settings: {


### PR DESCRIPTION
This PR resolves #1908.

In a comparison I ran locally, the output is:
```js
// New method - includes extended configuration
{
  options: {
    esModuleInterop: true,
    forceConsistentCasingInFileNames: true,
    noFallthroughCasesInSwitch: true,
    skipLibCheck: true,
    strict: true,
    baseUrl: '[redacted]/tsconfig.json',
    allowJs: true,
    jsx: 1,
    target: 99,
    module: 99,
    lib: [ 'lib.dom.d.ts', 'lib.esnext.d.ts' ],
    noEmit: true,
    moduleResolution: 2,
    resolveJsonModule: true,
    isolatedModules: true,
    incremental: true,
    paths: { '~/*': [ './*' ], '@*': [ '../shared/*' ] },
    pathsBasePath: '[redacted]/tsconfig.json',
    configFilePath: undefined
  }
  // ...
}

// Old method - only references the config to extend.
{
  extends: '[extended-config-name]',
  compilerOptions: {
    baseUrl: '.',
    allowJs: true,
    jsx: 'preserve',
    target: 'ESNext',
    module: 'ESNext',
    lib: [ 'DOM', 'ESNext' ],
    noEmit: true,
    moduleResolution: 'node',
    resolveJsonModule: true,
    isolatedModules: true,
    incremental: true,
    paths: { '~/*': [Array], '@*': [Array] }
  },
  // ...
}
```

For reference, the shared config has:
```json
{
  "compilerOptions": {
    "esModuleInterop": true,
    "forceConsistentCasingInFileNames": true,
    "noFallthroughCasesInSwitch": true,
    "skipLibCheck": true,
    "strict": true
  }
}
```