### PR TITLE
[Fix] `dynamic-import-chunkname`: add handling webpack magic comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`order`]: require with member expression could not be fixed if alphabetize.order was used ([#2490], thanks [@msvab])
 - [`order`]: leave more space in rankings for consecutive path groups ([#2506], thanks [@Pearce-Ropion])
 - [`no-cycle`]: add ExportNamedDeclaration statements to dependencies ([#2511], thanks [@BenoitZugmeyer])
+- [`dynamic-import-chunkname`]: prevent false report on a valid webpack magic comment ([#2330], thanks [@mhmadhamster])
 
 ### Changed
 - [Tests] `named`: Run all TypeScript test ([#2427], thanks [@ProdigySim])
@@ -1027,6 +1028,7 @@ for info on changes for earlier releases.
 [#2358]: https://github.com/import-js/eslint-plugin-import/pull/2358
 [#2341]: https://github.com/import-js/eslint-plugin-import/pull/2341
 [#2334]: https://github.com/import-js/eslint-plugin-import/pull/2334
+[#2330]: https://github.com/import-js/eslint-plugin-import/pull/2330
 [#2305]: https://github.com/import-js/eslint-plugin-import/pull/2305
 [#2299]: https://github.com/import-js/eslint-plugin-import/pull/2299
 [#2297]: https://github.com/import-js/eslint-plugin-import/pull/2297
@@ -1652,6 +1654,7 @@ for info on changes for earlier releases.
 [@maxkomarychev]: https://github.com/maxkomarychev
 [@maxmalov]: https://github.com/maxmalov
 [@mgwalker]: https://github.com/mgwalker
+[@mhmadhamster]: https://github.com/MhMadHamster
 [@MikeyBeLike]: https://github.com/MikeyBeLike
 [@mplewis]: https://github.com/mplewis
 [@mrmckeb]: https://github.com/mrmckeb

--- a/src/rules/dynamic-import-chunkname.js
+++ b/src/rules/dynamic-import-chunkname.js
@@ -27,10 +27,10 @@ module.exports = {
   create(context) {
     const config = context.options[0];
     const { importFunctions = [] } = config || {};
-    const { webpackChunknameFormat = '[0-9a-zA-Z-_/.]+' } = config || {};
+    const { webpackChunknameFormat = '([0-9a-zA-Z-_/.]|\\[(request|index)\\])+' } = config || {};
 
     const paddedCommentRegex = /^ (\S[\s\S]+\S) $/;
-    const commentStyleRegex = /^( \w+: (["'][^"']*["']|\d+|false|true),?)+ $/;
+    const commentStyleRegex = /^( ((webpackChunkName: .+)|((webpackPrefetch|webpackPreload): (true|false|-?[0-9]+))|(webpackIgnore: (true|false))|((webpackInclude|webpackExclude): \/.*\/)|(webpackMode: ["'](lazy|lazy-once|eager|weak)["'])|(webpackExports: (['"]\w+['"]|\[(['"]\w+['"], *)+(['"]\w+['"]*)\]))),?)+ $/;
     const chunkSubstrFormat = ` webpackChunkName: ["']${webpackChunknameFormat}["'],? `;
     const chunkSubstrRegex = new RegExp(chunkSubstrFormat);
 
@@ -83,7 +83,7 @@ module.exports = {
           context.report({
             node,
             message:
-              `dynamic imports require a leading comment in the form /*${chunkSubstrFormat}*/`,
+              `dynamic imports require a "webpack" comment with valid syntax`,
           });
           return;
         }

--- a/tests/src/rules/dynamic-import-chunkname.js
+++ b/tests/src/rules/dynamic-import-chunkname.js
@@ -5,7 +5,7 @@ import semver from 'semver';
 const rule = require('rules/dynamic-import-chunkname');
 const ruleTester = new RuleTester();
 
-const commentFormat = '[0-9a-zA-Z-_/.]+';
+const commentFormat = '([0-9a-zA-Z-_/.]|\\[(request|index)\\])+';
 const pickyCommentFormat = '[a-zA-Z-_/.]+';
 const options = [{ importFunctions: ['dynamicImport'] }];
 const pickyCommentOptions = [{
@@ -21,8 +21,9 @@ const noLeadingCommentError = 'dynamic imports require a leading comment with th
 const nonBlockCommentError = 'dynamic imports require a /* foo */ style comment, not a // foo comment';
 const noPaddingCommentError = 'dynamic imports require a block comment padded with spaces - /* foo */';
 const invalidSyntaxCommentError = 'dynamic imports require a "webpack" comment with valid syntax';
-const commentFormatError = `dynamic imports require a leading comment in the form /* webpackChunkName: ["']${commentFormat}["'],? */`;
-const pickyCommentFormatError = `dynamic imports require a leading comment in the form /* webpackChunkName: ["']${pickyCommentFormat}["'],? */`;
+const commentFormatError = `dynamic imports require a "webpack" comment with valid syntax`;
+const chunkNameFormatError = `dynamic imports require a leading comment in the form /* webpackChunkName: ["']${commentFormat}["'],? */`;
+const pickyChunkNameFormatError = `dynamic imports require a leading comment in the form /* webpackChunkName: ["']${pickyCommentFormat}["'],? */`;
 
 ruleTester.run('dynamic-import-chunkname', rule, {
   valid: [
@@ -53,6 +54,34 @@ ruleTester.run('dynamic-import-chunkname', rule, {
         'someModule'
       )`,
       options: pickyCommentOptions,
+    },
+    {
+      code: `dynamicImport(
+        /* webpackChunkName: "[request]" */
+        'someModule'
+      )`,
+      options,
+    },
+    {
+      code: `dynamicImport(
+        /* webpackChunkName: "my-chunk-[request]-custom" */
+        'someModule'
+      )`,
+      options,
+    },
+    {
+      code: `dynamicImport(
+        /* webpackChunkName: '[index]' */
+        'someModule'
+      )`,
+      options,
+    },
+    {
+      code: `dynamicImport(
+        /* webpackChunkName: 'my-chunk.[index].with-index' */
+        'someModule'
+      )`,
+      options,
     },
     {
       code: `import(
@@ -130,6 +159,24 @@ ruleTester.run('dynamic-import-chunkname', rule, {
     },
     {
       code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackPrefetch: 12 */
+        'test'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackPrefetch: -30 */
+        'test'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
         /* webpackChunkName: 'someModule' */
         'someModule'
       )`,
@@ -142,6 +189,217 @@ ruleTester.run('dynamic-import-chunkname', rule, {
         'someModule'
       )`,
       options: pickyCommentOptions,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "[request]" */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "my-chunk-[request]-custom" */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: '[index]' */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: 'my-chunk.[index].with-index' */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackInclude: /\\.json$/ */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule", webpackInclude: /\\.json$/ */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackExclude: /\\.json$/ */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule", webpackExclude: /\\.json$/ */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackPreload: true */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackPreload: 0 */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackPreload: -2 */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule", webpackPreload: false */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackIgnore: false */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule", webpackIgnore: true */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackMode: "lazy" */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: 'someModule', webpackMode: 'lazy' */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackMode: "lazy-once" */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackMode: "eager" */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackMode: "weak" */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackExports: "default" */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule", webpackExports: "named" */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackExports: ["default", "named"] */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: 'someModule', webpackExports: ['default', 'named'] */
+        'someModule'
+      )`,
+      options,
+      parser,
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "someModule" */
+        /* webpackInclude: /\\.json$/ */
+        /* webpackExclude: /\\.json$/ */
+        /* webpackPrefetch: true */
+        /* webpackPreload: true */
+        /* webpackIgnore: false */
+        /* webpackMode: "eager" */
+        /* webpackExports: ["default", "named"] */
+        'someModule'
+      )`,
+      options,
       parser,
     },
     ...SYNTAX_CASES,
@@ -256,6 +514,54 @@ ruleTester.run('dynamic-import-chunkname', rule, {
     },
     {
       code: `import(
+        /* webpackChunkName: true */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackChunkName: true */
+        'someModule'
+      )`,
+      errors: [{
+        message: chunkNameFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackChunkName: "my-module-[id]" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackChunkName: "my-module-[id]" */
+        'someModule'
+      )`,
+      errors: [{
+        message: chunkNameFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackChunkName: ["request"] */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackChunkName: ["request"] */
+        'someModule'
+      )`,
+      errors: [{
+        message: chunkNameFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
         /*webpackChunkName: "someModule"*/
         'someModule'
       )`,
@@ -364,7 +670,183 @@ ruleTester.run('dynamic-import-chunkname', rule, {
         'someModule'
       )`,
       errors: [{
-        message: pickyCommentFormatError,
+        message: pickyChunkNameFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackPrefetch: "module", webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackPrefetch: "module", webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      errors: [{
+        message: commentFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackPreload: "module", webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackPreload: "module", webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      errors: [{
+        message: commentFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackIgnore: "no", webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackIgnore: "no", webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      errors: [{
+        message: commentFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackInclude: "someModule", webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackInclude: "someModule", webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      errors: [{
+        message: commentFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackInclude: true, webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackInclude: true, webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      errors: [{
+        message: commentFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackExclude: "someModule", webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackExclude: "someModule", webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      errors: [{
+        message: commentFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackExclude: true, webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackExclude: true, webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      errors: [{
+        message: commentFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackMode: "fast", webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackMode: "fast", webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      errors: [{
+        message: commentFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackMode: true, webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackMode: true, webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      errors: [{
+        message: commentFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackExports: true, webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackExports: true, webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      errors: [{
+        message: commentFormatError,
+        type: 'CallExpression',
+      }],
+    },
+    {
+      code: `import(
+        /* webpackExports: /default/, webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      options,
+      parser,
+      output: `import(
+        /* webpackExports: /default/, webpackChunkName: "someModule" */
+        'someModule'
+      )`,
+      errors: [{
+        message: commentFormatError,
         type: 'CallExpression',
       }],
     },
@@ -478,7 +960,7 @@ ruleTester.run('dynamic-import-chunkname', rule, {
         'someModule'
       )`,
       errors: [{
-        message: pickyCommentFormatError,
+        message: pickyChunkNameFormatError,
         type: 'CallExpression',
       }],
     },
@@ -570,19 +1052,226 @@ context('TypeScript', () => {
         {
           code: `import(
             /* webpackChunkName: "someModule" */
+            /* webpackPrefetch: 11 */
+            'test'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule" */
+            /* webpackPrefetch: -11 */
+            'test'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule" */
             'someModule'
           )`,
           options: pickyCommentOptions,
           parser: typescriptParser,
-          errors: [{
-            message: pickyCommentFormatError,
-            type: nodeType,
-          }],
         },
         {
           code: `import(
             /* webpackChunkName: 'someModule' */
             'test'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "[request]" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "my-chunk-[request]-custom" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: '[index]' */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: 'my-chunk.[index].with-index' */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule" */
+            /* webpackInclude: /\\.json$/ */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule", webpackInclude: /\\.json$/ */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule" */
+            /* webpackExclude: /\\.json$/ */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule", webpackExclude: /\\.json$/ */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule" */
+            /* webpackPreload: true */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule", webpackPreload: false */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule" */
+            /* webpackIgnore: false */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule", webpackIgnore: true */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule" */
+            /* webpackMode: "lazy" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: 'someModule', webpackMode: 'lazy' */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule" */
+            /* webpackMode: "lazy-once" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule" */
+            /* webpackMode: "eager" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule" */
+            /* webpackMode: "weak" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule" */
+            /* webpackExports: "default" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule", webpackExports: "named" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule" */
+            /* webpackExports: ["default", "named"] */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: 'someModule', webpackExports: ['default', 'named'] */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "someModule" */
+            /* webpackInclude: /\\.json$/ */
+            /* webpackExclude: /\\.json$/ */
+            /* webpackPrefetch: true */
+            /* webpackPreload: true */
+            /* webpackIgnore: false */
+            /* webpackMode: "eager" */
+            /* webpackExports: ["default", "named"] */
+            'someModule'
           )`,
           options,
           parser: typescriptParser,
@@ -795,6 +1484,54 @@ context('TypeScript', () => {
         },
         {
           code: `import(
+            /* webpackChunkName: true */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackChunkName: true */
+            'someModule'
+          )`,
+          errors: [{
+            message: chunkNameFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackChunkName: "my-module-[id]" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackChunkName: "my-module-[id]" */
+            'someModule'
+          )`,
+          errors: [{
+            message: chunkNameFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackChunkName: ["request"] */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackChunkName: ["request"] */
+            'someModule'
+          )`,
+          errors: [{
+            message: chunkNameFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
             /* webpackChunkName: "someModule123" */
             'someModule'
           )`,
@@ -805,7 +1542,183 @@ context('TypeScript', () => {
             'someModule'
           )`,
           errors: [{
-            message: pickyCommentFormatError,
+            message: pickyChunkNameFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackPrefetch: "module", webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackPrefetch: "module", webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          errors: [{
+            message: commentFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackPreload: "module", webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackPreload: "module", webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          errors: [{
+            message: commentFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackIgnore: "no", webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackIgnore: "no", webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          errors: [{
+            message: commentFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackInclude: "someModule", webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackInclude: "someModule", webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          errors: [{
+            message: commentFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackInclude: true, webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackInclude: true, webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          errors: [{
+            message: commentFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackExclude: "someModule", webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackExclude: "someModule", webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          errors: [{
+            message: commentFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackExclude: true, webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackExclude: true, webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          errors: [{
+            message: commentFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackMode: "fast", webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackMode: "fast", webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          errors: [{
+            message: commentFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackMode: true, webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackMode: true, webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          errors: [{
+            message: commentFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackExports: true, webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackExports: true, webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          errors: [{
+            message: commentFormatError,
+            type: nodeType,
+          }],
+        },
+        {
+          code: `import(
+            /* webpackExports: /default/, webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          options,
+          parser: typescriptParser,
+          output: `import(
+            /* webpackExports: /default/, webpackChunkName: "someModule" */
+            'someModule'
+          )`,
+          errors: [{
+            message: commentFormatError,
             type: nodeType,
           }],
         },

--- a/tests/src/rules/dynamic-import-chunkname.js
+++ b/tests/src/rules/dynamic-import-chunkname.js
@@ -53,10 +53,6 @@ ruleTester.run('dynamic-import-chunkname', rule, {
         'someModule'
       )`,
       options: pickyCommentOptions,
-      errors: [{
-        message: pickyCommentFormatError,
-        type: 'CallExpression',
-      }],
     },
     {
       code: `import(
@@ -147,10 +143,6 @@ ruleTester.run('dynamic-import-chunkname', rule, {
       )`,
       options: pickyCommentOptions,
       parser,
-      errors: [{
-        message: pickyCommentFormatError,
-        type: 'CallExpression',
-      }],
     },
     ...SYNTAX_CASES,
   ],


### PR DESCRIPTION
This PR follows the conversation from https://github.com/import-js/eslint-plugin-import/pull/1411 and aims to add support for all of the magic comments that currently (at the point of opening this pr) supported by webpack itself. [Webpack documentation](https://webpack.js.org/api/module-methods/#magic-comments) and [ImportParserPlugin](https://github.com/webpack/webpack/blob/c181294865dca01b28e6e316636fef5f2aad4eb6/lib/dependencies/ImportParserPlugin.js) are used as reference for rules.

This PR **not yet ready** for merge and more of a PoC (haven't updated docs/changelog yet). The reason why i consider this more of a PoC is because by introducing changes in this PR, IMO rule becomes more than a "check for a correct chunkname in a webpack dynamic import" because it now validates other magic comments as well. Following the conversation from https://github.com/import-js/eslint-plugin-import/pull/1411 i would suggest either completely removing anything unrelated to `webpackChunkname` (i.e. rule just checks for presence of `webpackChunkname` and that it is a valid string, and doesn't care for anything else in a comment) **OR** renaming the rule to (for example) `webpack-dynamic-import` keeping the changes from this PR and adding a separate flag, that you can enable, for `webpackChunkname` to be required in your dynamic imports. I am, open for other suggestions.

I dont see a point in adding "partial" support of magic comments suggested in https://github.com/import-js/eslint-plugin-import/pull/1411 You will be able to use invalid values, but rule will try to somewhat validate your comments anyway, why even validate anything aside from `webpackChunkname` then?

Related:
https://github.com/import-js/eslint-plugin-import/issues/1407
https://github.com/import-js/eslint-plugin-import/issues/1840
https://github.com/import-js/eslint-plugin-import/issues/1904
https://github.com/import-js/eslint-plugin-import/issues/2306
https://github.com/import-js/eslint-plugin-import/pull/1411