### PR TITLE
[Test] import/named should support export = assignment of object in TS

### DIFF
--- a/tests/files/typescript-export-assign-object.ts
+++ b/tests/files/typescript-export-assign-object.ts
@@ -1,0 +1,5 @@
+const someObj = {
+  FooBar: 12,
+};
+
+export = someObj;

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -388,7 +388,13 @@ context('TypeScript', function () {
       'import/resolver': { 'eslint-import-resolver-typescript': true },
     };
 
-    let valid = [];
+    let valid = [
+      test({
+        code: `import { FooBar } from './typescript-export-assign-object'`,
+        parser,
+        settings,
+      }),
+    ];
     const invalid = [
       // TODO: uncomment this test
       // test({
@@ -400,8 +406,17 @@ context('TypeScript', function () {
       //     { message: 'a not found in ./export-star-3/b' },
       //   ],
       // }),
+      test({
+        code: `import { NotExported } from './typescript-export-assign-object'`,
+        parser,
+        settings,
+        errors: [{
+          message: `NotExported not found in './typescript-export-assign-object'`,
+          type: 'Identifier',
+        }],
+      }),
     ];
-
+    
     [
       'typescript',
       'typescript-declare',


### PR DESCRIPTION
This pattern is valid typescript, but `import/named` can't find resolve the imports. Relevant issue: #1984 

[Here's a demo showing that it should work in TS](https://codesandbox.io/s/ts-export-assignment-demo-l2mym?file=/src/index.ts)

This test currently does not run, as no TS tests in `named.js` are currently running: waiting for #2427 

Once the test is wired up, it fails with:

```
  1) TypeScript named [TypeScript] valid import { FooBar } from './typescript-export-assign-object':

      AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: Should have no errors but had 1: [
  {
    ruleId: 'named [TypeScript]',
    severity: 1,
    message: "FooBar not found in './typescript-export-assign-object'",
    line: 1,
    column: 10,
    nodeType: 'Identifier',
    endLine: 1,
    endColumn: 16
  }
]
      + expected - actual

      -1
      +0
```