### PR TITLE
[meta] replace `git.io` link in comments with the original URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [Tests] `named`: Run all TypeScript test ([#2427], thanks [@ProdigySim])
 - [readme] note use of typescript in readme `import/extensions` section ([#2440], thanks [@OutdatedVersion])
 - [Docs] `order`: use correct default value ([#2392], thanks [@hyperupcall])
+- [meta] replace git.io link in comments with the original URL ([#2444], thanks [@liby])
 
 ## [2.26.0] - 2022-04-05
 
@@ -1281,6 +1282,7 @@ for info on changes for earlier releases.
 [#211]: https://github.com/import-js/eslint-plugin-import/pull/211
 [#164]: https://github.com/import-js/eslint-plugin-import/pull/164
 [#157]: https://github.com/import-js/eslint-plugin-import/pull/157
+[#2444]: https://github.com/import-js/eslint-plugin-import/issues/2444
 [#2392]: https://github.com/import-js/eslint-plugin-import/issues/2392
 [#2340]: https://github.com/import-js/eslint-plugin-import/issues/2340
 [#2255]: https://github.com/import-js/eslint-plugin-import/issues/2255

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -67,7 +67,7 @@ function runResolverTests(resolver) {
         options: [{ amd: true }] }),
       rest({ code: 'require(["./does-not-exist"], function (bar) {})',
         options: [{ amd: false }] }),
-      // magic modules: https://git.io/vByan
+      // magic modules: https://github.com/requirejs/requirejs/wiki/Differences-between-the-simplified-CommonJS-wrapper-and-standard-AMD-define#magic-modules
       rest({ code: 'define(["require", "exports", "module"], function (r, e, m) { })',
         options: [{ amd: true }] }),
 

--- a/utils/moduleVisitor.js
+++ b/utils/moduleVisitor.js
@@ -81,7 +81,7 @@ exports.default = function visitModules(visitor, options) {
       if (typeof element.value !== 'string') continue;
 
       if (element.value === 'require' ||
-          element.value === 'exports') continue; // magic modules: https://git.io/vByan
+          element.value === 'exports') continue; // magic modules: https://github.com/requirejs/requirejs/wiki/Differences-between-the-simplified-CommonJS-wrapper-and-standard-AMD-define#magic-modules
 
       checkSourceValue(element, element);
     }


### PR DESCRIPTION
Fix #2443 