### PR TITLE
[Fix] Drop NoFilesFoundError for ignoreExports

### DIFF
--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -176,7 +176,15 @@ const resolveFiles = (src, ignoreExports, context) => {
   const srcFileList = listFilesToProcess(src, extensions);
 
   // prepare list of ignored files
-  const ignoredFilesList =  listFilesToProcess(ignoreExports, extensions);
+  let ignoredFilesList = [];
+  try {
+    listFilesToProcess(ignoreExports, extensions);
+  } catch (e) {
+    // pattern for ignored files is allowed to have zero matches
+    if (e.constructor.name !== 'NoFilesFoundError') {
+      throw e;
+    }
+  }
   ignoredFilesList.forEach(({ filename }) => ignoredFiles.add(filename));
 
   // prepare list of source files, don't consider files from node_modules


### PR DESCRIPTION
Silently swallows glob patterns that match 0 files when the pattern is used for ignoring the file.

Fixes https://github.com/import-js/eslint-plugin-import/issues/2128

**PR checklist**

- [ ] `write tests` - I'm not familiar with the test setup in this project and got a bit overwhelmed from the various helpers and abstractions. Would love if someone could help me out here.
- [X] `implement feature/fix bug`
- [ ] `update docs` - N/A?
- [ ] `make a note in change log` - I realized after the first commit I had missed this; in which section and what format should I add it? "Fixes"?