### PR TITLE
[readme] clarify `eslint-import-resolver-typescript` usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [Docs] `order`: use correct default value ([#2392], thanks [@hyperupcall])
 - [meta] replace git.io link in comments with the original URL ([#2444], thanks [@liby])
 - [Docs] remove global install in readme ([#2412], thanks [@aladdin-add])
+- [readme] clarify `eslint-import-resolver-typescript` usage ([#2503], thanks [@JounQin])
 
 ## [2.26.0] - 2022-04-05
 
@@ -996,6 +997,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2503]: https://github.com/import-js/eslint-plugin-import/pull/2503
 [#2490]: https://github.com/import-js/eslint-plugin-import/pull/2490
 [#2466]: https://github.com/import-js/eslint-plugin-import/pull/2466
 [#2440]: https://github.com/import-js/eslint-plugin-import/pull/2440

--- a/README.md
+++ b/README.md
@@ -157,19 +157,24 @@ rules:
 
 You may use the following shortcut or assemble your own config using the granular settings described below.
 
-Make sure you have installed [`@typescript-eslint/parser`] which is used in the following configuration. Unfortunately NPM does not allow to list optional peer dependencies.
+Make sure you have installed [`@typescript-eslint/parser`] and [`eslint-import-resolver-typescript`] which are used in the following configuration.
 
 ```yaml
 extends:
   - eslint:recommended
   - plugin:import/recommended
-  - plugin:import/typescript # this line does the trick
+# the following lines do the trick
+  - plugin:import/typescript
+settings:
+  import/resolver:
+    # You will also need to install and configure the TypeScript resolver
+    # See also https://github.com/import-js/eslint-import-resolver-typescript#configuration
+    typescript: true
+    node: true
 ```
 
 [`@typescript-eslint/parser`]: https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/parser
-
-You will also need to install and configure the TypeScript resolver:
-[`eslint-import-resolver-typescript`](https://github.com/alexgorbatchev/eslint-import-resolver-typescript).
+[`eslint-import-resolver-typescript`]: https://github.com/import-js/eslint-import-resolver-typescript
 
 # Resolvers
 


### PR DESCRIPTION
Add a real example usage for `eslint-import-resolver-typescript`, it seems a lot of users just ignore the non-example part...