### PR TITLE
[Fix] `order`: leave more space in rankings for consecutive path groups 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`no-restricted-paths`]: fix an error message ([#2466], thanks [@AdriAt360])
 - [`no-restricted-paths`]: use `Minimatch.match` instead of `minimatch` to comply with Windows Native paths ([#2466], thanks [@AdriAt360])
 - [`order`]: require with member expression could not be fixed if alphabetize.order was used ([#2490], thanks [@msvab])
+- [`order`]: leave more space in rankings for consecutive path groups ([#2506], thanks [@Pearce-Ropion])
 
 ### Changed
 - [Tests] `named`: Run all TypeScript test ([#2427], thanks [@ProdigySim])
@@ -997,6 +998,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2506]: https://github.com/import-js/eslint-plugin-import/pull/2506
 [#2503]: https://github.com/import-js/eslint-plugin-import/pull/2503
 [#2490]: https://github.com/import-js/eslint-plugin-import/pull/2490
 [#2466]: https://github.com/import-js/eslint-plugin-import/pull/2466
@@ -1657,6 +1659,7 @@ for info on changes for earlier releases.
 [@panrafal]: https://github.com/panrafal
 [@paztis]: https://github.com/paztis
 [@pcorpet]: https://github.com/pcorpet
+[@Pearce-Ropion]: https://github.com/Pearce-Ropion
 [@Pessimistress]: https://github.com/Pessimistress
 [@pmcelhaney]: https://github.com/pmcelhaney
 [@preco21]: https://github.com/preco21

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -407,7 +407,7 @@ function convertGroupsToRanks(groups) {
       if (res[groupItem] !== undefined) {
         throw new Error('Incorrect configuration of the rule: `' + groupItem + '` is duplicated');
       }
-      res[groupItem] = index;
+      res[groupItem] = index * 2;
     });
     return res;
   }, {});
@@ -417,7 +417,7 @@ function convertGroupsToRanks(groups) {
   });
 
   const ranks = omittedTypes.reduce(function (res, type) {
-    res[type] = groups.length;
+    res[type] = groups.length * 2;
     return res;
   }, rankObject);
 

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -2099,6 +2099,74 @@ ruleTester.run('order', rule, {
         },
       ],
     }),
+    test({
+      code: `
+        import path from 'path';
+        import { namespace } from '@namespace';
+        import { a } from 'a';
+        import { b } from 'b';
+        import { c } from 'c';
+        import { d } from 'd';
+        import { e } from 'e';
+        import { f } from 'f';
+        import { g } from 'g';
+        import { h } from 'h';
+        import { i } from 'i';
+        import { j } from 'j';
+        import { k } from 'k';`,
+      output: `
+        import path from 'path';
+
+        import { namespace } from '@namespace';
+
+        import { a } from 'a';
+
+        import { b } from 'b';
+
+        import { c } from 'c';
+
+        import { d } from 'd';
+
+        import { e } from 'e';
+
+        import { f } from 'f';
+
+        import { g } from 'g';
+
+        import { h } from 'h';
+
+        import { i } from 'i';
+
+        import { j } from 'j';
+        import { k } from 'k';`,
+      options: [
+        {
+          groups: [
+            'builtin',
+            'external',
+            'internal',
+          ],
+          pathGroups: [
+            { pattern: '@namespace', group: 'external', position: 'after' },
+            { pattern: 'a', group: 'internal', position: 'before' },
+            { pattern: 'b', group: 'internal', position: 'before' },
+            { pattern: 'c', group: 'internal', position: 'before' },
+            { pattern: 'd', group: 'internal', position: 'before' },
+            { pattern: 'e', group: 'internal', position: 'before' },
+            { pattern: 'f', group: 'internal', position: 'before' },
+            { pattern: 'g', group: 'internal', position: 'before' },
+            { pattern: 'h', group: 'internal', position: 'before' },
+            { pattern: 'i', group: 'internal', position: 'before' },
+          ],
+          'newlines-between': 'always',
+          pathGroupsExcludedImportTypes: ['builtin'],
+        },
+      ],
+      settings: {
+        'import/internal-regex': '^(a|b|c|d|e|f|g|h|i|j|k)(\\/|$)',
+      },
+      errors: Array.from({ length: 11 }, () => 'There should be at least one empty line between import groups'),
+    }),
 
     // reorder fix cannot cross non import or require
     test(withoutAutofixOutput({


### PR DESCRIPTION
Resolves #2494 

Creates more space (numerically) between consecutive groups to allow for what would have been overlapping path groups.

The issue occurs when there are enough (9-10) before/after `pathGroups` in consecutive `groups` where the rankings start to overlap with the previous/next group. See the repro in #2494 for one example of this.

I think a better fix would be to rework some of the ranking logic in `convertPathGroupsForRanks`. However, this change was a non-invasive easy workaround that doesn't introduce any regressions (as far as I can tell).