### PR TITLE
[Tests] npm 9 defaults `install-links` to `true`, which breaks us

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+install-links=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
   fast_finish: true
 
 before_install:
+  - 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash && . $NVM_DIR/nvm.sh'
   - 'nvm install-latest-npm'
   - 'NPM_CONFIG_LEGACY_PEER_DEPS=true npm install'
   - 'npm run copy-metafiles'


### PR DESCRIPTION
Fixes #2594.