### PR TITLE
[New] add `named-order` rule to sort specifiers of import, export, require

### DIFF
--- a/docs/rules/named-order.md
+++ b/docs/rules/named-order.md
@@ -47,21 +47,12 @@ This option enables reporting of errors if `import` / `export` specifiers are no
 #### `commonjs`
 This option enablee reporting of errors if `require` specifiers are not sorted. Its value is `true` by default.
 
-#### `caseInsensitive`
-There is a `caseInsensitive` option available to be case insensitive. Its value is `false` by default.
-
-Without `caseInsensitive` option:
-```js
-import { alpha, Alpha, ALPHA } from 'foo' // <- reported, should sort as { ALPHA, Alpha, alpha }
-```
-
-With `caseInsensitive` option:
-```js
-import { alpha, Alpha, ALPHA } from 'foo' // <- will not report
-```
-
 #### `order`
-There is a `order` option available to sort an order into either `asc` or `desc`. Its value is `asc` by default.
+There is a `order` option available to sort an order into either `caseInsensitive`  or `lowercaseFirst` or `lowercaseLast`.
+
+* `caseInsensitive` : Correct order is `['Bar', 'baz', 'Foo']`. (This is the default.)
+* `lowercaseFirst`: Correct order is `['baz', 'Bar', 'Foo']`.
+* `lowercaseLast`: Correct order is `['Bar', 'Foo', 'baz']`.
 
 ## When Not To Use It
 

--- a/docs/rules/named-order.md
+++ b/docs/rules/named-order.md
@@ -1,0 +1,68 @@
+# import/named-order
+
+Enforce a convention in the order of `import` / `export` / `require()` specifiers
++(fixable) The `--fix` option on the [command line] automatically fixes problems reported by this rule.
+
+## Rule Details
+
+The following patterns are valid:
+
+```js
+import { Alpha, Bravo } from 'foo'
+```
+
+```js
+const { Alpha, Bravo } = require('foo')
+```
+
+```js
+const Alpha = 'A'
+const Bravo = 'B'
+
+export { Alpha, Bravo }
+```
+
+The following patterns are invalid:
+
+```js
+import { Bravo, Alpha } from 'foo' // <- reported
+```
+
+```js
+const { Bravo, Alpha } = require('foo') // <- reported
+```
+
+```js
+const Alpha = 'A'
+const Bravo = 'B'
+
+export { Alpha, Bravo } // <- reported
+```
+
+### Options
+
+#### `esmodule`
+This option enables reporting of errors if `import` / `export` specifiers are not sorted. Its value is `true` by default.
+
+#### `commonjs`
+This option enablee reporting of errors if `require` specifiers are not sorted. Its value is `true` by default.
+
+#### `caseInsensitive`
+There is a `caseInsensitive` option available to be case insensitive. Its value is `false` by default.
+
+Without `caseInsensitive` option:
+```js
+import { alpha, Alpha, ALPHA } from 'foo' // <- reported, should sort as { ALPHA, Alpha, alpha }
+```
+
+With `caseInsensitive` option:
+```js
+import { alpha, Alpha, ALPHA } from 'foo' // <- will not report
+```
+
+#### `order`
+There is a `order` option available to sort an order into either `asc` or `desc`. Its value is `asc` by default.
+
+## When Not To Use It
+
+If your environment specifically requires specifiers order of `import` / `export` / `require`.

--- a/docs/rules/named-order.md
+++ b/docs/rules/named-order.md
@@ -36,7 +36,7 @@ const { Bravo, Alpha } = require('foo') // <- reported
 const Alpha = 'A'
 const Bravo = 'B'
 
