### PR TITLE
[actions] add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/node-4+.yml
+++ b/.github/workflows/node-4+.yml
@@ -2,6 +2,9 @@ name: 'Tests: node.js'
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/node-pretest.yml
+++ b/.github/workflows/node-pretest.yml
@@ -2,6 +2,9 @@ name: 'Tests: pretest/posttest'
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   # pretest:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -2,6 +2,9 @@ name: 'Tests: packages'
 
 on: [pull_request, push]
 
+permissions:
+  contents: read
+
 jobs:
   matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -2,8 +2,14 @@ name: Automatic Rebase
 
 on: [pull_request_target]
 
+permissions:
+  contents: read
+
 jobs:
   _:
+    permissions:
+      contents: write  # for ljharb/rebase to push code to rebase
+      pull-requests: read  # for ljharb/rebase to get info about PR
     name: "Automatic Rebase"
 
     runs-on: ubuntu-latest

--- a/.github/workflows/require-allow-edits.yml
+++ b/.github/workflows/require-allow-edits.yml
@@ -2,8 +2,13 @@ name: Require “Allow Edits”
 
 on: [pull_request_target]
 
+permissions:
+  contents: read
+
 jobs:
   _:
+    permissions:
+      pull-requests: read  # for ljharb/require-allow-edits to check 'allow edits' on PR
     name: "Require “Allow Edits”"
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows. 

GitHub Actions workflows have a GITHUB_TOKEN with `write` access to multiple scopes. 
After this change, the scopes will be reduced to the minimum needed for each workflow. 

### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced. 
- GitHub recommends defining minimum GITHUB_TOKEN permissions. 
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository. 

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>