### PR TITLE
[New] `no-cycle`: add option to allow cycle via dynamic import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`no-named-default`, `no-default-export`, `prefer-default-export`, `no-named-export`, `export`, `named`, `namespace`, `no-unused-modules`]: support arbitrary module namespace names ([#2358], thanks [@sosukesuzuki])
 - [`no-dynamic-require`]: support dynamic import with espree ([#2371], thanks [@sosukesuzuki])
 - [`no-relative-packages`]: add fixer ([#2381], thanks [@forivall])
+- [`no-cycle`]: add `allowUnsafeDynamicCyclicDependency` option ([#2387], thanks [@GerkinDev])
 
 ### Fixed
 - [`default`]: `typescript-eslint-parser`: avoid a crash on exporting as namespace (thanks [@ljharb])

--- a/docs/rules/no-cycle.md
+++ b/docs/rules/no-cycle.md
@@ -75,6 +75,22 @@ import { a } from './dep-a.js' // not reported as this module is external
 
 Its value is `false` by default, but can be set to `true` for reducing total project lint time, if needed.
 
+#### `allowUnsafeDynamicCyclicDependency`
+
+This option disable reporting of errors if a cycle is detected with at least one dynamic import.
+
+```js
+// bar.js
+import { foo } from './foo';
+export const bar = foo;
+
+// foo.js
+export const foo = 'Foo';
+export function getBar() { return import('./bar'); }
+```
+
+> Cyclic dependency are **always** a dangerous anti-pattern as discussed extensively in [#2265](https://github.com/import-js/eslint-plugin-import/issues/2265). Please be extra careful about using this option.
+
 ## When Not To Use It
 
 This rule is comparatively computationally expensive. If you are pressed for lint

--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -395,6 +395,7 @@ ExportMap.parse = function (path, content, context) {
           loc: source.loc,
         },
         importedSpecifiers,
+        dynamic: true,
       }]),
     });
   }

--- a/tests/files/cycles/es6/depth-one-dynamic.js
+++ b/tests/files/cycles/es6/depth-one-dynamic.js
@@ -1,0 +1,1 @@
+export const bar = () => import("../depth-zero").then(({foo}) => foo);


### PR DESCRIPTION
Hi,

as discussed in #2265, I added a new option, `allowUnsafeDynamicCyclicDependency`. I've tested all cases I could.

Unfortunately, I did not managed to write tests using the `TS_OLD` parser. I don't know if this is important.

Feedbacks are welcome ! Have a nice day

Fixes #2265.