### PR TITLE
[Fix] `no-unused-modules`: `checkPkgFieldObject` filters boolean fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`dynamic-import-chunkname`]: prevent false report on a valid webpack magic comment ([#2330], thanks [@mhmadhamster])
 - [`export`]: do not error on TS export overloads ([#1590], thanks [@ljharb])
 - [`no-unresolved`], [`extensions`]: ignore type only exports ([#2436], thanks [@Lukas-Kullmann])
-- [Fix] `ExportMap`: add missing param to function ([#2589], thanks [@Fdawgs])
+- `ExportMap`: add missing param to function ([#2589], thanks [@Fdawgs])
+- [`no-unused-modules`]: `checkPkgFieldObject` filters boolean fields from checks ([#2598], thanks [@mpint])
 
 ### Changed
 - [Tests] [`named`]: Run all TypeScript test ([#2427], thanks [@ProdigySim])
@@ -1022,6 +1023,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2598]: https://github.com/import-js/eslint-plugin-import/pull/2598
 [#2589]: https://github.com/import-js/eslint-plugin-import/pull/2589
 [#2588]: https://github.com/import-js/eslint-plugin-import/pull/2588
 [#2582]: https://github.com/import-js/eslint-plugin-import/pull/2582
@@ -1697,6 +1699,7 @@ for info on changes for earlier releases.
 [@mgwalker]: https://github.com/mgwalker
 [@mhmadhamster]: https://github.com/MhMadHamster
 [@MikeyBeLike]: https://github.com/MikeyBeLike
+[@mpint]: https://github.com/mpint
 [@mplewis]: https://github.com/mplewis
 [@mrmckeb]: https://github.com/mrmckeb
 [@msvab]: https://github.com/msvab

--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -364,7 +364,10 @@ const fileIsInPkg = file => {
   };
 
   const checkPkgFieldObject = pkgField => {
-    const pkgFieldFiles = values(pkgField).map(value => join(basePath, value));
+    const pkgFieldFiles = values(pkgField)
+      .filter((value) => typeof value !== 'boolean')
+      .map(value => join(basePath, value));
+
     if (includes(pkgFieldFiles, file)) {
       return true;
     }

--- a/tests/files/no-unused-modules/browserObject/package.json
+++ b/tests/files/no-unused-modules/browserObject/package.json
@@ -1,5 +1,6 @@
 {
   "browser": {
-    "browserObject": "./index.js"
+    "browserObject": "./index.js",
+    "an-ignored-module": false
   }
 }

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -367,7 +367,7 @@ describe('ExportMap', function () {
 
         let imports;
         before('load imports', function () {
-          this.timeout(20000);  // takes a long time :shrug:
+          this.timeout(20e3);  // takes a long time :shrug:
           sinon.spy(tsConfigLoader, 'tsConfigLoader');
           imports = ExportMap.get('./typescript.ts', context);
         });
@@ -436,13 +436,13 @@ describe('ExportMap', function () {
         it('should cache after parsing for an ambiguous module', function () {
           const source = './typescript-declare-module.ts';
           const parseSpy = sinon.spy(ExportMap, 'parse');
-      
+
           expect(ExportMap.get(source, context)).to.be.null;
-      
+
           ExportMap.get(source, context);
-      
+
           expect(parseSpy.callCount).to.equal(1);
-      
+
           parseSpy.restore();
         });
       });

--- a/tests/src/core/resolve.js
+++ b/tests/src/core/resolve.js
@@ -401,7 +401,7 @@ describe('resolve', function () {
 
         // special behavior for infinity
         describe('infinite cache', function () {
-          this.timeout(1500);
+          this.timeout(1.5e3);
 
           before((done) => setTimeout(done, 1100));
 
@@ -414,7 +414,7 @@ describe('resolve', function () {
         });
 
         describe('finite cache', function () {
-          this.timeout(1200);
+          this.timeout(1.2e3);
           before((done) => setTimeout(done, 1000));
           it('gets correct values after cache lifetime', function () {
             expect(resolve(original, context)).not.to.exist;

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -243,13 +243,15 @@ ruleTester.run('no-unused-modules', rule, {
 });
 
 
-describe('dynamic imports', () => {
+describe('dynamic imports', function () {
   if (semver.satisfies(eslintPkg.version, '< 6')) {
     beforeEach(function () {
       this.skip();
     });
     return;
   }
+
+  this.timeout(10e3);
 
   // test for unused exports with `import()`
   ruleTester.run('no-unused-modules', rule, {


### PR DESCRIPTION
Fixes the error reported in [this issue](https://github.com/import-js/eslint-plugin-import/issues/1996) where `boolean` fields aren't handled nicely by `path.join`.

According to the `package.json` [browser field spec](https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module), a `false` field denotes an ignored module in the browser.
```
  // package.json

  "browser": {
    "browserObject": "./index.js",
    "an-ignored-module": false
  }
```