-export { Alpha, Bravo } // <- reported
+export { Bravo, Alpha } // <- reported
 ```
 
 ### Options

--- a/docs/rules/named-order.md
+++ b/docs/rules/named-order.md
@@ -41,12 +41,6 @@ export { Alpha, Bravo } // <- reported
 
 ### Options
 
-#### `esmodule`
-This option enables reporting of errors if `import` / `export` specifiers are not sorted. Its value is `true` by default.
-
-#### `commonjs`
-This option enablee reporting of errors if `require` specifiers are not sorted. Its value is `true` by default.
-
 #### `order`
 There is a `order` option available to sort an order into either `caseInsensitive`  or `lowercaseFirst` or `lowercaseLast`.
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export const rules = {
   'no-useless-path-segments': require('./rules/no-useless-path-segments'),
   'dynamic-import-chunkname': require('./rules/dynamic-import-chunkname'),
   'no-import-module-exports': require('./rules/no-import-module-exports'),
+  'named-order': require('./rules/named-order'),
 
   // export
   'exports-last': require('./rules/exports-last'),

--- a/src/rules/named-order.js
+++ b/src/rules/named-order.js
@@ -6,7 +6,7 @@ import docsUrl from '../docsUrl';
 // utils
 //
 
-const getOptions = (context) => {
+function getOptions(context) {
   const {
     caseInsensitive = false,
     order = 'asc',
@@ -20,23 +20,23 @@ const getOptions = (context) => {
     commonjs,
     esmodule,
   };
-};
+}
 
-const isArrayShallowEquals = (left, right) => {
+function isArrayShallowEquals(left, right) {
   return left.length === right.length && left.every((leftValue, offset) => {
     const rightValue = right[offset];
     return leftValue === rightValue;
   });
-};
+}
 
-const getFullRangeOfNodes = (nodes) => {
+function getFullRangeOfNodes(nodes) {
   const ranges = nodes.map(node => node.range);
   const rangeFrom = Math.min(...ranges[0]);
   const rangeTo = Math.max(...ranges[1]);
   return [rangeFrom, rangeTo];
-};
+}
 
-const compareString = (left, right) => {
+function compareString(left, right) {
   if (left < right) {
     return -1;
   }
@@ -44,22 +44,22 @@ const compareString = (left, right) => {
     return 1;
   }
   return 0;
-};
+}
 
-const makeDeepSorter = (options, sortFieldKeyPath) => {
+function makeDeepSorter(options, sortFieldKeyPath) {
   const orderMultiplier = options.order === 'desc' ? -1 : 1;
 
   const sortFieldKeys = sortFieldKeyPath.split('.');
 
-  const getNormalizedValue = (rootValue) => {
+  function getNormalizedValue(rootValue) {
     const value = sortFieldKeys.reduce((value, key) => value[key], rootValue);
 
     return options.caseInsensitive
       ? String(value).toLowerCase()
       : String(value);
-  };
+  }
 
-  return (left, right) => {
+  return function sorter(left, right) {
     const leftValue = getNormalizedValue(left);
     const rightValue = getNormalizedValue(right);
 
@@ -67,7 +67,7 @@ const makeDeepSorter = (options, sortFieldKeyPath) => {
   
     return order * orderMultiplier;
   };
-};
+}
 
 //
 // named-order rule
@@ -111,10 +111,10 @@ module.exports = {
     const options = getOptions(context);
     const sourceCode = context.getSourceCode();
 
-    const getSourceCodeTextOfNode = (node) => {
+    function getSourceCodeTextOfNode(node) {
       const [from, to] = node.range;
       return sourceCode.text.substring(from, to);
-    };
+    }
 
     // sorters
     const namedImportSpecifierSorter = makeDeepSorter(options, 'imported.name');
@@ -122,7 +122,7 @@ module.exports = {
     const requireIdPropertySorter = makeDeepSorter(options, 'key.name');
 
     return {
-      ImportDeclaration: (node) => {
+      ImportDeclaration: function handleImports(node) {
         if (
           !options.esmodule
           || !node 
@@ -155,7 +155,7 @@ module.exports = {
           });
         }
       },
-      ExportNamedDeclaration: (node) => {
+      ExportNamedDeclaration: function handleExports(node) {
         if (
           !options.esmodule
           || !node
@@ -187,7 +187,7 @@ module.exports = {
           });
         }
       },
-      VariableDeclarator: (node) => {
+      VariableDeclarator: function handleRequires(node) {
         if (
           !options.commonjs
           || !node

--- a/src/rules/named-order.js
+++ b/src/rules/named-order.js
@@ -144,11 +144,7 @@ module.exports = {
 
           context.report({
             node,
-            message: 'Named import specifiers of `{{{source}}}` should sort as `{{{destination}}}`',
-            data: {
-              source: sourceString,
-              destination: destinationString,
-            },
+            message: `Named import specifiers of \`${sourceString}\` should sort as \`${destinationString}\``,
             fix(fixer) {
               return fixer.replaceTextRange(sourceFullRange, destinationString);
             },
