### PR TITLE
Update eslint-doc-generator to v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [Tests] [`no-restricted-paths`]: fix one failing `import type` test case, submitted by [@golergka], thanks [@azyzz228]
 - [Docs] automate docs with eslint-doc-generator ([#2582], thanks [@bmish])
 - [readme] Increase clarity around typescript configuration ([#2588], thanks [@Nfinished])
+- [Docs] update `eslint-doc-generator` to v1.0.0 ([#2605], thanks [@bmish])
 
 ## [2.26.0] - 2022-04-05
 
@@ -1023,6 +1024,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2605]: https://github.com/import-js/eslint-plugin-import/pull/2605
 [#2598]: https://github.com/import-js/eslint-plugin-import/pull/2598
 [#2589]: https://github.com/import-js/eslint-plugin-import/pull/2589
 [#2588]: https://github.com/import-js/eslint-plugin-import/pull/2588

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "prepublishOnly": "safe-publish-latest && npm run build",
     "prepublish": "not-in-publish || npm run prepublishOnly",
     "preupdate:eslint-docs": "npm run build",
-    "update:eslint-docs": "eslint-doc-generator --rule-doc-title-format prefix-name --rule-doc-section-options false --split-by meta.docs.category --ignore-config stage-0 --config-emoji recommended,☑️"
+    "update:eslint-docs": "eslint-doc-generator --rule-doc-title-format prefix-name --rule-doc-section-options false --rule-list-split meta.docs.category --ignore-config stage-0 --config-emoji recommended,☑️"
   },
   "repository": {
     "type": "git",
@@ -73,7 +73,7 @@
     "cross-env": "^4.0.0",
     "escope": "^3.6.0",
     "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8",
-    "eslint-doc-generator": "^0.19.0",
+    "eslint-doc-generator": "^1.0.0",
     "eslint-import-resolver-node": "file:./resolvers/node",
     "eslint-import-resolver-typescript": "^1.0.2 || ^1.1.1",
     "eslint-import-resolver-webpack": "file:./resolvers/webpack",


### PR DESCRIPTION
First stable [v1.0.0](https://github.com/bmish/eslint-doc-generator/releases/tag/v1.0.0) release of [eslint-doc-generator](https://github.com/bmish/eslint-doc-generator).

Originally added in:
* https://github.com/import-js/eslint-plugin-import/pull/2582

The only change is that one CLI option was renamed.