### PR TITLE
[actions] update GitHub Actions

### DIFF
--- a/.github/workflows/node-4+.yml
+++ b/.github/workflows/node-4+.yml
@@ -99,7 +99,7 @@ jobs:
             eslint: 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ljharb/actions/node/install@main
         continue-on-error: ${{ matrix.eslint == 4 && matrix.node-version == 4 }}
         name: 'nvm install ${{ matrix.node-version }} && npm install, with eslint ${{ matrix.eslint }}'
@@ -113,7 +113,7 @@ jobs:
           skip-ls-check: true
       - run: npm run pretest
       - run: npm run tests-only
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
 
   node:
     name: 'node 4+'

--- a/.github/workflows/node-pretest.yml
+++ b/.github/workflows/node-pretest.yml
@@ -10,7 +10,7 @@ jobs:
   #   runs-on: ubuntu-latest
 
   #   steps:
-  #     - uses: actions/checkout@v2
+  #     - uses: actions/checkout@v3
   #     - uses: ljharb/actions/node/install@main
   #       name: 'nvm install lts/* && npm install'
   #       with:
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ljharb/actions/node/install@main
         name: 'nvm install lts/* && npm install'
         with:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -38,7 +38,7 @@ jobs:
           # - utils
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         env:
@@ -50,7 +50,7 @@ jobs:
           after_install: npm run copy-metafiles && ./tests/dep-time-travel.sh && cd ${{ matrix.package }} && npm install
           skip-ls-check: true
       - run: cd ${{ matrix.package }} && npm run tests-only
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
 
   packages:
     name: 'packages: all tests'

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -2,20 +2,8 @@ name: Automatic Rebase
 
 on: [pull_request_target]
 
-permissions:
-  contents: read
-
 jobs:
   _:
-    permissions:
-      contents: write  # for ljharb/rebase to push code to rebase
-      pull-requests: read  # for ljharb/rebase to get info about PR
-    name: "Automatic Rebase"
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - uses: ljharb/rebase@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ljharb/actions/.github/workflows/rebase.yml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR bumps GitHub Actions to their latest major versions, which now use Node 16 internally instead of Node 12 (EOL as of end of April 2022, no longer receives security updates):

- Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- Changelog for `codecov/codecov-action` actions can be [found here](https://github.com/codecov/codecov-action/blob/main/CHANGELOG.md)