### PR TITLE
[Fix] `ExportMap`: add caching after parsing for an ambiguous module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [Docs] remove global install in readme ([#2412], thanks [@aladdin-add])
 - [readme] clarify `eslint-import-resolver-typescript` usage ([#2503], thanks [@JounQin])
 - [Refactor] `no-cycle`: Add per-run caching of traversed paths ([#2419], thanks [@nokel81])
+- [Performance] `ExportMap`: add caching after parsing for an ambiguous module ([#2531], thanks [@stenin-nikita])
 
 ## [2.26.0] - 2022-04-05
 
@@ -999,6 +1000,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2531]: https://github.com/import-js/eslint-plugin-import/pull/2531
 [#2506]: https://github.com/import-js/eslint-plugin-import/pull/2506
 [#2503]: https://github.com/import-js/eslint-plugin-import/pull/2503
 [#2490]: https://github.com/import-js/eslint-plugin-import/pull/2490
@@ -1701,6 +1703,7 @@ for info on changes for earlier releases.
 [@spalger]: https://github.com/spalger
 [@st-sloth]: https://github.com/st-sloth
 [@stekycz]: https://github.com/stekycz
+[@stenin-nikita]: https://github.com/stenin-nikita
 [@stephtr]: https://github.com/stephtr
 [@straub]: https://github.com/straub
 [@strawbrary]: https://github.com/strawbrary

--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -346,7 +346,11 @@ ExportMap.for = function (context) {
   exportMap = ExportMap.parse(path, content, context);
 
   // ambiguous modules return null
-  if (exportMap == null) return null;
+  if (exportMap == null) {
+    log('ignored path due to ambiguous parse:', path);
+    exportCache.set(cacheKey, null);
+    return null;
+  }
 
   exportMap.mtime = stats.mtime;
 

--- a/tests/files/typescript-declare-module.ts
+++ b/tests/files/typescript-declare-module.ts
@@ -1,0 +1,3 @@
+declare module "typescript-declare-module-foo" {
+  export const foo: string;
+}

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -431,6 +431,19 @@ describe('ExportMap', function () {
           ExportMap.parse('./baz.ts', 'export const baz = 5', differentContext);
           expect(tsConfigLoader.tsConfigLoader.callCount).to.equal(2);
         });
+
+        it('should cache after parsing for an ambiguous module', function () {
+          const source = './typescript-declare-module.ts';
+          const parseSpy = sinon.spy(ExportMap, 'parse');
+      
+          expect(ExportMap.get(source, context)).to.be.null;
+      
+          ExportMap.get(source, context);
+      
+          expect(parseSpy.callCount).to.equal(1);
+      
+          parseSpy.restore();
+        });
       });
     });
   });


### PR DESCRIPTION
This PR is a fix for #2529 