### PR TITLE
[New] `prefer-default-export`: add "target" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`order`]: new `alphabetize.orderImportKind` option to sort imports with same path based on their kind (`type`, `typeof`) ([#2544], thanks [@stropho])
 - [`consistent-type-specifier-style`]: add rule ([#2473], thanks [@bradzacher])
 - Add [`no-empty-named-blocks`] rule ([#2568], thanks [@guilhermelimak])
+- [`prefer-default-export`]: add "target" option ([#2602], thanks [@azyzz228])
 
 ### Fixed
 - [`order`]: move nested imports closer to main import entry ([#2396], thanks [@pri1311])
@@ -1025,6 +1026,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#2605]: https://github.com/import-js/eslint-plugin-import/pull/2605
+[#2602]: https://github.com/import-js/eslint-plugin-import/pull/2602
 [#2598]: https://github.com/import-js/eslint-plugin-import/pull/2598
 [#2589]: https://github.com/import-js/eslint-plugin-import/pull/2589
 [#2588]: https://github.com/import-js/eslint-plugin-import/pull/2588

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 | [no-namespace](docs/rules/no-namespace.md)                                       | Forbid namespace (a.k.a. "wildcard" `*`) imports.                          |    |       |    | 🔧 |    |    |
 | [no-unassigned-import](docs/rules/no-unassigned-import.md)                       | Forbid unassigned imports                                                  |    |       |    |    |    |    |
 | [order](docs/rules/order.md)                                                     | Enforce a convention in module import order.                               |    |       |    | 🔧 |    |    |
-| [prefer-default-export](docs/rules/prefer-default-export.md)                     | Prefer a default export if module exports a single name.                   |    |       |    |    |    |    |
+| [prefer-default-export](docs/rules/prefer-default-export.md)                     | Prefer a default export if module exports a single name or multiple names. |    |       |    |    |    |    |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/prefer-default-export.md
+++ b/docs/rules/prefer-default-export.md
@@ -2,9 +2,43 @@
 
 <!-- end auto-generated rule header -->
 
-When there is only a single export from a module, prefer using default export over named export.
+In exporting files, this rule checks if there is default export or not.
 
 ## Rule Details
+
+##### rule schema:
+
+```javascript
+"import/prefer-default-export": [
+    ( "off" | "warn" | "error" ),
+	{ "target": "single" | "any" } // default is "single"
+]
+```
+
+### Config Options
+
+There are two options available: `single` and `any`. By default, if you do not specify the option, rule will assume it is `single`.
+
+#### single
+
+**Definition**: When there is only a single export from a module, prefer using default export over named export.
+
+How to setup config file for this rule:
+
+```javascript
+// you can manually specify it
+"rules": {
+    "import/prefer-default-export": [
+        ( "off" | "warn" | "error" ),
+        { "target": "single" }
+    ]
+}
+
+// config setup below will also work
+"rules": {
+    "import/prefer-default-export": "off" | "warn" | "error"
+}
+```
 
 The following patterns are considered warnings:
 
@@ -57,4 +91,96 @@ export { foo as default }
 
 // Any batch export will disable this rule. The remote module is not inspected.
 export * from './other-module'
+```
+
+#### any
+
+**Definition**: any exporting file must contain a default export.
+
+How to setup config file for this rule:
+
+```javascript
+// you have to manually specify it
+"rules": {
+    "import/prefer-default-export": [
+        ( "off" | "warn" | "error" ),
+        { "target": "any" }
+    ]
+}
+```
+
+
+The following patterns are *not* considered warnings:
+
+```javascript
+// good1.js
+
+//has default export
+export default function bar() {};
+```
+
+```javascript
+// good2.js
+
+// has default export
+let foo;
+export { foo as default }
+```
+
+```javascript
+// good3.js
+
+//contains multiple exports AND default export
+export const a = 5;
+export function bar(){};
+let foo;
+export { foo as default }
+```
+
+```javascript
+// good4.js
+
+// does not contain any exports => file is not checked by the rule
+import * as foo from './foo';﻿
+```
+
+```javascript
+// export-star.js
+
+// Any batch export will disable this rule. The remote module is not inspected.
+export * from './other-module'
+```
+
+The following patterns are considered warnings:
+
+```javascript
+// bad1.js
+
+//has 2 named exports, but no default export
+export const foo = 'foo';
+export const bar = 'bar';
+```
+
+```javascript
+// bad2.js
+
+// does not have default export
+let foo, bar;
+export { foo, bar }
+```
+
+```javascript
+// bad3.js
+
+// does not have default export
+export { a, b } from "foo.js"﻿
+```
+
+```javascript
+// bad4.js
+
+// does not have default export
+let item;
+export const foo = item;
+export { item };
 ```


### PR DESCRIPTION
Solution for #2600.

I have added new option for the `prefer-default-export` that will check any exporting file to have a default export.

###### schema:

```
"import/prefer-default-export": [
 	( "off" | "warn" | "error" ),
	{ "target": "single" | "any" } // default is "single"
]
```
###### Config options

* **single** (current implementation of the rule, I did not change anything here): When there is only a single export from a module, prefer using default export over named export.

All examples from below are from the [rule descriptions](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/prefer-default-export.md).

Considered warnings:

```
// bad.js

// There is only a single module export and it's a named export.
export const foo = 'foo';

```

The following patterns are not warnings:

```
// good1.js

// There is a default export.
export const foo = 'foo';
const bar = 'bar';
export default bar;
```

```
// good2.js

// There is more than one named export in the module.
export const foo = 'foo';
export const bar = 'bar';
```

```
// good3.js

// There is more than one named export in the module
const foo = 'foo';
const bar = 'bar';
export { foo, bar }
```

```
// good4.js

// There is a default export.
const foo = 'foo';
export { foo as default }
```

```
// export-star.js

// Any batch export will disable this rule. The remote module is not inspected.
export * from './other-module'
```

newly added config option:

* **any**: any exporting file must contain default export.

No warnings:

```
//has default export
export default function bar() {};
```

```
// has default export
let foo;
export { foo as default }
```

```
//contains multiple exports AND default export﻿
export const a = 5;
export function bar(){};
let foo;
export { foo as default }`
```

```
// does not contain any exports => file is not checked by the rule
import * as foo from './foo';﻿
```

```
// export-star.js

// Any batch export will disable this rule. The remote module is not inspected.
export * from './other-module'
```

Following are considered as warnings:

```
//has 2 named exports, but no default export
export const foo = 'foo';
export const bar = 'bar';
```

```
// does not have default export
let foo, bar;
export { foo, bar }
```

```
// does not have default export
export { a, b } from "foo.js"﻿
```

```
// does not have default export
let item;
export const foo = item;
export { item };`
```

### Questions

I am not sure how to migrate the test cases below to new option "any". I do not understand what's going on here and what is exported.

```
export const { foo, bar } = item;
```

```
export const { foo, bar: baz } = item;
```

```
export const { foo: { bar, baz } } = item;
```

```
export const [a, b] = item;
```

I will update docs after your review.



