### PR TITLE
[Tests] `namespace`: add passing test case to close #2572

### DIFF
--- a/tests/files/jsx/bar/baz.jsx
+++ b/tests/files/jsx/bar/baz.jsx
@@ -1,0 +1,16 @@
+
+export function Baz1() {
+  return (
+    <div>
+    </div>
+  );
+}
+
+// Fragment Syntax
+export function Baz2() {
+  return (
+    <div>
+      <span>Baz2</span>
+    </div>
+  );
+}

--- a/tests/files/jsx/bar/index.js
+++ b/tests/files/jsx/bar/index.js
@@ -1,0 +1,2 @@
+export * from "./baz.jsx";
+export { Qux1, Qux2 } from "./qux.jsx";

--- a/tests/files/jsx/bar/qux.jsx
+++ b/tests/files/jsx/bar/qux.jsx
@@ -1,0 +1,16 @@
+
+export function Qux1() {
+  return (
+    <div>
+      <p>Qux1</p>
+    </div>
+  );
+}
+
+export function Qux2() {
+  return (
+    <div>
+      <p>Qux1</p>
+    </div>
+  );;
+}

--- a/tests/files/jsx/re-export.js
+++ b/tests/files/jsx/re-export.js
@@ -1,0 +1,1 @@
+export * from './named.jsx'

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -29,6 +29,35 @@ const valid = [
       ecmaVersion: 2015,
     },
   }),
+  // import re-exported jsx files, where jsx file exports a string
+  test({
+    code: `
+      import * as foo from "./jsx/re-export.js";
+      console.log(foo.jsxFoo);
+    `,
+    settings: {
+      'import/extensions': ['.js', '.jsx'],
+    },
+  }),
+  // import re-exported jsx files, where jsx files export functions that return html tags
+  test({
+    code: `
+      import * as foo from "./jsx/bar/index.js";
+      console.log(foo.Baz1);
+      console.log(foo.Baz2);
+      console.log(foo.Qux1);
+      console.log(foo.Qux2);
+    `,
+    settings: {
+      'import/extensions': ['.js', '.jsx'],
+    },
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  }),
+
   test({ code: "import * as foo from './common';" }),
 
   // destructuring namespaces


### PR DESCRIPTION
Closes #2572 .

The main issue was that [ExportMap](https://github.com/import-js/eslint-plugin-import/blob/main/src/ExportMap.js) (lines 323-327) did not crawl exports from .jsx files because it did not pass the [file extension check](https://github.com/import-js/eslint-plugin-import/blob/main/utils/ignore.js). As a result, `ExportMap` class was not created for `.jsx` files. And in export cache map, value for `.jsx` files was simply set to null.

`Namespace` in turn, tried to retrieve `ExportMap` class for `.jsx`, but got null and flagged it as error.