### PR TITLE
Add an option for `no-unresolved` rule that allows one to resolve .ts files from .js imports

### DIFF
--- a/src/rules/no-unresolved.js
+++ b/src/rules/no-unresolved.js
@@ -17,6 +17,7 @@ module.exports = {
 
     schema: [
       makeOptionsSchema({
+        ts: { type: 'boolean', default: false },
         caseSensitive: { type: 'boolean', default: true },
         caseSensitiveStrict: { type: 'boolean', default: false },
       }),
@@ -34,8 +35,15 @@ module.exports = {
 
       const caseSensitive = !CASE_SENSITIVE_FS && options.caseSensitive !== false;
       const caseSensitiveStrict = !CASE_SENSITIVE_FS && options.caseSensitiveStrict;
+      const useTS = options.ts;
 
-      const resolvedPath = resolve(source.value, context);
+      let resolvedPath = resolve(source.value, context);
+      if (useTS) {
+        resolvedPath = resolvedPath ||
+          resolve(source.value.replace(/\.js$/, '.ts'), context) ||
+          resolve(source.value.replace(/\.jsx$/, '.tsx'), context);
+      }
+
 
       if (resolvedPath === undefined) {
         context.report(

--- a/tests/files/app.tsx
+++ b/tests/files/app.tsx
@@ -1,0 +1,1 @@
+export default function App() {};

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -451,12 +451,40 @@ context('TypeScript', () => {
           code: 'import type { JSONSchema7Type } from "@types/json-schema";',
           parser,
         }),
+        test({
+          code: 'import * as foo from "./typescript.js";',
+          parser,
+          options: [{ ts: true }],
+        }),
+        test({
+          code: 'import * as foo from "./app.jsx";',
+          parser,
+          options: [{ ts: true }],
+        }),
       ],
       invalid: [
         test({
           code: 'import { JSONSchema7Type } from "@types/json-schema";',
           errors: [ "Unable to resolve path to module '@types/json-schema'." ],
           parser,
+        }),
+        test({
+          code: 'import * as foo from "./typescript.js";',
+          errors: [ "Unable to resolve path to module './typescript.js'." ],
+          parser,
+          options: [{ ts: false }],
+        }),
+        test({
+          code: 'import * as foo from "./app.jsx";',
+          errors: [ "Unable to resolve path to module './app.jsx'." ],
+          parser,
+          options: [{ ts: false }],
+        }),
+        test({
+          code: 'import * as foo from "./typescript.jsx";',
+          errors: [ "Unable to resolve path to module './typescript.jsx'." ],
+          parser,
+          options: [{ ts: true }],
         }),
       ],
     });


### PR DESCRIPTION
One problem that prevents this package from being useable on TS codebase, is that it treats a file extension literally. TypeScript-based ES modules require you to import TS files using .js extension:
```
import * as foo from './foo.js'
```
The statement above really imports content of `./foo.ts` file.

This PR adds a new boolean option `ts`, set to `false` by default. If it is set to `true`, a statement above in a TS codebase is considered valid. If the plugin can not resolve `./foo.js`, it tries to also resolve `./foo.ts`, and then goes on as before.