### PR TITLE
Exclude `no-unresolved` in TypeScript config

### DIFF
--- a/config/typescript.js
+++ b/config/typescript.js
@@ -27,5 +27,8 @@ module.exports = {
 
     // TypeScript compilation already ensures that named imports exist in the referenced module
     'import/named': 'off',
+
+    // TypeScript compilation already ensures that imports can be resolved
+    'import/no-unresolved': 'off',
   },
 };


### PR DESCRIPTION
I think this rule isn't useful on TS codebase