### PR TITLE
[utils] [patch] Fix `@babel/eslint-parser` 8 compatibility

### DIFF
--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -5,10 +5,13 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Fixed
+- [patch] Fix `@babel/eslint-parser` 8 compatibility ([#2343], thanks [@nicolo-ribaudo])
+
 ## v2.7.1 - 2021-10-13
 
 ### Fixed
- - fixed SyntaxError in node <= 6: Unexpected token ) in parse.js ([#2261], thanks [@VitusFW])
+- fixed SyntaxError in node <= 6: Unexpected token ) in parse.js ([#2261], thanks [@VitusFW])
 
 ## v2.7.0 - 2021-10-11
 
@@ -102,6 +105,7 @@ Yanked due to critical issue with cache key resulting from #839.
 ### Fixed
 - `unambiguous.test()` regex is now properly in multiline mode
 
+[#2343]: https://github.com/import-js/eslint-plugin-import/pull/2343
 [#2261]: https://github.com/import-js/eslint-plugin-import/pull/2261
 [#2212]: https://github.com/import-js/eslint-plugin-import/pull/2212
 [#2160]: https://github.com/import-js/eslint-plugin-import/pull/2160
@@ -138,6 +142,7 @@ Yanked due to critical issue with cache key resulting from #839.
 [@manuth]: https://github.com/manuth
 [@maxkomarychev]: https://github.com/maxkomarychev
 [@mgwalker]: https://github.com/mgwalker
+[@nicolo-ribaudo]: https://github.com/nicolo-ribaudo
 [@pmcelhaney]: https://github.com/pmcelhaney
 [@sergei-startsev]: https://github.com/sergei-startsev
 [@sompylasar]: https://github.com/sompylasar

--- a/utils/parse.js
+++ b/utils/parse.js
@@ -7,34 +7,27 @@ const fs = require('fs');
 
 const log = require('debug')('eslint-plugin-import:parse');
 
-function getBabelVisitorKeys(parserPath) {
+function getBabelEslintVisitorKeys(parserPath) {
   if (parserPath.endsWith('index.js')) {
     const hypotheticalLocation = parserPath.replace('index.js', 'visitor-keys.js');
     if (fs.existsSync(hypotheticalLocation)) {
       const keys = moduleRequire(hypotheticalLocation);
       return keys.default || keys;
     }
-  } else if (parserPath.endsWith('index.cjs')) {
-    const hypotheticalLocation = parserPath.replace('index.cjs', 'worker/ast-info.cjs');
-    if (fs.existsSync(hypotheticalLocation)) {
-      const astInfo = moduleRequire(hypotheticalLocation);
-      return astInfo.getVisitorKeys();
-    }
   }
   return null;
 }
 
 function keysFromParser(parserPath, parserInstance, parsedResult) {
+  // Exposed by @typescript-eslint/parser and @babel/eslint-parser
+  if (parsedResult && parsedResult.visitorKeys) {
+    return parsedResult.visitorKeys;
+  }
   if (/.*espree.*/.test(parserPath)) {
     return parserInstance.VisitorKeys;
   }
-  if (/.*(babel-eslint|@babel\/eslint-parser).*/.test(parserPath)) {
-    return getBabelVisitorKeys(parserPath);
-  }
-  if (/.*@typescript-eslint\/parser/.test(parserPath)) {
-    if (parsedResult) {
-      return parsedResult.visitorKeys;
-    }
+  if (/.*babel-eslint.*/.test(parserPath)) {
+    return getBabelEslintVisitorKeys(parserPath);
   }
   return null;
 }


### PR DESCRIPTION
In Babel 8, you won't be able to directly require `@babel/eslint-parser/worker/ast-info.cjs` anymore (there is a reason if the path contains "worker": it's meant to be used in workers after properly setting them up :stuck_out_tongue:). However, `@babel/eslint-parser` exposes the `visitorKeys` on its result object, similarly to how `@typescript-eslint/parser` does: you can access it without requiring any internal file.

We caught this in our integration tests: even if for some reason the error is logged without reporting a failure, in https://app.circleci.com/pipelines/github/babel/babel/8764/workflows/3516a741-7bca-4713-8b12-9f2f20310066/jobs/50483/parallel-runs/0/steps/0-103 you can see
```
Error while parsing /home/circleci/babel/eslint/babel-eslint-tests/test/fixtures/eslint-plugin-import/a.js
Line undefined, column undefined: Cannot read properties of undefined (reading 'VISITOR_KEYS')
 PASS  eslint/babel-eslint-tests/test/integration/eslint-plugin-import.js (66.694 s)
```

There aren't any tests for `@babel/eslint-parser`, and I'm not sure about how to add them from scratch because it requires a `babel.config.json` file when used with `eslint-plugin-import` (to specify which additional syntax should be supported, such as TS). However, I verified manually that this change makes our test pass.