### PR TITLE
[Docs] `order`: Remove duplicate mention of default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - `importType`: avoid crashing on a non-string' ([#2305], thanks [@ljharb])
 
 ### Changed
-- [`no-default-import`]: report on the token "default" instead of the entire node ([#2299], [@pmcelhaney])
+- [`no-default-import`]: report on the token "default" instead of the entire node ([#2299], thanks [@pmcelhaney])
+- [Docs] [`order`]: Remove duplicate mention of default ([#2280], thanks [@johnthagen])
 
 ## [2.25.3] - 2021-11-09
 
@@ -948,14 +949,12 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
-<<<<<<< HEAD
 [#2305]: https://github.com/import-js/eslint-plugin-import/pull/2305
-=======
 [#2299]: https://github.com/import-js/eslint-plugin-import/pull/2299
->>>>>>> 374ce41e... [Fix] `no-default-import`: report on the token "default" instead of the entire node
 [#2297]: https://github.com/import-js/eslint-plugin-import/pull/2297
 [#2287]: https://github.com/import-js/eslint-plugin-import/pull/2287
 [#2282]: https://github.com/import-js/eslint-plugin-import/pull/2282
+[#2280]: https://github.com/import-js/eslint-plugin-import/pull/2280
 [#2279]: https://github.com/import-js/eslint-plugin-import/pull/2279
 [#2272]: https://github.com/import-js/eslint-plugin-import/pull/2272
 [#2271]: https://github.com/import-js/eslint-plugin-import/pull/2271

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -175,10 +175,12 @@ The default value is `["builtin", "external"]`.
 
 Enforces or forbids new lines between import groups:
 
-- If set to `ignore`, no errors related to new lines between import groups will be reported (default).
+- If set to `ignore`, no errors related to new lines between import groups will be reported.
 - If set to `always`, at least one new line between each group will be enforced, and new lines inside a group will be forbidden. To prevent multiple lines between imports, core `no-multiple-empty-lines` rule can be used.
 - If set to `always-and-inside-groups`, it will act like `always` except newlines are allowed inside import groups.
 - If set to `never`, no new lines are allowed in the entire import section.
+
+The default value is `"ignore"`.
 
 With the default group setting, the following will be invalid:
 


### PR DESCRIPTION
Update docs for `import` rule / `newlines-between` option. Default value is taken from:

https://github.com/import-js/eslint-plugin-import/blob/ccb69d9a41e484802ecbfb88c5320defbf803902/src/rules/order.js#L588