### PR TITLE
[Improvement]: `no-extraneous-dependencies` add support for npm workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Changed
 - [`no-default-import`]: report on the token "default" instead of the entire node ([#2299], thanks [@pmcelhaney])
 - [Docs] [`order`]: Remove duplicate mention of default ([#2280], thanks [@johnthagen])
+- [`no-extraneous-dependencies`]: add npm workspaces support ([#2342], thank [@acdibble])
 
 ## [2.25.3] - 2021-11-09
 

--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -1,6 +1,6 @@
 # import/no-extraneous-dependencies: Forbid the use of extraneous packages
 
-Forbid the import of external modules that are not declared in the `package.json`'s `dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`, or `bundledDependencies`.
+Forbid the import of external modules that are not declared in the `package.json`'s `dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`, `bundledDependencies`, or npm `workspaces`.
 The closest parent `package.json` will be used. If no `package.json` is found, the rule will not lint anything. This behavior can be changed with the rule option `packageDir`.
 
 Modules have to be installed for this rule to work.
@@ -16,6 +16,8 @@ This rule supports the following options:
 `peerDependencies`: If set to `false`, then the rule will show an error when `peerDependencies` are imported. Defaults to `true`.
 
 `bundledDependencies`: If set to `false`, then the rule will show an error when `bundledDependencies` are imported. Defaults to `true`.
+
+`workspaces`: If set to `false`, then the rule will show an error when npm `workspaces` are imported. Defaults to `false`.
 
 You can set the options like this:
 
@@ -75,6 +77,9 @@ Given the following `package.json`:
   },
   "bundledDependencies": [
     "@generated/foo",
+  ],
+  "workspaces": [
+    "packages/bar",
   ]
 }
 ```
@@ -99,6 +104,10 @@ var isArray = require('lodash.isarray');
 /* eslint import/no-extraneous-dependencies: ["error", {"bundledDependencies": false}] */
 import foo from '"@generated/foo"';
 var foo = require('"@generated/foo"');
+
+/* eslint import/no-extraneous-dependencies: ["error", {"bundledDependencies": false}] */
+import bar from 'bar';
+var bar = require('bar');
 ```
 
 
@@ -113,6 +122,7 @@ import test from 'ava';
 import find from 'lodash.find';
 import isArray from 'lodash.isarray';
 import foo from '"@generated/foo"';
+import bar from 'bar';
 
 /* eslint import/no-extraneous-dependencies: ["error", {"peerDependencies": true}] */
 import react from 'react';

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -27,7 +27,7 @@ function extractDepFields(pkg) {
     // BundledDeps should be in the form of an array, but object notation is also supported by
     // `npm`, so we convert it to an array if it is an object
     bundledDependencies: arrayOrKeys(pkg.bundleDependencies || pkg.bundledDependencies || []),
-    workspaces: pkg.workspaces || [],
+    workspaces: (pkg.workspaces || []).map((ws) => ws.split('/').slice(-1)[0]),
   };
 }
 
@@ -158,8 +158,8 @@ function checkDependencyDeclaration(deps, packageName, declarationStatus) {
       isInPeerDeps: result.isInPeerDeps || deps.peerDependencies[ancestorName] !== undefined,
       isInBundledDeps:
         result.isInBundledDeps || deps.bundledDependencies.indexOf(ancestorName) !== -1,
-      isInWorkspaces: result.isInWorkspaces ||
-        deps.workspaces.findIndex((ws) => ws === ancestorName || ws.endsWith(`/${ancestorName}`)) !== -1,
+      isInWorkspaces:
+        result.isInWorkspaces || deps.workspaces.indexOf(ancestorName) !== -1,
     };
   }, newDeclarationStatus);
 }
@@ -252,6 +252,7 @@ module.exports = {
           'optionalDependencies': { 'type': ['boolean', 'array'] },
           'peerDependencies': { 'type': ['boolean', 'array'] },
           'bundledDependencies': { 'type': ['boolean', 'array'] },
+          'workspaces': { 'type': ['boolean', 'array'] },
           'packageDir': { 'type': ['string', 'array'] },
         },
         'additionalProperties': false,
@@ -269,7 +270,7 @@ module.exports = {
       allowOptDeps: testConfig(options.optionalDependencies, filename) !== false,
       allowPeerDeps: testConfig(options.peerDependencies, filename) !== false,
       allowBundledDeps: testConfig(options.bundledDependencies, filename) !== false,
-      allowWorkspaces: testConfig(options.workspaces, filename) !== false,
+      allowWorkspaces: testConfig(options.workspaces, filename) === true,
     };
 
     return moduleVisitor((source, node) => {

--- a/tests/files/node_modules/nested-package/package.json
+++ b/tests/files/node_modules/nested-package/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "nested-package"
+}

--- a/tests/files/node_modules/top-level-package/package.json
+++ b/tests/files/node_modules/top-level-package/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "top-level-package",
+  "main": "index.js"
+}

--- a/tests/files/npm-workspaces/package.json
+++ b/tests/files/npm-workspaces/package.json
@@ -1,0 +1,12 @@
+{
+  "workspaces": [
+    "top-level-package",
+    "nested/nested-package"
+  ],
+  "dependencies": {
+    "right-pad": "^1.0.1"
+  },
+  "devDependencies": {
+    "left-pad": "^1.2.0"
+  }
+}

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -26,6 +26,7 @@ const packageDirWithEmpty = path.join(__dirname, '../../files/empty');
 const packageDirBundleDeps = path.join(__dirname, '../../files/bundled-dependencies/as-array-bundle-deps');
 const packageDirBundledDepsAsObject = path.join(__dirname, '../../files/bundled-dependencies/as-object');
 const packageDirBundledDepsRaceCondition = path.join(__dirname, '../../files/bundled-dependencies/race-condition');
+const packageDirNpmWorkspaces = path.join(__dirname, '../../files/npm-workspaces');
 
 const {
   dependencies: deps,
@@ -180,6 +181,14 @@ ruleTester.run('no-extraneous-dependencies', rule, {
           },
         },
       },
+    }),
+
+    test({
+      code: `
+      import "top-level-package";
+      import "nested-package";
+      `,
+      options: [{ packageDir: packageDirNpmWorkspaces, workspaces: true }],
     }),
   ],
   invalid: [
@@ -390,6 +399,13 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       code: 'import "esm-package-not-in-pkg-json/esm-module";',
       errors: [{
         message: `'esm-package-not-in-pkg-json' should be listed in the project's dependencies. Run 'npm i -S esm-package-not-in-pkg-json' to add it`,
+      }],
+    }),
+    test({
+      code: 'import "top-level-package";',
+      options: [{ packageDir: packageDirNpmWorkspaces }],
+      errors: [{
+        message: "'top-level-package' should be listed in the project's dependencies. Run 'npm i -S top-level-package' to add it",
       }],
     }),
   ],


### PR DESCRIPTION
This adds support for npm workspaces (I am the only one using them?) with the plugin.

The rule is set to `false` by default because the vast minority of projects will be using npm workspaces.