### PR TITLE
[order] Sort type imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`order`]: Add `distinctGroup` option ([#2395], thanks [@hyperupcall])
 - [`no-extraneous-dependencies`]: Add `includeInternal` option ([#2541], thanks [@bdwain])
 - [`no-extraneous-dependencies`]: Add `includeTypes` option ([#2543], thanks [@bdwain])
+- [`order`]: new `alphabetize.orderImportKind` option to sort imports with same path based on their kind (`type`, `typeof`) ([#2544], thanks [@stropho])
 
 ### Fixed
 - [`order`]: move nested imports closer to main import entry ([#2396], thanks [@pri1311])

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -267,11 +267,12 @@ import index from './';
 import sibling from './foo';
 ```
 
-### `alphabetize: {order: asc|desc|ignore, caseInsensitive: true|false}`:
+### `alphabetize: {order: asc|desc|ignore, orderImportKind: asc|desc|ignore, caseInsensitive: true|false}`:
 
 Sort the order within each group in alphabetical manner based on **import path**:
 
 - `order`: use `asc` to sort in ascending order, and `desc` to sort in descending order (default: `ignore`).
+- `orderImportKind`: use `asc` to sort in ascending order various import kinds, e.g. imports prefixed with `type` or `typeof`, with same import path. Use `desc` to sort in descending order (default: `ignore`).
 - `caseInsensitive`: use `true` to ignore case, and `false` to consider case (default: `false`).
 
 Example setting:


### PR DESCRIPTION
Here's a preliminary PR that resolves #2339. It's my first contribution, so please bear with me! 🙂

- Type imports are now sorted before regular imports, because this appears to be the overwhelming ecosystem standard.
- To reduce ambiguity, error messages can now refer to "type import" instead of just "import".
- I included `typeof` support just in case (though I don't know much about Flow).
- Tests were updated to reflect revised behaviour, and two new tests were added.

I also did some opportunistic code cleanup:

- Some test messages seemed to reflect old non-deterministic rule behaviour with "before" vs. "after" errors. Given this is now predictable, I made the tests easier to understand and maintain.
- Coding style toward the end of the test file was all over the place, so I cleaned it up.
- I made a minor performance improvement in `fixOutOfOrder`.

Let me know if there's anything I should undo here, or separate into separate PRs.