### PR TITLE
[Docs] `order`: use correct default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Changed
 - [Tests] `named`: Run all TypeScript test ([#2427], thanks [@ProdigySim])
 - [readme] note use of typescript in readme `import/extensions` section ([#2440], thanks [@OutdatedVersion])
+- [Docs] `order`: use correct default value ([#2392], thanks [@hyperupcall])
 
 ## [2.26.0] - 2022-04-05
 
@@ -1280,6 +1281,7 @@ for info on changes for earlier releases.
 [#211]: https://github.com/import-js/eslint-plugin-import/pull/211
 [#164]: https://github.com/import-js/eslint-plugin-import/pull/164
 [#157]: https://github.com/import-js/eslint-plugin-import/pull/157
+[#2392]: https://github.com/import-js/eslint-plugin-import/issues/2392
 [#2340]: https://github.com/import-js/eslint-plugin-import/issues/2340
 [#2255]: https://github.com/import-js/eslint-plugin-import/issues/2255
 [#2210]: https://github.com/import-js/eslint-plugin-import/issues/2210
@@ -1559,6 +1561,7 @@ for info on changes for earlier releases.
 [@hayes]: https://github.com/hayes
 [@himynameisdave]: https://github.com/himynameisdave
 [@hulkish]: https://github.com/hulkish
+[@hyperupcall]: https://github.com/hyperupcall
 [@Hypnosphi]: https://github.com/Hypnosphi
 [@isiahmeadows]: https://github.com/isiahmeadows
 [@IvanGoncharov]: https://github.com/IvanGoncharov

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -169,7 +169,7 @@ Example:
   ]
 }
 ```
-The default value is `["builtin", "external"]`.
+The default value is `["builtin", "external", "object"]`.
 
 ### `newlines-between: [ignore|always|always-and-inside-groups|never]`:
 


### PR DESCRIPTION
Hai~,

In the source, the [default values](https://github.com/import-js/eslint-plugin-import/blob/b0e6f7f48945e2533e96d513248bf3e54e0c1aac/src/rules/order.js#L589) includes `"object"` for option `pathGroupsExcludedImportTypes`, but this is not reflected in the docs

This discrepancy been mentioned in [this comment](https://github.com/import-js/eslint-plugin-import/issues/2291#issuecomment-1050199872)