### PR TITLE
[readme] Add note to TypeScript docs to install appropriate resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 - [`extensions`]: ignore unresolveable type-only imports ([#2270], [#2271], [@jablko])
 
 ### Changed
-- [Docs] order: add type to the default groups ([#2272], [@charpeni])
+- [Docs] [`order`]: add type to the default groups ([#2272], [@charpeni])
+- [readme] Add note to TypeScript docs to install appropriate resolver ([#2279], [@johnthagen])
 
 ## [2.25.2] - 2021-10-12
 
@@ -1492,6 +1493,7 @@ for info on changes for earlier releases.
 [@jkimbo]: https://github.com/jkimbo
 [@joaovieira]: https://github.com/joaovieira
 [@johndevedu]: https://github.com/johndevedu
+[@johnthagen]: https://github.com/johnthagen
 [@jonboiser]: https://github.com/jonboiser
 [@josh]: https://github.com/josh
 [@JounQin]: https://github.com/JounQin

--- a/README.md
+++ b/README.md
@@ -174,6 +174,9 @@ extends:
 
 [`@typescript-eslint/parser`]: https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/parser
 
+You will also need to install and configure the TypeScript resolver:
+[`eslint-import-resolver-typescript`](https://github.com/alexgorbatchev/eslint-import-resolver-typescript).
+
 # Resolvers
 
 With the advent of module bundlers and the current state of modules and module


### PR DESCRIPTION
Make it more discoverable for new TypeScript users that they need  to install the TypeScript resolver.

Addresses this comment: https://github.com/import-js/eslint-plugin-import/issues/2236#issuecomment-949812173