### PR TITLE
[Deps] upgrade tsconfig-paths to ^4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,6 @@ matrix:
   - os: osx
     env: ESLINT_VERSION=3
     node_js: 6
-  - os: osx
-    env: ESLINT_VERSION=2
-    node_js: 4
 
   fast_finish: true
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.26.0",
   "description": "Import with sanity.",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "main": "lib/index.js",
   "directories": {
@@ -111,6 +111,6 @@
     "minimatch": "^3.1.2",
     "object.values": "^1.1.5",
     "resolve": "^1.22.0",
-    "tsconfig-paths": "^3.14.1"
+    "tsconfig-paths": "^4.0.0"
   }
 }


### PR DESCRIPTION
This deps upgrade will introduce a breaking change, because `tsconfig-paths` upgrade its `json5` version to v2 which does not support node 4. see https://github.com/dividab/tsconfig-paths/pull/198

If we want to upgrade `tsconfig-paths` to the latest, I think we could do it on the next major release and drop the node v4 support. But I am sure if it is accepted. @ljharb what do you think?