### PR TITLE
[Docs] `no-useless-path-segments`: fix paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [readme] clarify `eslint-import-resolver-typescript` usage ([#2503], thanks [@JounQin])
 - [Refactor] `no-cycle`: Add per-run caching of traversed paths ([#2419], thanks [@nokel81])
 - [Performance] `ExportMap`: add caching after parsing for an ambiguous module ([#2531], thanks [@stenin-nikita])
+- [Docs] `no-useless-path-segments`: fix paths ([#2424] thanks [@s-h-a-d-o-w])
 
 ## [2.26.0] - 2022-04-05
 
@@ -1011,6 +1012,7 @@ for info on changes for earlier releases.
 [#2466]: https://github.com/import-js/eslint-plugin-import/pull/2466
 [#2440]: https://github.com/import-js/eslint-plugin-import/pull/2440
 [#2427]: https://github.com/import-js/eslint-plugin-import/pull/2427
+[#2424]: https://github.com/import-js/eslint-plugin-import/pull/2424
 [#2419]: https://github.com/import-js/eslint-plugin-import/pull/2419
 [#2417]: https://github.com/import-js/eslint-plugin-import/pull/2417
 [#2411]: https://github.com/import-js/eslint-plugin-import/pull/2411

--- a/docs/rules/no-useless-path-segments.md
+++ b/docs/rules/no-useless-path-segments.md
@@ -14,6 +14,7 @@ my-project
 └── helpers.js
 └── helpers
     └── index.js
+├── index.js
 └── pages
     ├── about.js
     ├── contact.js
@@ -27,10 +28,10 @@ The following patterns are considered problems:
  *  in my-project/app.js
  */
 
-import "./../pages/about.js"; // should be "./pages/about.js"
-import "./../pages/about"; // should be "./pages/about"
-import "../pages/about.js"; // should be "./pages/about.js"
-import "../pages/about"; // should be "./pages/about"
+import "./../my-project/pages/about.js"; // should be "./pages/about.js"
+import "./../my-project/pages/about"; // should be "./pages/about"
+import "../my-project/pages/about.js"; // should be "./pages/about.js"
+import "../my-project/pages/about"; // should be "./pages/about"
 import "./pages//about"; // should be "./pages/about"
 import "./pages/"; // should be "./pages"
 import "./pages/index"; // should be "./pages" (except if there is a ./pages.js file)


### PR DESCRIPTION
Really not much to say here. Somebody simply overlooked that `../` refers to the parent directory. 🙂
(Had me worried about whether this rule works correctly. Which it does.)

I also added the root `index.js` because of the `import "."` further below.