@@ -176,11 +172,7 @@ module.exports = {
 
           context.report({
             node,
-            message: 'Named export specifiers of `{{{source}}}` should sort as `{{{destination}}}`',
-            data: {
-              source: sourceString,
-              destination: destinationString,
-            },
+            message: `Named export specifiers of \`${sourceString}\` should sort as \`${destinationString}\``,
             fix(fixer) {
               return fixer.replaceTextRange(sourceFullRange, destinationString);
             },
@@ -219,11 +211,7 @@ module.exports = {
 
           context.report({
             node,
-            message: 'Require specifiers of `{{{source}}}` should sort as `{{{destination}}}`',
-            data: {
-              source: sourceString,
-              destination: destinationString,
-            },
+            message: `Require specifiers of \`${sourceString}\` should sort as \`${destinationString}\``,
             fix(fixer) {
               return fixer.replaceTextRange(sourceFullRange, destinationString);
             },

--- a/src/rules/named-order.js
+++ b/src/rules/named-order.js
@@ -30,9 +30,8 @@ function isArrayShallowEquals(left, right) {
 }
 
 function getFullRangeOfNodes(nodes) {
-  const ranges = nodes.map(node => node.range);
-  const rangeFrom = Math.min(...ranges[0]);
-  const rangeTo = Math.max(...ranges[1]);
+  const rangeFrom = Math.min(...nodes.map(node => node.range[0]));
+  const rangeTo = Math.max(...nodes.map(node => node.range[1]));
   return [rangeFrom, rangeTo];
 }
 

--- a/src/rules/named-order.js
+++ b/src/rules/named-order.js
@@ -144,7 +144,7 @@ module.exports = {
 
           context.report({
             node,
-            message: `Named import specifiers of \`${sourceString}\` should sort as \`${destinationString}\``,
+            message: `Named import specifiers of \`{${sourceString}}\` should sort as \`{${destinationString}}\``,
             fix(fixer) {
               return fixer.replaceTextRange(sourceFullRange, destinationString);
             },
@@ -172,7 +172,7 @@ module.exports = {
 
           context.report({
             node,
-            message: `Named export specifiers of \`${sourceString}\` should sort as \`${destinationString}\``,
+            message: `Named export specifiers of \`{${sourceString}}\` should sort as \`{${destinationString}}\``,
             fix(fixer) {
               return fixer.replaceTextRange(sourceFullRange, destinationString);
             },
@@ -211,7 +211,7 @@ module.exports = {
 
           context.report({
             node,
-            message: `Require specifiers of \`${sourceString}\` should sort as \`${destinationString}\``,
+            message: `Require specifiers of \`{${sourceString}}\` should sort as \`{${destinationString}}\``,
             fix(fixer) {
               return fixer.replaceTextRange(sourceFullRange, destinationString);
             },

--- a/src/rules/named-order.js
+++ b/src/rules/named-order.js
@@ -9,14 +9,10 @@ import docsUrl from '../docsUrl';
 function getOptions(context) {
   const {
     order = 'caseInsensitive',
-    commonjs = true,
-    esmodule = true,
   } = context.options[0] || {};
 
   return {
     order,
-    commonjs,
-    esmodule,
   };
 }
 
@@ -99,14 +95,6 @@ module.exports = {
             enum: ['caseInsensitive', 'lowercaseFirst', 'uppercaseFirst'],
             default: 'caseInsensitive',
           },
-          commonjs: {
-            type: 'boolean',
-            default: true,
-          },
-          esmodule: {
-            type: 'boolean',
-            default: true,
-          },
         },
         additionalProperties: false,
       },
@@ -130,8 +118,7 @@ module.exports = {
     return {
       ImportDeclaration: function handleImports(node) {
         if (
-          !options.esmodule
-          || !node 
+          !node 
           || node.type !== 'ImportDeclaration'
           || !node.specifiers 
           || node.specifiers.length === 0
@@ -159,8 +146,7 @@ module.exports = {
       },
       ExportNamedDeclaration: function handleExports(node) {
         if (
-          !options.esmodule
-          || !node
+          !node
           || node.type !== 'ExportNamedDeclaration'
           || !node.specifiers
           || node.specifiers.length === 0) {
@@ -187,8 +173,7 @@ module.exports = {
       },
       VariableDeclarator: function handleRequires(node) {
         if (
-          !options.commonjs
-          || !node
+          !node
           // check root node
           || node.type !== 'VariableDeclarator'
           // check it has valid properties

--- a/src/rules/named-order.js
+++ b/src/rules/named-order.js
@@ -1,0 +1,45 @@
+'use strict';
+
+import docsUrl from '../docsUrl';
+
+//
+// named-order rule
+// 
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      url: docsUrl('named-order'),
+    },
+
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          caseInsensitive: {
+            type: 'boolean',
+            default: false,
+          },
+          order: {
+            enum: ['asc', 'desc'],
+            default: 'asc',
+          },
+          commonjs: {
+            type: 'boolean',
+            default: true,
+          },
+          esmodule: {
+            type: 'boolean',
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create: function namedOrderRule() {
+  },
+};

--- a/src/rules/named-order.js
+++ b/src/rules/named-order.js
@@ -3,6 +3,26 @@
 import docsUrl from '../docsUrl';
 
 //
+// utils
+//
+
+const getOptions = (context) => {
+  const {
+    caseInsensitive = false,
+    order = 'asc',
+    commonjs = true,
+    esmodule = true,
+  } = context.options[0] || {};
+
+  return {
+    caseInsensitive,
+    order,
+    commonjs,
+    esmodule,
+  };
+};
+
+//
 // named-order rule
 // 
 
@@ -40,6 +60,7 @@ module.exports = {
     ],
   },
 
-  create: function namedOrderRule() {
+  create: function namedOrderRule(context) {
+    const options = getOptions(context);
   },
 };

--- a/tests/src/rules/named-order.js
+++ b/tests/src/rules/named-order.js
@@ -1,0 +1,13 @@
+import { test, parsers } from '../utils';
+
+import { RuleTester } from 'eslint';
+
+const ruleTester = new RuleTester();
+const rule = require('rules/named-order');
+
+ruleTester.run('named-order', rule, {
+  valid: [
+  ],
+  invalid: [
+  ],
+});

--- a/tests/src/rules/named-order.js
+++ b/tests/src/rules/named-order.js
@@ -48,6 +48,12 @@ ruleTester.run('named-order', rule, {
       options: [{ order: 'lowercaseFirst' }],
     }),
     test({
+      code: `import {A2, A1, a} from 'foo'`,
+      output: `import {a, A1, A2} from 'foo'`,
+      errors: ['Named import specifiers of `{A2, A1, a}` should sort as `{a, A1, A2}`'],
+      options: [{ order: 'lowercaseFirst' }],
+    }),
+    test({
       code: `import {A, B, a} from 'foo'`,
       options: [{ order: 'uppercaseFirst' }],
     }),

--- a/tests/src/rules/named-order.js
+++ b/tests/src/rules/named-order.js
@@ -48,12 +48,6 @@ ruleTester.run('named-order', rule, {
       options: [{ order: 'lowercaseFirst' }],
     }),
     test({
-      code: `import {A2, A1, a} from 'foo'`,
-      output: `import {a, A1, A2} from 'foo'`,
-      errors: ['Named import specifiers of `{A2, A1, a}` should sort as `{a, A1, A2}`'],
-      options: [{ order: 'lowercaseFirst' }],
-    }),
-    test({
       code: `import {A, B, a} from 'foo'`,
       options: [{ order: 'uppercaseFirst' }],
     }),
@@ -178,6 +172,12 @@ ruleTester.run('named-order', rule, {
       code: `import {A, a, B} from 'foo'`,
       output: `import {a, A, B} from 'foo'`,
       errors: ['Named import specifiers of `{A, a, B}` should sort as `{a, A, B}`'],
+      options: [{ order: 'lowercaseFirst' }],
+    }),
+    test({
+      code: `import {A2, A1, a} from 'foo'`,
+      output: `import {a, A1, A2} from 'foo'`,
+      errors: ['Named import specifiers of `{A2, A1, a}` should sort as `{a, A1, A2}`'],
       options: [{ order: 'lowercaseFirst' }],
     }),
     test({

--- a/tests/src/rules/named-order.js
+++ b/tests/src/rules/named-order.js
@@ -75,6 +75,22 @@ ruleTester.run('named-order', rule, {
       `,
       options: [{ caseInsensitive: true }],
     }),
+    //
+    // require
+    //
+    test({
+      code: `const foo = require('foo')`,
+    }),
+    test({
+      code: `const {} = require('foo')`,
+    }),
+    test({
+      code: `const {a, b} = require('foo')`,
+    }),
+    test({
+      code: `const {a, A} = require('foo')`,
+      options: [{ caseInsensitive: true }],
+    }),
   ],
   invalid: [
     //
@@ -162,6 +178,19 @@ ruleTester.run('named-order', rule, {
         export {A, a}
       `,
       errors: ['Named export specifiers of `{a, A}` should sort as `{A, a}`'],
+    }),
+    //
+    // require
+    //
+    test({
+      code: `const {b, a} = require('foo')`,
+      output: `const {a, b} = require('foo')`,
+      errors: ['Require specifiers of `{b, a}` should sort as `{a, b}`'],
+    }),
+    test({
+      code: `const {a, A} = require('foo')`,
+      output: `const {A, a} = require('foo')`,
+      errors: ['Require specifiers of `{a, A}` should sort as `{A, a}`'],
     }),
   ],
 });

--- a/tests/src/rules/named-order.js
+++ b/tests/src/rules/named-order.js
@@ -40,12 +40,16 @@ ruleTester.run('named-order', rule, {
       parser: parsers.BABEL_OLD,
     }),
     test({
-      code: `import {b, a} from 'foo'`,
-      options: [{ order: 'desc' }],
+      code: `import {A, a, B} from 'foo'`,
+      options: [{ order: 'caseInsensitive' }],
     }),
     test({
-      code: `import {A, a} from 'foo'`,
-      options: [{ caseInsensitive: true }],
+      code: `import {a, A, B} from 'foo'`,
+      options: [{ order: 'lowercaseFirst' }],
+    }),
+    test({
+      code: `import {A, B, a} from 'foo'`,
+      options: [{ order: 'uppercaseFirst' }],
     }),
     //
     // named export
@@ -70,10 +74,29 @@ ruleTester.run('named-order', rule, {
     test({
       code: `
         const A = ''
+        const B = ''
         function a() {}
-        export {a, A}
+        export {A, a, B}
       `,
-      options: [{ caseInsensitive: true }],
+      options: [{ order: 'caseInsensitive' }],
+    }),
+    test({
+      code: `
+        const A = ''
+        const B = ''
+        function a() {}
+        export {a, A, B}
+      `,
+      options: [{ order: 'lowercaseFirst' }],
+    }),
+    test({
+      code: `
+        const A = ''
+        const B = ''
+        function a() {}
+        export {A, B, a}
+      `,
+      options: [{ order: 'uppercaseFirst' }],
     }),
     //
     // require
@@ -88,8 +111,16 @@ ruleTester.run('named-order', rule, {
       code: `const {a, b} = require('foo')`,
     }),
     test({
-      code: `const {a, A} = require('foo')`,
-      options: [{ caseInsensitive: true }],
+      code: `const {A, a, B} = require('foo')`,
+      options: [{ order: 'caseInsensitive' }],
+    }),
+    test({
+      code: `const {a, A, B} = require('foo')`,
+      options: [{ order: 'lowercaseFirst' }],
+    }),
+    test({
+      code: `const {A, B, a} = require('foo')`,
+      options: [{ order: 'uppercaseFirst' }],
     }),
   ],
   invalid: [
@@ -132,10 +163,22 @@ ruleTester.run('named-order', rule, {
       parser: parsers.BABEL_OLD,
     }),
     test({
-      code: `import {a, b} from 'foo'`,
-      output: `import {b, a} from 'foo'`,
-      errors: ['Named import specifiers of `{a, b}` should sort as `{b, a}`'],
-      options: [{ order: 'desc' }],
+      code: `import {A, B, a} from 'foo'`,
+      output: `import {A, a, B} from 'foo'`,
+      errors: ['Named import specifiers of `{A, B, a}` should sort as `{A, a, B}`'],
+      options: [{ order: 'caseInsensitive' }],
+    }),
+    test({
+      code: `import {A, a, B} from 'foo'`,
+      output: `import {a, A, B} from 'foo'`,
+      errors: ['Named import specifiers of `{A, a, B}` should sort as `{a, A, B}`'],
+      options: [{ order: 'lowercaseFirst' }],
+    }),
+    test({
+      code: `import {A, a, B} from 'foo'`,
+      output: `import {A, B, a} from 'foo'`,
+      errors: ['Named import specifiers of `{A, a, B}` should sort as `{A, B, a}`'],
+      options: [{ order: 'uppercaseFirst' }],
     }),
     //
     // named export
@@ -168,16 +211,51 @@ ruleTester.run('named-order', rule, {
     }),
     test({
       code: `
-        const A = ''
+        const A = null
+        const B = null
         function a() {}
-        export {a, A}
+        export {A, B, a}
       `,
       output: `
-        const A = ''
+        const A = null
+        const B = null
         function a() {}
-        export {A, a}
+        export {A, a, B}
       `,
-      errors: ['Named export specifiers of `{a, A}` should sort as `{A, a}`'],
+      errors: ['Named export specifiers of `{A, B, a}` should sort as `{A, a, B}`'],
+      options: [{ order: 'caseInsensitive' }],
+    }),
+    test({
+      code: `
+        const A = null
+        const B = null
+        function a() {}
+        export {A, a, B}
+      `,
+      output: `
+        const A = null
+        const B = null
+        function a() {}
+        export {a, A, B}
+      `,
+      errors: ['Named export specifiers of `{A, a, B}` should sort as `{a, A, B}`'],
+      options: [{ order: 'lowercaseFirst' }],
+    }),
+    test({
+      code: `
+        const A = null
+        const B = null
+        function a() {}
+        export {A, a, B}
+      `,
+      output: `
+        const A = null
+        const B = null
+        function a() {}
+        export {A, B, a}
+      `,
+      errors: ['Named export specifiers of `{A, a, B}` should sort as `{A, B, a}`'],
+      options: [{ order: 'uppercaseFirst' }],
     }),
     //
     // require
@@ -188,9 +266,22 @@ ruleTester.run('named-order', rule, {
       errors: ['Require specifiers of `{b, a}` should sort as `{a, b}`'],
     }),
     test({
-      code: `const {a, A} = require('foo')`,
-      output: `const {A, a} = require('foo')`,
-      errors: ['Require specifiers of `{a, A}` should sort as `{A, a}`'],
+      code: `const {A, B, a} = require('foo')`,
+      output: `const {A, a, B} = require('foo')`,
+      errors: ['Require specifiers of `{A, B, a}` should sort as `{A, a, B}`'],
+      options: [{ order: 'caseInsensitive' }],
+    }),
+    test({
+      code: `const {A, a, B} = require('foo')`,
+      output: `const {a, A, B} = require('foo')`,
+      errors: ['Require specifiers of `{A, a, B}` should sort as `{a, A, B}`'],
+      options: [{ order: 'lowercaseFirst' }],
+    }),
+    test({
+      code: `const {A, a, B} = require('foo')`,
+      output: `const {A, B, a} = require('foo')`,
+      errors: ['Require specifiers of `{A, a, B}` should sort as `{A, B, a}`'],
+      options: [{ order: 'uppercaseFirst' }],
     }),
   ],
 });

--- a/tests/src/rules/named-order.js
+++ b/tests/src/rules/named-order.js
@@ -47,6 +47,34 @@ ruleTester.run('named-order', rule, {
       code: `import {A, a} from 'foo'`,
       options: [{ caseInsensitive: true }],
     }),
+    //
+    // named export
+    //
+    test({
+      code: `export {}`,
+    }),
+    test({
+      code: `
+        function a() {}
+        function b() {}
+        export {a, b}
+      `,
+    }),
+    test({
+      code: `
+        function foo() {}
+        function b() {}
+        export {foo as a, b}
+      `,
+    }),
+    test({
+      code: `
+        const A = ''
+        function a() {}
+        export {a, A}
+      `,
+      options: [{ caseInsensitive: true }],
+    }),
   ],
   invalid: [
     //
@@ -92,6 +120,48 @@ ruleTester.run('named-order', rule, {
       output: `import {b, a} from 'foo'`,
       errors: ['Named import specifiers of `{a, b}` should sort as `{b, a}`'],
       options: [{ order: 'desc' }],
+    }),
+    //
+    // named export
+    //
+    test({
+      code: `
+        function a() {}
+        function b() {}
+        export {b, a}
+      `,
+      output: `
+        function a() {}
+        function b() {}
+        export {a, b}
+      `,
+      errors: ['Named export specifiers of `{b, a}` should sort as `{a, b}`'],
+    }),
+    test({
+      code: `
+        function foo() {}
+        function b() {}
+        export {b, foo as a}
+      `,
+      output: `
+        function foo() {}
+        function b() {}
+        export {foo as a, b}
+      `,
+      errors: ['Named export specifiers of `{b, foo as a}` should sort as `{foo as a, b}`'],
+    }),
+    test({
+      code: `
+        const A = ''
+        function a() {}
+        export {a, A}
+      `,
+      output: `
+        const A = ''
+        function a() {}
+        export {A, a}
+      `,
+      errors: ['Named export specifiers of `{a, A}` should sort as `{A, a}`'],
     }),
   ],
 });

--- a/tests/src/rules/named-order.js
+++ b/tests/src/rules/named-order.js
@@ -7,7 +7,91 @@ const rule = require('rules/named-order');
 
 ruleTester.run('named-order', rule, {
   valid: [
+    //
+    // named import
+    //
+    test({
+      code: `import foo from 'foo'`,
+    }),
+    test({
+      code: `import {} from 'foo'`,
+    }),
+    test({
+      code: `import {a, b} from 'foo'`,
+    }),
+    test({
+      code: `import type {a, b} from 'foo'`,
+      parser: parsers.BABEL_OLD,
+    }),
+    test({
+      code: `import typeof {a, b} from 'foo'`,
+      parser: parsers.BABEL_OLD,
+    }),
+    test({
+      code: `import {type a, type b} from 'foo'`,
+      parser: parsers.BABEL_OLD,
+    }),
+    test({
+      code: `import {typeof a, typeof b} from 'foo'`,
+      parser: parsers.BABEL_OLD,
+    }),
+    test({
+      code: `import {typeof a, type b} from 'foo'`,
+      parser: parsers.BABEL_OLD,
+    }),
+    test({
+      code: `import {b, a} from 'foo'`,
+      options: [{ order: 'desc' }],
+    }),
+    test({
+      code: `import {A, a} from 'foo'`,
+      options: [{ caseInsensitive: true }],
+    }),
   ],
   invalid: [
+    //
+    // named import
+    //
+    test({
+      code: `import {b, a} from 'foo'`,
+      output: `import {a, b} from 'foo'`,
+      errors: ['Named import specifiers of `{b, a}` should sort as `{a, b}`'],
+    }),
+    test({
+      code: `import type {b, a} from 'foo'`,
+      output: `import type {a, b} from 'foo'`,
+      errors: ['Named import specifiers of `{b, a}` should sort as `{a, b}`'],
+      parser: parsers.BABEL_OLD,
+    }),
+    test({
+      code: `import typeof {b, a} from 'foo'`,
+      output: `import typeof {a, b} from 'foo'`,
+      errors: ['Named import specifiers of `{b, a}` should sort as `{a, b}`'],
+      parser: parsers.BABEL_OLD,
+    }),
+    test({
+      code: `import {type b, type a} from 'foo'`,
+      output: `import {type a, type b} from 'foo'`,
+      errors: ['Named import specifiers of `{type b, type a}` should sort as `{type a, type b}`'],
+      parser: parsers.BABEL_OLD,
+    }),
+    test({
+      code: `import {typeof b, typeof a} from 'foo'`,
+      output: `import {typeof a, typeof b} from 'foo'`,
+      errors: ['Named import specifiers of `{typeof b, typeof a}` should sort as `{typeof a, typeof b}`'],
+      parser: parsers.BABEL_OLD,
+    }),
+    test({
+      code: `import {typeof b, type a} from 'foo'`,
+      output: `import {type a, typeof b} from 'foo'`,
+      errors: ['Named import specifiers of `{typeof b, type a}` should sort as `{type a, typeof b}`'],
+      parser: parsers.BABEL_OLD,
+    }),
+    test({
+      code: `import {a, b} from 'foo'`,
+      output: `import {b, a} from 'foo'`,
+      errors: ['Named import specifiers of `{a, b}` should sort as `{b, a}`'],
+      options: [{ order: 'desc' }],
+    }),
   ],
 });


### PR DESCRIPTION
### Examples
✅ Valid with `named-order`
```js
import { a, b } from './foo';
const { a, b } = require('./foo');
export { a, b };
```

❌ Invalid with `named-order`
```js
import { b, a } from './foo';
const { b, a } = require('./foo');
export { b, a };
```

### Why?
I experienced a significant decrease in readability as the number of specifiers increased in the named import. So, I made this rule. Tell me if there's anything weird in this rule 😄 

