### PR TITLE
[Tests] `named`: Add direct test for `export =` assignment in TS

### DIFF
--- a/tests/files/typescript-export-assign-object/index.ts
+++ b/tests/files/typescript-export-assign-object/index.ts
@@ -1,0 +1,5 @@
+const someObj = {
+  FooBar: 12,
+};
+
+export = someObj;

--- a/tests/files/typescript-export-assign-object/tsconfig.json
+++ b/tests/files/typescript-export-assign-object/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "esModuleInterop": true
+    }
+}

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -1,5 +1,6 @@
 import { test, SYNTAX_CASES, getTSParsers, testFilePath, testVersion, parsers } from '../utils';
 import { RuleTester } from 'eslint';
+import path from 'path';
 
 import { CASE_SENSITIVE_FS } from 'eslint-module-utils/resolve';
 
@@ -388,7 +389,16 @@ context('TypeScript', function () {
       'import/resolver': { 'eslint-import-resolver-typescript': true },
     };
 
-    let valid = [];
+    let valid = [
+      test({
+        code: `import x from './typescript-export-assign-object'`,
+        parser,
+        parserOptions: {
+          tsconfigRootDir: path.resolve(__dirname, '../../files/typescript-export-assign-object/'),
+        },
+        settings,
+      }),
+    ];
     const invalid = [
       // TODO: uncomment this test
       // test({
@@ -400,6 +410,31 @@ context('TypeScript', function () {
       //     { message: 'a not found in ./export-star-3/b' },
       //   ],
       // }),
+      test({
+        code: `import { NotExported } from './typescript-export-assign-object'`,
+        parser,
+        parserOptions: {
+          tsconfigRootDir: path.resolve(__dirname, '../../files/typescript-export-assign-object/'),
+        },
+        settings,
+        errors: [{
+          message: `NotExported not found in './typescript-export-assign-object'`,
+          type: 'Identifier',
+        }],
+      }),
+      test({
+        // `export =` syntax creates a default export only
+        code: `import { FooBar } from './typescript-export-assign-object'`,
+        parser,
+        parserOptions: {
+          tsconfigRootDir: path.resolve(__dirname, '../../files/typescript-export-assign-object/'),
+        },
+        settings,
+        errors: [{
+          message: `FooBar not found in './typescript-export-assign-object'`,
+          type: 'Identifier',
+        }],
+      }),
     ];
 
     [


### PR DESCRIPTION
This pattern is valid typescript, but `import/named` can't find resolve the imports. Relevant issue: #1984 

[Here's a demo showing that it should work in TS](https://codesandbox.io/s/ts-export-assignment-demo-l2mym?file=/src/index.ts)

Test fails with

```
  1) TypeScript named [TypeScript] valid import { FooBar } from './typescript-export-assign-object':

      AssertionError [ERR_ASSERTION] [ERR_ASSERTION]: Should have no errors but had 1: [
  {
    ruleId: 'named [TypeScript]',
    severity: 1,
    message: "FooBar not found in './typescript-export-assign-object'",
    line: 1,
    column: 10,
    nodeType: 'Identifier',
    endLine: 1,
    endColumn: 16
  }
]
      + expected - actual

      -1
      +0
```

Reopened from #2428 