### PR TITLE
Perf: Optimize ignoreModule calls in no-cycle

### DIFF
--- a/src/rules/no-cycle.js
+++ b/src/rules/no-cycle.js
@@ -81,7 +81,7 @@ module.exports = {
       let path = resolvedPaths[name];
       if (path === undefined) {
         path = resolve(name, context);
-        resolvedPaths[name]= path;
+        resolvedPaths[name] = path;
       }
 
       let isExternal = externalModules[path];


### PR DESCRIPTION
Hello 👋 - Thanks for taking the time to review this PR

### Summary

This PR adds a few performance optimizations to the `no-cycle` rule to make calls to `ignoreModule` faster.

### Details

_Lots of details because digging into this was really interesting_

I was recently profiling our ESLint suite and the `no-cycle` rule was responsible for 79% of the total lint time. I found #2348 and attempted to speed up the rule by opting _IN_ to the `ignoreExternal` option for the rule, but surprisingly that *increased* our total lint time from ~5min to ~9min which seemed odd 🤔 

This comment had a very helpful hint that lead to the issue: https://github.com/import-js/eslint-plugin-import/issues/2076#issuecomment-931802708

When the `ignoreExternal` option is enabled the `ignoreModule` will call `resolve` for each module to determine if it's an external module. I added some counters and found that our repo, which has ~2,000 modules, ended up calling this check ~215,000 times (that number wasn't surprising since each file does a breadth first search of the file's entire dependency tree) so attempting to ignore external modules can actually add a lot of work calling `resolve`

### Optimization

This update optimizes this codepath by adding:

1. A new early return check for relative path imports
2. A simple object cache of evaluated modules to short circuit subsequent evaluations

#### Results

For our medium sized codebase this update:

1. Reduced total lint time from ~5min to ~2min 15s when we opted in to `ignoreExternal`
2. Reduced relative time spent in no-cycle from ~80% to ~42% 

_Note for these comparisons I disabled all the other rules that use `ExportMap` to try and ensure rule order and building the export map wasn't variable._





