### PR TITLE
docs: remove global-install in readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [readme] note use of typescript in readme `import/extensions` section ([#2440], thanks [@OutdatedVersion])
 - [Docs] `order`: use correct default value ([#2392], thanks [@hyperupcall])
 - [meta] replace git.io link in comments with the original URL ([#2444], thanks [@liby])
+- [Docs] remove global install in readme ([#2412], thanks [@aladdin-add])
 
 ## [2.26.0] - 2022-04-05
 
@@ -1289,6 +1290,7 @@ for info on changes for earlier releases.
 [#164]: https://github.com/import-js/eslint-plugin-import/pull/164
 [#157]: https://github.com/import-js/eslint-plugin-import/pull/157
 [#2444]: https://github.com/import-js/eslint-plugin-import/issues/2444
+[#2412]: https://github.com/import-js/eslint-plugin-import/issues/2412
 [#2392]: https://github.com/import-js/eslint-plugin-import/issues/2392
 [#2340]: https://github.com/import-js/eslint-plugin-import/issues/2340
 [#2255]: https://github.com/import-js/eslint-plugin-import/issues/2255

--- a/README.md
+++ b/README.md
@@ -124,12 +124,6 @@ The maintainers of `eslint-plugin-import` and thousands of other packages are wo
 ## Installation
 
 ```sh
-npm install eslint-plugin-import -g
-```
-
-or if you manage ESLint as a dev dependency:
-
-```sh
 # inside your project's working tree
 npm install eslint-plugin-import --save-dev
 ```


### PR DESCRIPTION
as said in the docs, In eslint v6+, users have to install the plugins locally.
refs: https://eslint.org/docs/user-guide/migrating-to-6.0.0#-plugins-and-shareable-configs-are-no-longer-affected-by-eslints-location