### PR TITLE
fix eslint-module-utils version for compatibility with v2.24.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "debug": "^2.6.9",
     "doctrine": "^2.1.0",
     "eslint-import-resolver-node": "^0.3.6",
-    "eslint-module-utils": "^2.6.2",
+    "eslint-module-utils": "2.6.2",
     "find-up": "^2.0.0",
     "has": "^1.0.3",
     "is-core-module": "^2.6.0",


### PR DESCRIPTION
Solves https://github.com/import-js/eslint-plugin-import/issues/2350