### PR TITLE
[New] `no-duplicates`: support inline type import with `prefer-inline` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - Add [`no-empty-named-blocks`] rule ([#2568], thanks [@guilhermelimak])
 - [`prefer-default-export`]: add "target" option ([#2602], thanks [@azyzz228])
 - [`no-absolute-path`]: add fixer ([#2613], thanks [@adipascu])
+- [`no-duplicates`]: support inline type import with `inlineTypeImport` option ([#2475], thanks [@snewcomer])
 
 ### Fixed
 - [`order`]: move nested imports closer to main import entry ([#2396], thanks [@pri1311])
@@ -1045,6 +1046,7 @@ for info on changes for earlier releases.
 [#2506]: https://github.com/import-js/eslint-plugin-import/pull/2506
 [#2503]: https://github.com/import-js/eslint-plugin-import/pull/2503
 [#2490]: https://github.com/import-js/eslint-plugin-import/pull/2490
+[#2475]: https://github.com/import-js/eslint-plugin-import/pull/2475
 [#2473]: https://github.com/import-js/eslint-plugin-import/pull/2473
 [#2466]: https://github.com/import-js/eslint-plugin-import/pull/2466
 [#2459]: https://github.com/import-js/eslint-plugin-import/pull/2459
@@ -1760,6 +1762,7 @@ for info on changes for earlier releases.
 [@singles]: https://github.com/singles
 [@skozin]: https://github.com/skozin
 [@skyrpex]: https://github.com/skyrpex
+[@snewcomer]: https://github.com/snewcomer
 [@sompylasar]: https://github.com/sompylasar
 [@soryy708]: https://github.com/soryy708
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/docs/rules/no-duplicates.md
+++ b/docs/rules/no-duplicates.md
@@ -67,6 +67,33 @@ import SomeDefaultClass from './mod?minify'
 import * from './mod.js?minify'
 ```
 
+### Inline Type imports
+
+TypeScript 4.5 introduced a new [feature](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#type-on-import-names) that allows mixing of named value and type imports. In order to support fixing to an inline type import when duplicate imports are detected, `prefer-inline` can be set to true.
+
+Config:
+
+```json
+"import/no-duplicates": ["error", {"prefer-inline": true}]
+```
+
+<!--tabs-->
+
+❌ Invalid `["error", "prefer-inline"]`
+
+```js
+import { AValue, type AType } from './mama-mia'
+import type { BType } from './mama-mia'
+```
+
+✅ Valid with `["error", "prefer-inline"]`
+
+```js
+import { AValue, type AType, type BType } from './mama-mia'
+```
+
+<!--tabs-->
+
 ## When Not To Use It
 
 If the core ESLint version is good enough (i.e. you're _not_ using Flow and you _are_ using [`import/extensions`](./extensions.md)), keep it and don't use this.


### PR DESCRIPTION
close https://github.com/import-js/eslint-plugin-import/issues/2470

ref https://github.com/typescript-eslint/typescript-eslint/pull/5050

Typescript `import { type A } from 'util/cool-linter'` was introduced in 4.5 https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#type-on-import-names

This PR seeks to add TypeScript support to the existing rule `no-duplicates`.

```
❌ Invalid `["error", "prefer-inline"]`

import { AValue, type AType } from './mama-mia'
import type { BType } from './mama-mia'

✅ Valid with `["error", "prefer-inline"]`

import { AValue, type AType, type BType } from './mama-mia'
```
