### PR TITLE
[Docs] `no-unresolved`: Fix RegExp escaping in readme 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Changed
 - [Tests] `no-nodejs-modules`: add tests for node protocol URL ([#2367], thanks [@sosukesuzuki])
 - [Tests] `default`, `no-anonymous-default-export`, `no-mutable-exports`, `no-named-as-default-member`, `no-named-as-default`: add tests for arbitrary module namespace names ([#2358], thanks [@sosukesuzuki])
+- [Docs] [`no-unresolved`]: Fix RegExp escaping in readme ([#2332], thanks [@stephtr])
 
 ## [2.25.4] - 2022-01-02
 
@@ -963,6 +964,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#2367]: https://github.com/import-js/eslint-plugin-import/pull/2367
+[#2332]: https://github.com/import-js/eslint-plugin-import/pull/2332
 [#2358]: https://github.com/import-js/eslint-plugin-import/pull/2358
 [#2341]: https://github.com/import-js/eslint-plugin-import/pull/2341
 [#2334]: https://github.com/import-js/eslint-plugin-import/pull/2334
@@ -1631,6 +1633,7 @@ for info on changes for earlier releases.
 [@spalger]: https://github.com/spalger
 [@st-sloth]: https://github.com/st-sloth
 [@stekycz]: https://github.com/stekycz
+[@stephtr]: https://github.com/stephtr
 [@straub]: https://github.com/straub
 [@strawbrary]: https://github.com/strawbrary
 [@stropho]: https://github.com/stropho

--- a/docs/rules/no-unresolved.md
+++ b/docs/rules/no-unresolved.md
@@ -60,7 +60,7 @@ This rule has its own ignore list, separate from [`import/ignore`]. This is beca
 To suppress errors from files that may not be properly resolved by your [resolver settings](../../README.md#resolver-plugins), you may add an `ignore` key with an array of `RegExp` pattern strings:
 
 ```js
-/*eslint import/no-unresolved: [2, { ignore: ['\.img$'] }]*/
+/*eslint import/no-unresolved: [2, { ignore: ['\\.img$'] }]*/
 
 import { x } from './mod' // may be reported, if not resolved to a module
 


### PR DESCRIPTION
In the `ignore` example the backslash in `'\.img$'` was escaping the "." as a string character, not in the RegExp sense. `'\\.img$'` would be the correct string.