### PR TITLE
[Fix] Ignore hashbang and BOM while parsing

### DIFF
--- a/tests/files/no-unused-modules/prefix-child.js
+++ b/tests/files/no-unused-modules/prefix-child.js
@@ -1,0 +1,1 @@
+export const foo = 1;

--- a/tests/files/no-unused-modules/prefix-parent-bom.js
+++ b/tests/files/no-unused-modules/prefix-parent-bom.js
@@ -1,0 +1,1 @@
+﻿import {foo} from './prefix-child.js';

--- a/tests/files/no-unused-modules/prefix-parent-bomhashbang.js
+++ b/tests/files/no-unused-modules/prefix-parent-bomhashbang.js
@@ -1,0 +1,2 @@
+﻿#!/usr/bin/env node
+import {foo} from './prefix-child.js';

--- a/tests/files/no-unused-modules/prefix-parent-hashbang.js
+++ b/tests/files/no-unused-modules/prefix-parent-hashbang.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import {foo} from './prefix-child.js';

--- a/tests/files/no-unused-modules/prefix-parent.js
+++ b/tests/files/no-unused-modules/prefix-parent.js
@@ -1,0 +1,2 @@
+﻿#!/usr/bin/env node
+import {foo} from './prefix-child.js';

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -307,7 +307,7 @@ describe('dynamic imports', () => {
       `,
         filename: testFilePath('./unused-modules-reexport-crash/src/index.tsx'),
         parser: parsers.TS_NEW,
-        options: [{        
+        options: [{
           unusedExports: true,
           ignoreExports: ['**/magic/**'],
         }],
@@ -1300,5 +1300,72 @@ describe('support ES2022 Arbitrary module namespace identifier names', () => {
         ],
       })),
     ),
+  });
+});
+
+describe('parser ignores prefixes like BOM and hashbang', () => {
+  // bom, hashbang
+  ruleTester.run('no-unused-modules', rule, {
+    valid: [
+      test({
+        options: unusedExportsOptions,
+        code: 'export const foo = 1;\n',
+        filename: testFilePath('./no-unused-modules/prefix-child.js'),
+      }),
+      test({
+        options: unusedExportsOptions,
+        code: `\uFEFF#!/usr/bin/env node\nimport {foo} from './prefix-child.js';\n`,
+        filename: testFilePath('./no-unused-modules/prefix-parent-bom.js'),
+      }),
+    ],
+    invalid: [],
+  });
+  // no bom, hashbang
+  ruleTester.run('no-unused-modules', rule, {
+    valid: [
+      test({
+        options: unusedExportsOptions,
+        code: 'export const foo = 1;\n',
+        filename: testFilePath('./no-unused-modules/prefix-child.js'),
+      }),
+      test({
+        options: unusedExportsOptions,
+        code: `#!/usr/bin/env node\nimport {foo} from './prefix-child.js';\n`,
+        filename: testFilePath('./no-unused-modules/prefix-parent-hashbang.js'),
+      }),
+    ],
+    invalid: [],
+  });
+  // bom, no hashbang
+  ruleTester.run('no-unused-modules', rule, {
+    valid: [
+      test({
+        options: unusedExportsOptions,
+        code: 'export const foo = 1;\n',
+        filename: testFilePath('./no-unused-modules/prefix-child.js'),
+      }),
+      test({
+        options: unusedExportsOptions,
+        code: `\uFEFF#!/usr/bin/env node\nimport {foo} from './prefix-child.js';\n`,
+        filename: testFilePath('./no-unused-modules/prefix-parent-bomhashbang.js'),
+      }),
+    ],
+    invalid: [],
+  });
+  // no bom, no hashbang
+  ruleTester.run('no-unused-modules', rule, {
+    valid: [
+      test({
+        options: unusedExportsOptions,
+        code: 'export const foo = 1;\n',
+        filename: testFilePath('./no-unused-modules/prefix-child.js'),
+      }),
+      test({
+        options: unusedExportsOptions,
+        code: `import {foo} from './prefix-child.js';\n`,
+        filename: testFilePath('./no-unused-modules/prefix-parent.js'),
+      }),
+    ],
+    invalid: [],
   });
 });

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -5,6 +5,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Fixed
+- [Fix] Ignore hashbang and BOM while parsing ([#2431], thanks [@silverwind])
+
 ## v2.7.3 - 2022-01-26
 
 ### Fixed
@@ -115,6 +118,7 @@ Yanked due to critical issue with cache key resulting from #839.
 ### Fixed
 - `unambiguous.test()` regex is now properly in multiline mode
 
+[#2431]: https://github.com/import-js/eslint-plugin-import/pull/2431
 [#2350]: https://github.com/import-js/eslint-plugin-import/issues/2350
 [#2343]: https://github.com/import-js/eslint-plugin-import/pull/2343
 [#2261]: https://github.com/import-js/eslint-plugin-import/pull/2261

--- a/utils/parse.js
+++ b/utils/parse.js
@@ -42,6 +42,14 @@ function makeParseReturn(ast, visitorKeys) {
   return ast;
 }
 
+function stripUnicodeBOM(text) {
+  return text.charCodeAt(0) === 0xFEFF ? text.slice(1) : text;
+}
+
+function transformHashbang(text) {
+  return text.replace(/^#!([^\r\n]+)/u, (_, captured) => `//${captured}`);
+}
+
 exports.default = function parse(path, content, context) {
 
   if (context == null) throw new Error('need context to parse properly');
@@ -77,6 +85,10 @@ exports.default = function parse(path, content, context) {
 
   // require the parser relative to the main module (i.e., ESLint)
   const parser = moduleRequire(parserPath);
+
+  // replicate bom strip and hashbang transform of ESLint
+  // https://github.com/eslint/eslint/blob/b93af98b3c417225a027cabc964c38e779adb945/lib/linter/linter.js#L779
+  content = transformHashbang(stripUnicodeBOM(String(content)));
 
   if (typeof parser.parseForESLint === 'function') {
     let ast;


### PR DESCRIPTION
ESLint does this outside their espree parser, so we need to do it as well. Just like ESLint, the code will convert hashbang to comments and strip off the BOM completely before handing the content to the parser.

Fixes: https://github.com/import-js/eslint-plugin-import/issues/1369