### PR TITLE
[New] `newline-after-import`: add `considerComments` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## [Unreleased]
 
+### Added
+- [`newline-after-import`]: add `considerComments` option ([#2399], thanks [@pri1311])
+
 ### Changed
 - [Tests] `named`: Run all TypeScript test ([#2427], thanks [@ProdigySim])
 
@@ -983,6 +986,7 @@ for info on changes for earlier releases.
 [#2427]: https://github.com/import-js/eslint-plugin-import/pull/2427
 [#2417]: https://github.com/import-js/eslint-plugin-import/pull/2417
 [#2411]: https://github.com/import-js/eslint-plugin-import/pull/2411
+[#2399]: https://github.com/import-js/eslint-plugin-import/pull/2399
 [#2393]: https://github.com/import-js/eslint-plugin-import/pull/2393
 [#2388]: https://github.com/import-js/eslint-plugin-import/pull/2388
 [#2381]: https://github.com/import-js/eslint-plugin-import/pull/2381
@@ -1628,6 +1632,7 @@ for info on changes for earlier releases.
 [@Pessimistress]: https://github.com/Pessimistress
 [@pmcelhaney]: https://github.com/pmcelhaney
 [@preco21]: https://github.com/preco21
+[@pri1311]: https://github.com/pri1311
 [@ProdigySim]: https://github.com/ProdigySim
 [@pzhine]: https://github.com/pzhine
 [@ramasilveyra]: https://github.com/ramasilveyra

--- a/docs/rules/newline-after-import.md
+++ b/docs/rules/newline-after-import.md
@@ -5,7 +5,10 @@ Enforces having one or more empty lines after the last top-level import statemen
 
 ## Rule Details
 
-This rule has one option, `count` which sets the number of newlines that are enforced after the last top-level import statement or require call. This option defaults to `1`.
+This rule supports the following options: 
+- `count` which sets the number of newlines that are enforced after the last top-level import statement or require call. This option defaults to `1`.
+
+- `considerComments` which enforces the rule on comments after the last import-statement as well when set to true. This option defaults to `false`.
 
 Valid:
 
@@ -71,6 +74,30 @@ import defaultExport from './foo'
 const FOO = 'BAR'
 ```
 
+With `considerComments` set to `false` this will be considered valid:
+
+```js
+import defaultExport from './foo'
+// some comment here.
+const FOO = 'BAR'
+```
+
+With `considerComments` set to `true` this will be considered valid:
+
+```js
+import defaultExport from './foo'
+
+// some comment here.
+const FOO = 'BAR'
+```
+
+With `considerComments` set to `true` this will be considered invalid:
+
+```js
+import defaultExport from './foo'
+// some comment here.
+const FOO = 'BAR'
+```
 
 ## Example options usage
 ```json

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -25,7 +25,38 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       parserOptions: { ecmaVersion: 6 } ,
     },
     {
+      code: `
+        const x = () => require('baz')
+            , y = () => require('bar')
+            
+        // some comment here
+      `,
+      parserOptions: { ecmaVersion: 6 } ,
+      options: [{ considerComments: true }],
+    },
+    {
       code: `const x = () => require('baz') && require('bar')`,
+      parserOptions: { ecmaVersion: 6 } ,
+    },
+    {
+      code: `
+        const x = () => require('baz') && require('bar')
+
+        // Some random single line comment
+        var bar = 42;
+      `,
+      parserOptions: { ecmaVersion: 6 } ,
+      options: [{ 'considerComments': true }],
+    },
+    {
+      code: `
+        const x = () => require('baz') && require('bar')
+        /**
+         * some multiline comment here
+         * another line of comment
+        **/
+        var bar = 42;
+      `,
       parserOptions: { ecmaVersion: 6 } ,
     },
     `function x() { require('baz'); }`,
@@ -255,9 +286,114 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       `,
       parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
+    {
+      code: `
+        import path from 'path';
+        import foo from 'foo';
+        /**
+         * some multiline comment here
+         * another line of comment
+        **/
+        var bar = 42;
+      `,
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' } ,
+    },
+    {
+      code: `
+        import path from 'path';import foo from 'foo';
+        
+        /**
+         * some multiline comment here
+         * another line of comment
+        **/
+        var bar = 42;
+      `,
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' } ,
+      options: [{ 'considerComments': true }],
+    },
+    {
+      code: `
+        import path from 'path';
+        import foo from 'foo';
+        
+        // Some random single line comment
+        var bar = 42;
+      `,
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' } ,
+    },
   ),
 
   invalid: [].concat(
+    {
+      code: `
+        import { A, B, C, D } from
+        '../path/to/my/module/in/very/far/directory'
+        // some comment
+        var foo = 'bar';
+      `,
+      output: `
+        import { A, B, C, D } from
+        '../path/to/my/module/in/very/far/directory'
+
+        // some comment
+        var foo = 'bar';
+      `,
+      errors: [ {
+        line: 3,
+        column: 1,
+        message: IMPORT_ERROR_MESSAGE,
+      } ],
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+      options: [{ 'considerComments': true }],
+    },
+    {
+      code: `
+        import path from 'path';
+        import foo from 'foo';
+        /**
+         * some multiline comment here
+         * another line of comment
+        **/
+        var bar = 42;
+      `,
+      output: `
+        import path from 'path';
+        import foo from 'foo';\n
+        /**
+         * some multiline comment here
+         * another line of comment
+        **/
+        var bar = 42;
+      `,
+      errors: [ {
+        line: 3,
+        column: 9,
+        message: IMPORT_ERROR_MESSAGE,
+      } ],
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' } ,
+      options: [{ 'considerComments': true }],
+    },
+    {
+      code: `
+        import path from 'path';
+        import foo from 'foo';
+        // Some random single line comment
+        var bar = 42;
+      `,
+      output: `
+        import path from 'path';
+        import foo from 'foo';\n
+        // Some random single line comment
+        var bar = 42;
+      `,
+      errors: [ {
+        line: 3,
+        column: 9,
+        message: IMPORT_ERROR_MESSAGE,
+      } ],
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' } ,
+      options: [{ 'considerComments': true, 'count': 1 }],
+    },
     {
       code: `import foo from 'foo';\nexport default function() {};`,
       output: `import foo from 'foo';\n\nexport default function() {};`,


### PR DESCRIPTION
Closes #2151 

Initially, the rule only checked whether some piece of code succeeded the imports. This PR alters the rule to check for any comments on the line following the imports too and enforces the `newline` rule for the same.

However, my confusion here is:
Out of the two code snippets below, which one is valid?
First Block:
```
import path from 'path';
//  some comment
import foo from 'foo';
```

Second Block:
```
import path from 'path';

//  some comment
import foo from 'foo';
```

Right now, the code I have added parses the second block to be correct.

Side note: Ran existing tests as well, nothing breaks.