### PR TITLE
Change the way existence of the path is checked. 

### DIFF
--- a/utils/resolve.js
+++ b/utils/resolve.js
@@ -68,8 +68,7 @@ exports.fileExistsWithCaseSync = function fileExistsWithCaseSync(filepath, cache
   if (dir === '' || parsedPath.root === filepath) {
     result = true;
   } else {
-    const filenames = fs.readdirSync(dir);
-    if (filenames.indexOf(parsedPath.base) === -1) {
+    if (!fs.existsSync(path.join(dir, parsedPath.base))) {
       result = false;
     } else {
       result = fileExistsWithCaseSync(dir, cacheSettings, strict);


### PR DESCRIPTION
Previously it was reading the source dir to get the list of its contents and then checking if the parsedPath.base is in the list. Not only this is not optimal, but also can cause an access issue if the script executor doesn't have access to project's parent folder, for example in CI/CD env.