### PR TITLE
New typescript flow rule

### DIFF
--- a/docs/rules/typescript-flow.md
+++ b/docs/rules/typescript-flow.md
@@ -1,0 +1,24 @@
+This rules helps to define type import patterns for the typescript.
+
+## Rule details
+
+##### rule schema:
+
+```javascript
+"import/prefer-default-export": [
+    ( "off" | "warn" | "error" ),
+	{ "prefer": "none" | "separate" | "modifier" } // default is ???
+]
+```
+### Config Options
+
+There are three avaiable options: `none`, `separate`, `modifier`.
+
+```javascript
+// import-stars.js
+
+// The remote module is not inspected.
+import * from './other-module'
+import * as b from './other-module'
+
+```

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "posttest": "eslint . && npm run update:eslint-docs -- --check",
     "mocha": "cross-env BABEL_ENV=test nyc mocha",
     "tests-only": "npm run mocha tests/src",
+    "debug": "DEBUG=eslint-plugin-import/typescript-flow npm run mocha tests/src/rules/typescript-flow",
     "test": "npm run tests-only",
     "test-compiled": "npm run prepublish && BABEL_ENV=testCompiled mocha --compilers js:babel-register tests/src",
     "test-all": "node --require babel-register ./scripts/testAll",

--- a/src/ExportMap.js
+++ b/src/ExportMap.js
@@ -623,6 +623,9 @@ ExportMap.parse = function (path, content, context) {
       // capture declaration
       if (n.declaration != null) {
         switch (n.declaration.type) {
+        case 'TSTypeAliasDeclaration':
+          m.namespace.set(n.declaration.id.name, 'type');
+          break;
         case 'FunctionDeclaration':
         case 'ClassDeclaration':
         case 'TypeAlias': // flowtype with babel-eslint parser
@@ -630,7 +633,6 @@ ExportMap.parse = function (path, content, context) {
         case 'DeclareFunction':
         case 'TSDeclareFunction':
         case 'TSEnumDeclaration':
-        case 'TSTypeAliasDeclaration':
         case 'TSInterfaceDeclaration':
         case 'TSAbstractClassDeclaration':
         case 'TSModuleDeclaration':

--- a/src/rules/typescript-flow.js
+++ b/src/rules/typescript-flow.js
@@ -1,0 +1,53 @@
+'use strict';
+
+import debug from 'debug';
+import docsUrl from '../docsUrl';
+
+const log = debug('eslint-plugin-import/typescript-flow');
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      category: 'Style guide',
+      description: 'Prefer a default export if module exports a single name or multiple names.',
+      url: docsUrl('prefer-default-export'),
+    },
+    schema: [{
+      type: 'object',
+      properties:{
+        target: {
+          type: 'string',
+          enum: ['single', 'any'],
+          default: 'single',
+        },
+      },
+      additionalProperties: false,
+    }],
+  },
+
+  create(context) {
+    // if TS is < 3.8 => we can just name import it. 
+ 
+    // works from typescript > 3.8
+    // import type { Person, Cache } from "./foo"  // ImportDeclaration importKind = 'type', ImportSpecifier.importKind = 'value'
+
+    // works only on typescript >4.5
+    // import { type Person, Cache } from "./foo"; // ImportDeclaration importKind = 'value', ImportSpecifier.importKind = 'type'
+
+    log('parser');
+    console.log(context.parserPath);
+
+    return {
+      'ImportDeclaration': function (node) {
+        // check the options flow
+        if (node.importKind === 'type') {
+          log('IF');
+          console.log(node);
+        } else {
+          context.report(node, 'BOOM');
+        }
+      },
+    };
+  },
+};

--- a/src/rules/typescript-flow.js
+++ b/src/rules/typescript-flow.js
@@ -1,10 +1,29 @@
 'use strict';
 
-import debug from 'debug';
 import docsUrl from '../docsUrl';
 
+import debug from 'debug';
 const log = debug('eslint-plugin-import/typescript-flow');
 
+// comes from tests/src/utils file, TODO?: import directly from there
+import typescriptPkg from 'typescript/package.json';
+import semver from 'semver';
+
+function tsVersionSatisfies(specifier) {
+  return semver.satisfies(typescriptPkg.version, specifier);
+}
+
+// It seems unfortunate to have a rule that is only useful for typescript, but perhaps a rule that detects your TS (or flow) version, 
+// and can be configured for an order of preferences - ie, between "types as separate import statements", 
+// "types mixed with values, but marked with a type modifier", you could prefer one over the other, 
+// and it would fall back to the next one if the preferred one wasn't supported, and if neither are supported, the rule would noop.
+
+// 3 options of prefering importing types: none, separate, modifier. 
+// none => no use of word 'type' preferred. 
+// separate: types as separate import statements
+// modifier: types mixed with values, but marked with a type modifier
+
+// To think about: if separate is preferred but none is used => need to check every import file. maybe exclude the none?
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -16,10 +35,10 @@ module.exports = {
     schema: [{
       type: 'object',
       properties:{
-        target: {
+        prefer: {
           type: 'string',
-          enum: ['single', 'any'],
-          default: 'single',
+          enum: ['none', 'separate', 'modifier'],
+          default: 'modifier',
         },
       },
       additionalProperties: false,
@@ -29,22 +48,30 @@ module.exports = {
   create(context) {
     // if TS is < 3.8 => we can just name import it. 
  
-    // works from typescript > 3.8
-    // import type { Person, Cache } from "./foo"  // ImportDeclaration importKind = 'type', ImportSpecifier.importKind = 'value'
+    // works from typescript >= 3.8
+    // import type { Person, Cache } from "./foo"  
+    // ImportDeclaration importKind = 'type', ImportSpecifier.importKind = 'value'
 
-    // works only on typescript >4.5
-    // import { type Person, Cache } from "./foo"; // ImportDeclaration importKind = 'value', ImportSpecifier.importKind = 'type'
+    // works only on typescript >= 4.5
+    // import { type Person, Cache } from "./foo"; 
+    // ImportDeclaration importKind = 'value', ImportSpecifier.importKind = 'type'
 
-    log('parser');
-    console.log(context.parserPath);
+    // get Rule options. Default: separate
+    const { prefer = 'separate' } =  context.options[0] || {};
+
+    const supportsTypeImport = tsVersionSatisfies('>=3.8'); // separate `import type { a } from 'x'` was introduced in TS 3.8
+    const supportsTypeModifier = tsVersionSatisfies('>=4.5'); // type modifiers were introduced in TS 4.5. 
 
     return {
       'ImportDeclaration': function (node) {
-        // check the options flow
-        if (node.importKind === 'type') {
-          log('IF');
-          console.log(node);
-        } else {
+        // case where we want type modifier but we got separate import type
+        if (supportsTypeModifier && prefer === 'modifier' && node.importKind === 'type') {
+          context.report(node, 'BOOM');
+        }
+      },
+      'ImportSpecifier': function (node) {
+        // we want separate import, but have type modifier
+        if (supportsTypeImport && prefer === 'separate' && node.importKind === 'type') {
           context.report(node, 'BOOM');
         }
       },

--- a/src/rules/typescript-flow.js
+++ b/src/rules/typescript-flow.js
@@ -84,9 +84,6 @@ module.exports = {
     if (config.length === 2 && config[0] === 'inline' && !supportInlineTypeImport) {
       config = 'separate';
     }
-    if (config === 'inline' && !supportInlineTypeImport) {
-      // raise error
-    }
     if (config[0] === 'separate') {
       config = 'separate';
     }
@@ -101,6 +98,11 @@ module.exports = {
 
     return {
       'ImportDeclaration': function (node){
+
+        if (config === 'inline' && !supportInlineTypeImport) {
+          // raise error
+          context.report(node, 'Type modifiers are not supported by your version of TS.');
+        }
 
         if (config === 'separate' && node.importKind !== 'type') {
           // identify importSpecifiers that have inline type imports as well as value imports

--- a/src/rules/typescript-flow.js
+++ b/src/rules/typescript-flow.js
@@ -5,7 +5,7 @@ import docsUrl from '../docsUrl';
 import debug from 'debug';
 const log = debug('eslint-plugin-import/typescript-flow');
 
-// comes from tests/src/utils file, TODO?: import directly from there
+// comes from tests/src/utils file, TODO?: import directly from there, issue: too many layers of folders away
 import typescriptPkg from 'typescript/package.json';
 import semver from 'semver';
 
@@ -43,16 +43,7 @@ function processBodyStatement(importMap, node){
   importMap.set(node.source.value, { specifiers, hasDefaultImport, hasInlineDefaultImport, hasNamespaceImport });
 }
 
-// It seems unfortunate to have a rule that is only useful for typescript, but perhaps a rule that detects your TS (or flow) version, 
-// and can be configured for an order of preferences - ie, between "types as separate import statements", 
-// "types mixed with values, but marked with a type modifier", you could prefer one over the other, 
-// and it would fall back to the next one if the preferred one wasn't supported, and if neither are supported, the rule would noop.
-
-// 3 options of prefering importing types: none, separate, modifier. 
-// none => no use of word 'type' preferred. 
-// separate: types as separate import statements
-// modifier: types mixed with values, but marked with a type modifier
-
+// TODO: revert changes in ExportMap file. 
 module.exports = {
   meta: {
     type: 'suggestion', // Layout?
@@ -70,7 +61,7 @@ module.exports = {
             'type': 'string',
             'enum': ['separate', 'inline'],
           },
-          'minItems': 1,
+          'minItems': 2,
           'maxItems': 2,
           'uniqueItems': true,
         },
@@ -81,20 +72,11 @@ module.exports = {
       ],
     }],
   },
-  create(context) {
-    // if TS is < 3.8 => we can just name import it. 
- 
-    // works from typescript >= 3.8
-    // import type { Person, Cache } from "./foo"  
-    // ImportDeclaration importKind = 'type', ImportSpecifier.importKind = 'value'
-
-    // works only on typescript >= 4.5
-    // import { type Person, Cache } from "./foo"; 
-    // ImportDeclaration importKind = 'value', ImportSpecifier.importKind = 'type'
+  create(context) { 
 
     // 3 cases: strict cases: separate, inline. 3rd case is array of preference. The only thing to check is if arr[0] === inline => 
     // check if it can be supported. If not, fall back on separate. 
-    // If arr[0] === separate => just do separate ? Then what is really a logic? Taking care of user worrying about TS version?
+    // If arr[0] === separate => just assume it is separate
 
     const supportInlineTypeImport = tsVersionSatisfies('>=4.5'); // type modifiers (inline type import) were introduced in TS 4.5. 
     // get Rule options.
@@ -270,11 +252,7 @@ module.exports = {
               },
             });
           }
-          
-
-
         }
-        
       },
     };
   },

--- a/src/rules/typescript-flow.js
+++ b/src/rules/typescript-flow.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import docsUrl from '../docsUrl';
+import Exports from '../ExportMap';
 
 import debug from 'debug';
 const log = debug('eslint-plugin-import/typescript-flow');
@@ -11,6 +12,55 @@ import semver from 'semver';
 
 function tsVersionSatisfies(specifier) {
   return semver.satisfies(typescriptPkg.version, specifier);
+}
+// no need to have separate function, or doing it before the program start running => need to incorporate inside of the function
+function processBodyStatement(context, typeExports, node) {
+  if (node.type !== 'ImportDeclaration') return;
+  
+  if (node.specifiers.length === 0) return;
+  
+  const imports = Exports.get(node.source.value, context);
+  // log('imports');
+  // console.log(imports.namespace);
+  if (imports == null) return null;
+  
+  if (imports.errors.length > 0) {
+    imports.reportErrors(context, node);
+    return;
+  }
+
+  imports.namespace.forEach((value, key) =>{
+    if (value === 'type') {
+      typeExports.add(key);
+    }
+  });
+  
+  
+
+
+  // node.specifiers.forEach((specifier) => {
+  //   switch (specifier.type) {
+  //   case 'ImportNamespaceSpecifier':
+  //     if (!imports.size) {
+  //       context.report(
+  //         specifier,
+  //         `No exported names found in module '${node.source.value}'.`,
+  //       );
+  //     }
+  //     namespaces.set(specifier.local.name, imports);
+  //     break;
+  //   case 'ImportDefaultSpecifier':
+  //   case 'ImportSpecifier': {
+  //     const meta = imports.get(
+  //       // default to 'default' for default https://i.imgur.com/nj6qAWy.jpg
+  //       specifier.imported ? (specifier.imported.name || specifier.imported.value) : 'default',
+  //     );
+  //     if (!meta || !meta.namespace) { break; }
+  //     namespaces.set(specifier.local.name, meta.namespace);
+  //     break;
+  //   }
+  //   }
+  // });
 }
 
 // It seems unfortunate to have a rule that is only useful for typescript, but perhaps a rule that detects your TS (or flow) version, 
@@ -24,26 +74,41 @@ function tsVersionSatisfies(specifier) {
 // modifier: types mixed with values, but marked with a type modifier
 
 // To think about: if separate is preferred but none is used => need to check every import file. maybe exclude the none?
+// Scenario: user imports exported types without explicitly saying type: TODO: check every import file if it's a type export -> use ExportMaps
+// What is import namespaces => omit?
+
 module.exports = {
   meta: {
-    type: 'suggestion',
+    type: 'suggestion', // Layout?
     docs: {
       category: 'Style guide',
-      description: 'Prefer a default export if module exports a single name or multiple names.',
-      url: docsUrl('prefer-default-export'),
+      description: 'Prefer a default export if module exports a single name or multiple names.', // TODO: change
+      url: docsUrl('prefer-default-export'), // TODO: change
     },
+    fixable: 'code',
     schema: [{
-      type: 'object',
-      properties:{
-        prefer: {
-          type: 'string',
-          enum: ['none', 'separate', 'modifier'],
-          default: 'modifier',
+      'anyOf': [
+        {
+          'type': 'array',
+          'items': {
+            'type': 'string',
+            'enum': ['none', 'separate', 'inline'],
+          },
+          'minItems': 1,
+          'maxItems': 3,
+          'uniqueItems': true,
         },
-      },
-      additionalProperties: false,
+        {
+          'type': 'string',
+          'enum': ['none', 'separate', 'inline'],
+        },
+      ],
     }],
   },
+
+
+  
+  
 
   create(context) {
     // if TS is < 3.8 => we can just name import it. 
@@ -56,24 +121,129 @@ module.exports = {
     // import { type Person, Cache } from "./foo"; 
     // ImportDeclaration importKind = 'value', ImportSpecifier.importKind = 'type'
 
-    // get Rule options. Default: separate
-    const { prefer = 'separate' } =  context.options[0] || {};
+    // get Rule options.
+    const config = context.options[0];
+    
+    // check the config
+    const configSingle = typeof(context.options[0]) === 'string' ? true : false;
 
+    const prefer = 'separate';
+
+    // allow single value or array of values. When list of available values not possible => message: unfixable problem. When there is multiple problems, finds first value in the list and makes it happen.
     const supportsTypeImport = tsVersionSatisfies('>=3.8'); // separate `import type { a } from 'x'` was introduced in TS 3.8
     const supportsTypeModifier = tsVersionSatisfies('>=4.5'); // type modifiers were introduced in TS 4.5. 
+    // TODO: check the array on TS version to leave possible options 
+    // If ! supportsTypeModifier => remove type modifier from the array
+    // if ! supportsTypeImport => check if options array has 'none', if not => flag an error
 
+    // useful if we can just remove as.
+    const typeExports = new Set();
+
+    // TODO: filter down available preferences: find the first one available then use it as preferred. If none is option: find all type key words and auto fixer => remove them.
+    // return 3 rule objets?
     return {
+      // pick up all type imports at body entry time, to properly respect hoisting
+      Program({ body }) {
+        body.forEach(x => processBodyStatement(context, typeExports, x));
+      },
       'ImportDeclaration': function (node) {
+
+        if (typeof(context.options[0]) === 'string' || config.length === 1) {
+          // only one config
+          
+          // we have none, but have word type
+          if (config === 'none' && node.importKind === 'type') {
+            log('inside of if');
+            context.report({
+              node,
+              message: 'BOOM',
+              fix(fixer) {
+                const sourceCode = context.getSourceCode();
+                // log('tokens -> need to find the one we need');
+                const token = sourceCode.getTokens(node)[1];
+                return fixer.replaceTextRange([token.range[0], token.range[1]+1], '');
+              },
+            });
+            // log('fixed node');
+            // console.log(node);: after fix, importKind for ImportDeclaration is still "type"
+
+          }
+
+          // Question: maybe we do not need to check the condition below because typescript checks for us?
+        } else if ((config === 'separate' || config[0] === 'separate') && node.importKind === 'type' && !supportsTypeImport) {
+          context.report({
+            node,
+            message: 'BOOM', // You version of Typescript does not support import type statements
+            fix(fixer) {
+              const sourceCode = context.getSourceCode();
+              // log('tokens -> need to find the one we need');
+              const token = sourceCode.getTokens(node)[1];
+              return fixer.replaceTextRange([token.range[0], token.range[1]+1], '');
+            },
+          });
+
+          // Question TODO: If user wants inline, but we have separate, then which named imports should be autofixed to have 'type' next to them:
+          // only exported types or also exported interaces ?
+
+        }
+
         // case where we want type modifier but we got separate import type
         if (supportsTypeModifier && prefer === 'modifier' && node.importKind === 'type') {
           context.report(node, 'BOOM');
         }
+        
+        // create a map for all imports?
       },
       'ImportSpecifier': function (node) {
-        // we want separate import, but have type modifier
-        if (supportsTypeImport && prefer === 'separate' && node.importKind === 'type') {
-          context.report(node, 'BOOM');
+
+        // cases when we have only one config option
+        if (typeof(context.options[0]) === 'string' || config.length === 1) {
+          // only one config
+          
+          // we have none, but have word type
+          if ((config === 'none' || config[0] === 'none') && node.importKind === 'type') {
+            context.report({
+              node,
+              message: 'BOOM',
+              fix(fixer) {
+                const sourceCode = context.getSourceCode();
+                const token = sourceCode.getTokens(node)[0];
+                // log('source code tokens');
+                // console.log(sourceCode.getTokens(node));
+                return fixer.replaceTextRange([token.range[0], token.range[1]+1], '');
+              },
+            });
+          }
+
+          // wanted separate but got inline case. Question: How to make two fixes?
+          if ((config === 'separate' || config[0] === 'separate') && node.importKind === 'type') {
+            context.report({
+              node,
+              message: 'BOOM',
+              fix(fixer) {
+                const sourceCode = context.getSourceCode();
+                const token = sourceCode.getTokens(node);
+                log('source code tokens');
+                console.log(token);
+
+                const tokenParent = sourceCode.getTokens(node.parent);
+                log('source code tokens -- PARENT');
+                console.log(tokenParent);
+                return fixer.replaceTextRange([token.range[0], token.range[1]+1], '') ;
+              },
+            });
+          }
+
         }
+
+        // we want separate import, but have type modifier
+        // if (supportsTypeImport && prefer === 'separate' && node.importKind === 'type') {
+        //   context.report(node, 'BOOM');
+        // }
+
+        // if none => remove all type key words ?
+
+        // TODO: import Cache from "./foo";  import Default Specifier type?
       },
     };
   },

--- a/src/rules/typescript-flow.js
+++ b/src/rules/typescript-flow.js
@@ -92,15 +92,15 @@ module.exports = {
           'type': 'array',
           'items': {
             'type': 'string',
-            'enum': ['none', 'separate', 'inline'],
+            'enum': ['separate', 'inline'],
           },
           'minItems': 1,
-          'maxItems': 3,
+          'maxItems': 2,
           'uniqueItems': true,
         },
         {
           'type': 'string',
-          'enum': ['none', 'separate', 'inline'],
+          'enum': ['separate', 'inline'],
         },
       ],
     }],
@@ -151,23 +151,6 @@ module.exports = {
         if (typeof(context.options[0]) === 'string' || config.length === 1) {
           // only one config
           
-          // we have none, but have word type
-          if (config === 'none' && node.importKind === 'type') {
-            log('inside of if');
-            context.report({
-              node,
-              message: 'BOOM',
-              fix(fixer) {
-                const sourceCode = context.getSourceCode();
-                // log('tokens -> need to find the one we need');
-                const token = sourceCode.getTokens(node)[1];
-                return fixer.replaceTextRange([token.range[0], token.range[1]+1], '');
-              },
-            });
-            // log('fixed node');
-            // console.log(node);: after fix, importKind for ImportDeclaration is still "type"
-
-          }
 
           // Question: maybe we do not need to check the condition below because typescript checks for us?
         } else if ((config === 'separate' || config[0] === 'separate') && node.importKind === 'type' && !supportsTypeImport) {
@@ -187,6 +170,10 @@ module.exports = {
 
         }
 
+        // Question TODO: iterate over all import specifiers and get a list of all inline type imports
+        // If option is separate, but we got none as input, how do we determine which named imports get to the new line?
+        // how to we deal when we have two fixers?
+
         // case where we want type modifier but we got separate import type
         if (supportsTypeModifier && prefer === 'modifier' && node.importKind === 'type') {
           context.report(node, 'BOOM');
@@ -201,19 +188,6 @@ module.exports = {
           // only one config
           
           // we have none, but have word type
-          if ((config === 'none' || config[0] === 'none') && node.importKind === 'type') {
-            context.report({
-              node,
-              message: 'BOOM',
-              fix(fixer) {
-                const sourceCode = context.getSourceCode();
-                const token = sourceCode.getTokens(node)[0];
-                // log('source code tokens');
-                // console.log(sourceCode.getTokens(node));
-                return fixer.replaceTextRange([token.range[0], token.range[1]+1], '');
-              },
-            });
-          }
 
           // wanted separate but got inline case. Question: How to make two fixes?
           if ((config === 'separate' || config[0] === 'separate') && node.importKind === 'type') {
@@ -235,11 +209,6 @@ module.exports = {
           }
 
         }
-
-        // we want separate import, but have type modifier
-        // if (supportsTypeImport && prefer === 'separate' && node.importKind === 'type') {
-        //   context.report(node, 'BOOM');
-        // }
 
         // if none => remove all type key words ?
 

--- a/src/rules/typescript-flow.js
+++ b/src/rules/typescript-flow.js
@@ -203,10 +203,12 @@ module.exports = {
           
           // function process body statement to find if there are any non-type imports from the same location
           node.parent.body.forEach(declaration => processBodyStatement(nonTypeImportDeclarations, declaration));
+          
+          // file has non type import from the same source
+          const declaration = nonTypeImportDeclarations.get(node.source.value);
 
-          if (nonTypeImportDeclarations.has(node.source.value)) {
-            // file has non type import from the same source
-            const declaration = nonTypeImportDeclarations.get(node.source.value);
+          if (declaration && !declaration.hasNamespaceImport) {
+
             // get the last specifier
             const  lastSpecifier = declaration.specifiers[declaration.specifiers.length - 1];
 

--- a/src/rules/typescript-flow.js
+++ b/src/rules/typescript-flow.js
@@ -13,6 +13,36 @@ function tsVersionSatisfies(specifier) {
   return semver.satisfies(typescriptPkg.version, specifier);
 }
 
+function processBodyStatement(importMap, node){
+  if (node.type !== 'ImportDeclaration' || node.importKind === 'type') return;
+  if (node.specifiers.length === 0) return;
+
+  const specifiers = [];
+  let hasDefaultImport= false;
+  let hasInlineDefaultImport = false;
+  let hasNamespaceImport =  false;
+  
+  node.specifiers.forEach((specifier)=>{
+    if (specifier.type === 'ImportNamespaceSpecifier') {
+      hasNamespaceImport = true;
+    }
+    // ignore the case for now. TODO: talk with Jordan and implement the handling of the rule here
+    if (specifier.type === 'ImportDefaultSpecifier') {
+      hasDefaultImport = true;
+      specifiers.push(specifier);
+    }
+    if (specifier.type === 'ImportSpecifier') {
+      // check if its {default as B}
+      if (specifier.imported.name === 'default') {
+        hasInlineDefaultImport = true;
+      }
+      specifiers.push(specifier);
+    }
+  });
+  // cache all imports
+  importMap.set(node.source.value, { specifiers, hasDefaultImport, hasInlineDefaultImport, hasNamespaceImport });
+}
+
 // It seems unfortunate to have a rule that is only useful for typescript, but perhaps a rule that detects your TS (or flow) version, 
 // and can be configured for an order of preferences - ie, between "types as separate import statements", 
 // "types mixed with values, but marked with a type modifier", you could prefer one over the other, 
@@ -22,10 +52,6 @@ function tsVersionSatisfies(specifier) {
 // none => no use of word 'type' preferred. 
 // separate: types as separate import statements
 // modifier: types mixed with values, but marked with a type modifier
-
-// To think about: if separate is preferred but none is used => need to check every import file. maybe exclude the none?
-// Scenario: user imports exported types without explicitly saying type: TODO: check every import file if it's a type export -> use ExportMaps
-// What is import namespaces => omit?
 
 module.exports = {
   meta: {
@@ -70,13 +96,13 @@ module.exports = {
     // check if it can be supported. If not, fall back on separate. 
     // If arr[0] === separate => just do separate ? Then what is really a logic? Taking care of user worrying about TS version?
 
-    const supportInlineTypeImport = tsVersionSatisfies('>=4.5'); // type modifiers were introduced in TS 4.5. 
+    const supportInlineTypeImport = tsVersionSatisfies('>=4.5'); // type modifiers (inline type import) were introduced in TS 4.5. 
     // get Rule options.
     let config = context.options[0];
     if (config.length === 2 && config[0] === 'inline' && !supportInlineTypeImport) {
       config = 'separate';
     }
-    if (config[0]==='separate') {
+    if (config[0] === 'separate') {
       config = 'separate';
     }
 
@@ -84,46 +110,46 @@ module.exports = {
     const typeImports = [];
     const valueImports =[];
     const valueNodeImports =[];
-    const importRangesToBeRemoved = [];
+    const importSpecifierRanges = [];
     let allImportsSize = 0;
+    const nonTypeImportDeclarations = new Map();
 
     return {
-
       'ImportDeclaration': function (node){
-        
-        // identify importSpecifiers that have inline type imports as well as value imports
-        node.specifiers.forEach((specifier) => {
-          // Question: do we want our rule to deal with default imports? It does not make sense that rule needs to since we do not know the type of default export.
-          // For now, ignore default export
-          if (specifier.type === 'ImportNamespaceSpecifier' || specifier.type === 'ImportDefaultSpecifier') {
-            return;
-          }
-          allImportsSize += 1;
-          // catch all inline imports and add them to the set
-          if (specifier.importKind === 'type') {
-            if (specifier.local.name !== specifier.imported.name) {
-              typeImports.push(`${specifier.imported.name} as ${specifier.local.name}`);
-            } else {
-              typeImports.push(specifier.local.name);
-            }
-            importRangesToBeRemoved.push(specifier.range);
-          } else {
-            valueNodeImports.push(specifier);
-            if (specifier.local.name !== specifier.imported.name) {
-              valueImports.push(`${specifier.imported.name} as ${specifier.local.name}`);
-            } else {
-              valueImports.push(specifier.local.name);
-            }
-            importRangesToBeRemoved.push(specifier.range);
-          }
-        });
 
         if (config === 'separate' && node.importKind !== 'type') {
+          // identify importSpecifiers that have inline type imports as well as value imports
+          node.specifiers.forEach((specifier) => {
+            if (specifier.type === 'ImportNamespaceSpecifier' || specifier.type === 'ImportDefaultSpecifier') {
+              return;
+            }
+            // Question: do we want our rule to deal with default imports? It does not make sense that rule needs to since we do not know the type of default export.
+            allImportsSize = allImportsSize + 1;
+            // catch all inline imports and add them to the set
+            if (specifier.importKind === 'type') {
+              if (specifier.local.name !== specifier.imported.name) {
+                typeImports.push(`${specifier.imported.name} as ${specifier.local.name}`);
+              } else {
+                typeImports.push(specifier.local.name);
+              }
+              importSpecifierRanges.push(specifier.range);
+            } else {
+              valueNodeImports.push(specifier);
+              if (specifier.local.name !== specifier.imported.name) {
+                valueImports.push(`${specifier.imported.name} as ${specifier.local.name}`);
+              } else {
+                valueImports.push(specifier.local.name);
+              }
+              importSpecifierRanges.push(specifier.range);
+            }
+          });
           // no inline type imports found
           if (typeImports.length === 0) {
             return;
-          } else if (typeImports.length === allImportsSize) {
-            // all inline imports are type imports => need to change it to separate import statement
+          }
+          // all inline imports are type imports => need to change it to separate import statement
+          // import {type X, type Y} form 'x' => import type { X, Y} from 'x'
+          if (typeImports.length === allImportsSize) {
             context.report({
               node,
               message: 'BOOM',
@@ -140,6 +166,9 @@ module.exports = {
               },
             });
           }
+          
+          // there is a mix of inline value imports and type imports
+          // import {type X, type Y, Z} form 'x' => import {Z} form 'x'\nimport type { X, Y } from 'x'
           else {
             context.report({
               node,
@@ -150,7 +179,7 @@ module.exports = {
                 const importPath = tokens[tokens.length-1].value;
   
                 // remove all imports
-                importRangesToBeRemoved.forEach((range)=>{
+                importSpecifierRanges.forEach((range)=>{
                   fixerArray.push(fixer.removeRange([range[0], range[1]]));
                 });
 
@@ -175,30 +204,74 @@ module.exports = {
         }
 
         if (config === 'inline' && node.importKind === 'type') {
-          // check if there are other imports from the same source, if there are, them add type imports there
-
-          // if there are none => remove type and add "type" to every import
-          // import type {a,b} from 'x' => import {type a, type b} from 'x'
-          log('want inline but got separate type import');
-          context.report({
-            node,
-            message: 'BOOM',
-            fix(fixer) {
-              const sourceCode = context.getSourceCode();
-              const tokens = sourceCode.getTokens(node);
-              log('tokens');
-              console.log(tokens);
-              fixerArray.push(fixer.remove(tokens[1]));
-
-              log('value imports');
-              console.log(valueNodeImports);
-
-              valueNodeImports.forEach(element => {
-                fixerArray.push(fixer.insertTextBefore(element, 'type '));
-              });
-              return fixerArray;
-            },
+          
+          node.specifiers.forEach((specifier) => {
+            if (specifier.local.name !== specifier.imported.name) {
+              typeImports.push(`type ${specifier.imported.name} as ${specifier.local.name}`);
+            } else {
+              typeImports.push(`type ${specifier.local.name}`);
+            }
+            valueNodeImports.push(specifier);
           });
+          
+          // function process body statement to find if there are any non-type imports from the same location
+          node.parent.body.forEach(declaration => processBodyStatement(nonTypeImportDeclarations, declaration));
+
+          if (nonTypeImportDeclarations.has(node.source.value)) {
+            // file has non type import from the same source
+            const declaration = nonTypeImportDeclarations.get(node.source.value);
+            // get the last specifier
+            const  lastSpecifier = declaration.specifiers[declaration.specifiers.length - 1];
+
+            // try to insert after the last specifier
+            context.report({
+              node,
+              message: 'BOOM',
+              fix(fixer) {
+
+                if (lastSpecifier.type === 'ImportDefaultSpecifier' && declaration.specifiers.length === 1) {
+                  // import defaultExport from 'x'
+                  // import type { X, Y } from 'x'
+                  // => import defaultExport, { type X, type Y } from 'x'
+                  const inlineTypeImportsToInsert = ', { ' + typeImports.join(', ') + ' }';
+                  fixerArray.push(fixer.insertTextAfter(lastSpecifier, inlineTypeImportsToInsert));
+                } else {
+                  // import { namedImport } from 'x'
+                  // import type { X, Y } from 'x'
+                  // => import { namedImport, type X, type Y } from 'x'
+                  const inlineTypeImportsToInsert = ', ' + typeImports.join(', ');
+                  fixerArray.push(fixer.insertTextAfter(lastSpecifier, inlineTypeImportsToInsert));
+                }
+
+                fixerArray.push(fixer.remove(node));
+                return fixerArray;
+              },
+            });
+          } else {
+          // There are no other imports from the same location => remove 'type' next to import statement and add "type" to every named import
+          // import type {a,b} from 'x' => import {type a, type b} from 'x'
+
+            // TODO: check this statement: valueNodeImports => possibly rename it ?
+            context.report({
+              node,
+              message: 'BOOM',
+              fix(fixer) {
+                const sourceCode = context.getSourceCode();
+                const tokens = sourceCode.getTokens(node);
+                // log('tokens');
+                // console.log(tokens);
+                fixerArray.push(fixer.remove(tokens[1]));
+                // log('value imports');
+                // console.log(valueNodeImports);
+                valueNodeImports.forEach(element => {
+                  fixerArray.push(fixer.insertTextBefore(element, 'type '));
+                });
+                return fixerArray;
+              },
+            });
+          }
+          
+
 
         }
         

--- a/src/rules/typescript-flow.js
+++ b/src/rules/typescript-flow.js
@@ -84,6 +84,9 @@ module.exports = {
     if (config.length === 2 && config[0] === 'inline' && !supportInlineTypeImport) {
       config = 'separate';
     }
+    if (config === 'inline' && !supportInlineTypeImport) {
+      // raise error
+    }
     if (config[0] === 'separate') {
       config = 'separate';
     }

--- a/tests/files/typescript-no-default-export.ts
+++ b/tests/files/typescript-no-default-export.ts
@@ -1,0 +1,4 @@
+export interface Persona {
+    name: string,
+    age: number
+};

--- a/tests/files/typescript.ts
+++ b/tests/files/typescript.ts
@@ -35,3 +35,8 @@ export namespace MyNamespace {
 }
 
 interface NotExported {}
+type DefaultTypeExport = {
+  name: string,
+  age: number
+}
+export default DefaultTypeExport;

--- a/tests/src/rules/default.js
+++ b/tests/src/rules/default.js
@@ -264,13 +264,13 @@ context('TypeScript', function () {
 
       invalid: [
         test({
-          code: `import foobar from "./typescript"`,
+          code: `import foobar from "./typescript-no-default-export"`,
           parser,
           settings: {
             'import/parsers': { [parser]: ['.ts'] },
             'import/resolver': { 'eslint-import-resolver-typescript': true },
           },
-          errors: ['No default export found in imported module "./typescript".'],
+          errors: ['No default export found in imported module "./typescript-no-default-export".'],
         }),
         test({
           code: `import React from "./typescript-export-assign-default-namespace"`,

--- a/tests/src/rules/typescript-flow.js
+++ b/tests/src/rules/typescript-flow.js
@@ -30,12 +30,24 @@ context('TypeScript', function () {
           options: ['separate'],
         }),
         test({
+          code: `import type { MyType, Bar } from "./typescript.ts"`,
+          parser,
+          settings,
+          options: ['separate'],
+        }),
+        test({
+          code: `import type { MyType as Foo } from "./typescript.ts"`,
+          parser,
+          settings,
+          options: ['separate'],
+        }),
+        test({
           code: `import * as Bar from "./typescript.ts"`,
           parser,
           settings,
           options: ['separate'],
         }),
-        // default import is ignored for now
+        // default imports are ignored
         test({
           code: `import Bar from "./typescript.ts"`,
           parser,
@@ -48,60 +60,20 @@ context('TypeScript', function () {
           settings,
           options: ['separate'],
         }),
-        // test({
-        //   code: `import { MyType } from "./typescript.ts"`,
-        //   parser,
-        //   settings,
-        //   options: [{
-        //     prefer: 'modifier',
-        //   }],
-        // }),
+        test({
+          code: `import { type MyType } from "./typescript.ts"`,
+          parser,
+          settings,
+          options: ['inline'],
+        }),
+        test({
+          code: `import { type MyType, Bar, MyEnum } from "./typescript.ts"`,
+          parser,
+          settings,
+          options: ['inline'],
+        }),
       ], 
       invalid: [
-        // test({
-        //   code: `import type { MyType, Bar } from "./typescript.ts"`,
-        //   parser,
-        //   settings,
-        //   options: ['none'],
-        //   errors: [{
-        //     message: 'BOOM',
-        //   }],
-        //   output: 'import { MyType, Bar } from "./typescript.ts"',
-        // }),
-        // test({
-        //   code: 'import { type MyType, Bar } from "./typescript.ts"',
-        //   parser,
-        //   settings,
-        //   options: ['none'],
-        //   errors: [{
-        //     message: 'BOOM',
-        //   }],
-        //   output: 'import { MyType, Bar } from "./typescript.ts"',
-        // }),
-        // test({
-        //   code: 'import { MyType, type Bar } from "./typescript.ts"',
-        //   parser,
-        //   settings,
-        //   options: ['none'],
-        //   errors: [{
-        //     message: 'BOOM',
-        //   }],
-        //   output: 'import { MyType, Bar } from "./typescript.ts"',
-        // }),
-        // test({
-        //   code: 'import { type MyType, type Bar } from "./typescript.ts"',
-        //   parser,
-        //   settings,
-        //   options: ['none'],
-        //   errors: [{
-        //     message: 'BOOM',
-        //   },
-        //   {
-        //     message: 'BOOM',
-        //   }],
-        //   output: 'import { MyType, Bar } from "./typescript.ts"',
-        // }),
-
         test({
           code: 'import {type MyType,Bar} from "./typescript.ts"',
           parser,
@@ -154,6 +126,28 @@ context('TypeScript', function () {
             message: 'BOOM',
           }],
           output: 'import type { MyType as Bar, Foo} from "./typescript.ts"',
+        }),
+        // the space is left over when 'type' is removed. Question
+        test({
+          code: 'import type {MyType} from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['inline'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          output: 'import  {type MyType} from "./typescript.ts"',
+        }),
+
+        test({
+          code: 'import type {MyType, Bar} from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['inline'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          output: 'import  {type MyType, type Bar} from "./typescript.ts"',
         }),
       ] },
     );

--- a/tests/src/rules/typescript-flow.js
+++ b/tests/src/rules/typescript-flow.js
@@ -23,12 +23,31 @@ context('TypeScript', function () {
 
     ruleTester.run('typescript-flow', rule, { 
       valid: [
-      //   test({
-      //     code: `import type { MyType } from "./typescript.ts"`,
-      //     parser,
-      //     settings,
-      //     options: ['separate'],
-      //   }),
+        test({
+          code: `import type { MyType } from "./typescript.ts"`,
+          parser,
+          settings,
+          options: ['separate'],
+        }),
+        test({
+          code: `import * as Bar from "./typescript.ts"`,
+          parser,
+          settings,
+          options: ['separate'],
+        }),
+        // default import is ignored for now
+        test({
+          code: `import Bar from "./typescript.ts"`,
+          parser,
+          settings,
+          options: ['separate'],
+        }),
+        test({
+          code: `import type Bar from "./typescript.ts"`,
+          parser,
+          settings,
+          options: ['separate'],
+        }),
         // test({
         //   code: `import { MyType } from "./typescript.ts"`,
         //   parser,
@@ -83,7 +102,6 @@ context('TypeScript', function () {
         //   output: 'import { MyType, Bar } from "./typescript.ts"',
         // }),
 
-        // Single Config option which is separate
         test({
           code: 'import {type MyType,Bar} from "./typescript.ts"',
           parser,
@@ -116,7 +134,26 @@ context('TypeScript', function () {
             message: 'BOOM',
           }],
           output: 'import {Bar as Namespace} from "./typescript.ts"\nimport type { MyType } from "./typescript.ts"',
-          //output: 'import type { Bar } from "./typescript.ts"\nimport type { MyType } from "./typescript.ts"',
+        }),
+        test({
+          code: 'import {type MyType,type Foo} from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['separate'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          output: 'import type { MyType, Foo} from "./typescript.ts"',
+        }),
+        test({
+          code: 'import {type MyType as Bar,type Foo} from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['separate'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          output: 'import type { MyType as Bar, Foo} from "./typescript.ts"',
         }),
       ] },
     );

--- a/tests/src/rules/typescript-flow.js
+++ b/tests/src/rules/typescript-flow.js
@@ -228,16 +228,26 @@ context('TypeScript', function () {
           }],
           output: 'import defaultExport, { type MyType as Persona, type Bar as Foo } from "./typescript.ts"',
         }),
-        // // TODO: what to do here? Output: import * as b, { type MyType, type Bar } from "./typescript.ts" ?
+        test({
+          code: 'import type {MyType, Bar} from "./typescript.ts";import * as b from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['inline'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          output: 'import  {type MyType, type Bar} from "./typescript.ts";import * as b from "./typescript.ts"',
+        }),
+        // TODO: Fix the one below
         // test({
-        //   code: 'import type {MyType, Bar} from "./typescript.ts";import * as b from "./typescript.ts"',
+        //   code: 'import type {MyType, Bar} from "./typescript.ts";import type A from "./typescript.ts"',
         //   parser,
         //   settings,
         //   options: ['inline'],
         //   errors: [{
         //     message: 'BOOM',
         //   }],
-        //   output: 'import defaultExport, { type MyType, type Bar } from "./typescript.ts"',
+        //   output: 'import  {type MyType, type Bar} from "./typescript.ts";import type A from "./typescript.ts"',
         // }),
       ] },
     );

--- a/tests/src/rules/typescript-flow.js
+++ b/tests/src/rules/typescript-flow.js
@@ -5,65 +5,96 @@ import { RuleTester } from 'eslint';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/typescript-flow');
-// TODO: add exports from .TSX files to the test cases
+// TODO: add exports from .TSX files to the test cases, import default
 context('TypeScript', function () {
   getTSParsers().forEach((parser) => {
-    const parserConfig = {
-      parser,
-      settings: {
-        'import/parsers': { [parser]: ['.ts'] },
-        'import/resolver': { 'eslint-import-resolver-typescript': true },
-      },
-    };
+    // const parserConfig = {
+    //   parser,
+    //   settings: {
+    //     'import/parsers': { [parser]: ['.ts'] },
+    //     'import/resolver': { 'eslint-import-resolver-typescript': true },
+    //   },
+    // };
 
     const settings = {
       'import/parsers': { [parser]: ['.ts'] },
       'import/resolver': { 'eslint-import-resolver-typescript': true },
     };
 
-    console.log(parser);
-    ruleTester.run('prefer-default-export', rule, { 
+    ruleTester.run('typescript-flow', rule, { 
       valid: [
-        test({
-          code: `import type { MyType } from "./typescript.ts"`,
-          parser: parserConfig.parser,
-          settings,
-          options: [{
-            prefer: 'separate',
-          }],
-        }),
-        test({
-          code: `import { type MyType } from "./typescript.ts"`,
-          parser: parserConfig.parser,
-          settings,
-          options: [{
-            prefer: 'modifier',
-          }],
-        }),
+      //   test({
+      //     code: `import type { MyType } from "./typescript.ts"`,
+      //     parser,
+      //     settings,
+      //     options: ['separate'],
+      //   }),
+      //   test({
+      //     code: `import { MyType } from "./typescript.ts"`,
+      //     parser,
+      //     settings,
+      //     options: [{
+      //       prefer: 'modifier',
+      //     }],
+      //   }),
       ], 
       invalid: [
+        // test({
+        //   code: `import type { MyType, Bar } from "./typescript.ts"`,
+        //   parser,
+        //   settings,
+        //   options: ['none'],
+        //   errors: [{
+        //     message: 'BOOM',
+        //   }],
+        //   output: 'import { MyType, Bar } from "./typescript.ts"',
+        // }),
+        // test({
+        //   code: 'import { type MyType, Bar } from "./typescript.ts"',
+        //   parser,
+        //   settings,
+        //   options: ['none'],
+        //   errors: [{
+        //     message: 'BOOM',
+        //   }],
+        //   output: 'import { MyType, Bar } from "./typescript.ts"',
+        // }),
+        // test({
+        //   code: 'import { MyType, type Bar } from "./typescript.ts"',
+        //   parser,
+        //   settings,
+        //   options: ['none'],
+        //   errors: [{
+        //     message: 'BOOM',
+        //   }],
+        //   output: 'import { MyType, Bar } from "./typescript.ts"',
+        // }),
+        // test({
+        //   code: 'import { type MyType, type Bar } from "./typescript.ts"',
+        //   parser,
+        //   settings,
+        //   options: ['none'],
+        //   errors: [{
+        //     message: 'BOOM',
+        //   },
+        //   {
+        //     message: 'BOOM',
+        //   }],
+        //   output: 'import { MyType, Bar } from "./typescript.ts"',
+        // }),
+
+        // Single Config option which is separate
         test({
-          code: `import type { MyType } from "./typescript.ts"`,
+          code: 'import { type MyType, Bar } from "./typescript.ts"',
           parser,
           settings,
-          options: [{
-            prefer: 'modifier',
-          }],
+          options: ['separate'],
           errors: [{
             message: 'BOOM',
           }],
+          output: 'import type { MyType, Bar } from "./typescript.ts"',
         }),
-        test({
-          code: `import { type MyType } from "./typescript.ts"`,
-          parser,
-          settings,
-          options: [{
-            prefer: 'separate',
-          }],
-          errors: [{
-            message: 'BOOM',
-          }],
-        }),
-      ] } );
+      ] },
+    );
   });
 });

--- a/tests/src/rules/typescript-flow.js
+++ b/tests/src/rules/typescript-flow.js
@@ -48,7 +48,7 @@ context('TypeScript', function () {
           settings,
           options: ['separate'],
         }),
-        // default imports are ignored for strict option separate
+        // default imports are ignored for strict option separate. Question. TODO
         test({
           code: `import Bar from "./typescript.ts"`,
           parser,
@@ -68,7 +68,19 @@ context('TypeScript', function () {
           options: ['inline'],
         }),
         test({
+          code: `import { type MyType as Persona } from "./typescript.ts"`,
+          parser,
+          settings,
+          options: ['inline'],
+        }),
+        test({
           code: `import { type MyType, Bar, MyEnum } from "./typescript.ts"`,
+          parser,
+          settings,
+          options: ['inline'],
+        }),
+        test({
+          code: `import { type MyType as Persona, Bar as Bar, MyEnum } from "./typescript.ts"`,
           parser,
           settings,
           options: ['inline'],
@@ -86,6 +98,16 @@ context('TypeScript', function () {
           output: 'import {Bar} from "./typescript.ts"\nimport type { MyType } from "./typescript.ts"',
         }),
         test({
+          code: 'import {type MyType as Persona,Bar} from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['separate'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          output: 'import {Bar} from "./typescript.ts"\nimport type { MyType as Persona } from "./typescript.ts"',
+        }),
+        test({
           code: 'import {type MyType,Bar,type Foo} from "./typescript.ts"',
           parser,
           settings,
@@ -94,6 +116,16 @@ context('TypeScript', function () {
             message: 'BOOM',
           }],
           output: 'import {Bar} from "./typescript.ts"\nimport type { MyType, Foo } from "./typescript.ts"',
+        }),
+        test({
+          code: 'import {type MyType as Persona,Bar,type Foo as Baz} from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['separate'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          output: 'import {Bar} from "./typescript.ts"\nimport type { MyType as Persona, Foo as Baz } from "./typescript.ts"',
         }),
         test({
           code: 'import {type MyType,Bar as Namespace} from "./typescript.ts"',
@@ -125,7 +157,7 @@ context('TypeScript', function () {
           }],
           output: 'import type { MyType as Bar, Foo} from "./typescript.ts"',
         }),
-        // the space is left over when 'type' is removed. Question
+        // the space is left over when 'type' is removed. Question. TODO
         test({
           code: 'import type {MyType} from "./typescript.ts"',
           parser,
@@ -157,6 +189,16 @@ context('TypeScript', function () {
           output: 'import {MyEnum, type MyType, type Bar} from "./typescript.ts"',
         }),
         test({
+          code: 'import type {MyType as Persona, Bar as Foo} from "./typescript.ts";import {MyEnum} from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['inline'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          output: 'import {MyEnum, type MyType as Persona, type Bar as Foo} from "./typescript.ts"',
+        }),
+        test({
           code: 'import type {MyType, Bar} from "./typescript.ts";import {default as B} from "./typescript.ts"',
           parser,
           settings,
@@ -175,6 +217,16 @@ context('TypeScript', function () {
             message: 'BOOM',
           }],
           output: 'import defaultExport, { type MyType, type Bar } from "./typescript.ts"',
+        }),
+        test({
+          code: 'import type {MyType as Persona, Bar as Foo} from "./typescript.ts";import defaultExport from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['inline'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          output: 'import defaultExport, { type MyType as Persona, type Bar as Foo } from "./typescript.ts"',
         }),
         // // TODO: what to do here? Output: import * as b, { type MyType, type Bar } from "./typescript.ts" ?
         // test({

--- a/tests/src/rules/typescript-flow.js
+++ b/tests/src/rules/typescript-flow.js
@@ -5,7 +5,7 @@ import { RuleTester } from 'eslint';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/typescript-flow');
-// TODO: add exports from .TSX files to the test cases, import default
+// TODO: add exports from .TSX files to the test cases, import default, import * as b statement
 context('TypeScript', function () {
   getTSParsers().forEach((parser) => {
     // const parserConfig = {
@@ -29,14 +29,14 @@ context('TypeScript', function () {
       //     settings,
       //     options: ['separate'],
       //   }),
-      //   test({
-      //     code: `import { MyType } from "./typescript.ts"`,
-      //     parser,
-      //     settings,
-      //     options: [{
-      //       prefer: 'modifier',
-      //     }],
-      //   }),
+        // test({
+        //   code: `import { MyType } from "./typescript.ts"`,
+        //   parser,
+        //   settings,
+        //   options: [{
+        //     prefer: 'modifier',
+        //   }],
+        // }),
       ], 
       invalid: [
         // test({
@@ -85,14 +85,38 @@ context('TypeScript', function () {
 
         // Single Config option which is separate
         test({
-          code: 'import { type MyType, Bar } from "./typescript.ts"',
+          code: 'import {type MyType,Bar} from "./typescript.ts"',
           parser,
           settings,
           options: ['separate'],
           errors: [{
             message: 'BOOM',
           }],
-          output: 'import type { MyType, Bar } from "./typescript.ts"',
+          // Question: Do we just remove the problematic node, what about comma? // import { type MyType, Bar, type Foo } => mport { , Bar,  }
+          output: 'import {Bar} from "./typescript.ts"\nimport type { MyType } from "./typescript.ts"',
+          //output: 'import type { Bar } from "./typescript.ts"\nimport type { MyType } from "./typescript.ts"',
+        }),
+        test({
+          code: 'import {type MyType,Bar,type Foo} from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['separate'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          // Question: Do we just remove the problematic node, what about comma? // import { type MyType, Bar, type Foo } => mport { , Bar,  }
+          output: 'import {Bar} from "./typescript.ts"\nimport type { MyType, Foo } from "./typescript.ts"',
+        }),
+        test({
+          code: 'import {type MyType,Bar as Namespace} from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['separate'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          output: 'import {Bar as Namespace} from "./typescript.ts"\nimport type { MyType } from "./typescript.ts"',
+          //output: 'import type { Bar } from "./typescript.ts"\nimport type { MyType } from "./typescript.ts"',
         }),
       ] },
     );

--- a/tests/src/rules/typescript-flow.js
+++ b/tests/src/rules/typescript-flow.js
@@ -1,0 +1,66 @@
+
+import { test, getTSParsers, parsers } from '../utils';
+
+import { RuleTester } from 'eslint';
+import semver from 'semver';
+
+const ruleTester = new RuleTester();
+const rule = require('rules/typescript-flow');
+
+const message = 'Do not use import syntax to configure webpack loaders.';
+
+context('TypeScript', function () {
+  getTSParsers().forEach((parser) => {
+    const parserConfig = {
+      parser,
+      settings: {
+        'import/parsers': { [parser]: ['.ts'] },
+        'import/resolver': { 'eslint-import-resolver-typescript': true },
+      },
+    };
+
+    console.log(parser);
+    ruleTester.run('prefer-default-export', rule, { 
+      valid: [
+        test({
+          code: `import type { MyType } from "./typescript.ts"`,
+          parser,
+          settings: {
+            'import/parsers': { [parser]: ['.ts'] },
+            'import/resolver': { 'eslint-import-resolver-typescript': true },
+          },
+        //   parserConfig,
+        }),
+      ], 
+      invalid: [
+        test({
+          code: `import { MyType } from "./typescript.ts"`,
+        //   parserConfig,
+        parser,
+        settings: {
+          'import/parsers': { [parser]: ['.ts'] },
+          'import/resolver': { 'eslint-import-resolver-typescript': true },
+        },
+          errors: [{
+            message: 'BOOM',
+          }], 
+        }),
+      ] } );
+    // @typescript-eslint/parser@5+ throw error for invalid module specifiers at parsing time.
+    // https://github.com/typescript-eslint/typescript-eslint/releases/tag/v5.0.0
+    // if (!(parser === parsers.TS_NEW && semver.satisfies(require('@typescript-eslint/parser/package.json').version, '>= 5'))) {
+    //   ruleTester.run('no-webpack-loader-syntax', rule, {
+    //     valid: [
+    //       test(Object.assign({
+    //         code: 'import { foo } from\nalert()',
+    //       }, parserConfig)),
+    //       test(Object.assign({
+    //         code: 'import foo from\nalert()',
+    //       }, parserConfig)),
+    //     ],
+    //     invalid: [],
+    //   });
+    // }
+
+  });
+});

--- a/tests/src/rules/typescript-flow.js
+++ b/tests/src/rules/typescript-flow.js
@@ -5,8 +5,9 @@ import { RuleTester } from 'eslint';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/typescript-flow');
-// TODO: add exports from .TSX files to the test cases, import default, import * as b statement
+// TODO: add imports from .TSX files to the test cases
 context('TypeScript', function () {
+  // Do we need to check for different TS parsers? TODO Question
   getTSParsers().forEach((parser) => {
     // const parserConfig = {
     //   parser,
@@ -47,7 +48,7 @@ context('TypeScript', function () {
           settings,
           options: ['separate'],
         }),
-        // default imports are ignored
+        // default imports are ignored for strict option separate
         test({
           code: `import Bar from "./typescript.ts"`,
           parser,
@@ -82,9 +83,7 @@ context('TypeScript', function () {
           errors: [{
             message: 'BOOM',
           }],
-          // Question: Do we just remove the problematic node, what about comma? // import { type MyType, Bar, type Foo } => mport { , Bar,  }
           output: 'import {Bar} from "./typescript.ts"\nimport type { MyType } from "./typescript.ts"',
-          //output: 'import type { Bar } from "./typescript.ts"\nimport type { MyType } from "./typescript.ts"',
         }),
         test({
           code: 'import {type MyType,Bar,type Foo} from "./typescript.ts"',
@@ -94,7 +93,6 @@ context('TypeScript', function () {
           errors: [{
             message: 'BOOM',
           }],
-          // Question: Do we just remove the problematic node, what about comma? // import { type MyType, Bar, type Foo } => mport { , Bar,  }
           output: 'import {Bar} from "./typescript.ts"\nimport type { MyType, Foo } from "./typescript.ts"',
         }),
         test({
@@ -138,7 +136,6 @@ context('TypeScript', function () {
           }],
           output: 'import  {type MyType} from "./typescript.ts"',
         }),
-
         test({
           code: 'import type {MyType, Bar} from "./typescript.ts"',
           parser,
@@ -149,6 +146,47 @@ context('TypeScript', function () {
           }],
           output: 'import  {type MyType, type Bar} from "./typescript.ts"',
         }),
+        test({
+          code: 'import type {MyType, Bar} from "./typescript.ts";import {MyEnum} from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['inline'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          output: 'import {MyEnum, type MyType, type Bar} from "./typescript.ts"',
+        }),
+        test({
+          code: 'import type {MyType, Bar} from "./typescript.ts";import {default as B} from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['inline'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          output: 'import {default as B, type MyType, type Bar} from "./typescript.ts"',
+        }),
+        test({
+          code: 'import type {MyType, Bar} from "./typescript.ts";import defaultExport from "./typescript.ts"',
+          parser,
+          settings,
+          options: ['inline'],
+          errors: [{
+            message: 'BOOM',
+          }],
+          output: 'import defaultExport, { type MyType, type Bar } from "./typescript.ts"',
+        }),
+        // // TODO: what to do here? Output: import * as b, { type MyType, type Bar } from "./typescript.ts" ?
+        // test({
+        //   code: 'import type {MyType, Bar} from "./typescript.ts";import * as b from "./typescript.ts"',
+        //   parser,
+        //   settings,
+        //   options: ['inline'],
+        //   errors: [{
+        //     message: 'BOOM',
+        //   }],
+        //   output: 'import defaultExport, { type MyType, type Bar } from "./typescript.ts"',
+        // }),
       ] },
     );
   });


### PR DESCRIPTION
Draft version of the new rule proposed at #2390. 

This new rule allows for changing between inline type imports (type modifiers introduced in TS 4.5) and separate type import statements (introduced in TS 3.8). The rule also fixes imports to the preferred option. The rule assumes that user specifies himself which imports are type imports. For example, if there is `enum` that is used as a type, user should import the enum as type. This rule does not check the usage of imports, but rather helps to enforce consistent style for importing types. 

The rule has 2 strict options (inline and separate) and one preferred flow option. In preferred flow option, user passes array of inline and separate in the order of preference. Rule checks if inline is supported, if not, falls back to "separate" as an option. If separate comes first in the array, then resume as if there is strict "separate" option.

Strict option enforces either inline type imports with type modifiers, or separate type imports.

Rule schema for strict options: we pass single string to the rule

```javascript
"import/typescript": [ 0 | 1 | 2, "inline" | "strict" ]
```

### separate option

**Definition**: All type imports must be imported in a separate `import type` statement.

The following patterns are *not* considered warnings:

```javascript
// good1.js

// Separate import type statement
import type { MyType } from "./typescript.ts"
```

```javascript
// good2.js

// Separate import type statement
import type { MyType as Persona, Bar as Foo } from "./typescript.ts"
```

The following patterns are considered warnings:


```javascript
// bad1.js

// type imports must be imported in separate import type statement
import {type MyType,Bar} from "./typescript.ts"

// gets fixed to the following:
import {Bar} from "./typescript.ts"
import type { MyType } from "./typescript.ts"
```

```javascript
// bad2.js

// type imports must be imported in separate import type statement
import {type MyType,type Foo} from "./typescript.ts"

// gets fixed to the following:
import type { MyType, Foo} from "./typescript.ts"
```

```javascript
// bad3.js

// type imports must be imported in separate import type statement
import {type MyType as Persona,Bar,type Foo as Baz} from "./typescript.ts"

// gets fixed to the following:
import {Bar} from "./typescript.ts"\nimport type { MyType as Persona, Foo as Baz } from "./typescript.ts"
```

### inline option

**Definition**: All type imports must be inline imported with type modifiers.

Patterns that do not raise the warning:

```javascript
// good1.js

// no separate import type statement. inline type import exists
import { type MyType } from "./typescript.ts"
```

```javascript
// good2.js

// no separate import type statement. inline type import exists
import { type MyType, Bar, type Foo as Baz } from "./typescript.ts"
```

Patterns are considered warnings and fixed:

```javascript
// bad1.js

// type imports must be imported inline
import type {MyType} from "./typescript.ts"

// gets fixed to the following:
import  {type MyType} from "./typescript.ts"
```

```javascript
// bad1.js

// type imports must be imported inline
import type {MyType, Bar} from "./typescript.ts"

// gets fixed to the following:
import  {type MyType, type Bar} from "./typescript.ts"
```

```javascript
// bad3.js

// type imports must be imported inline
import type {MyType, Bar} from "./typescript.ts"
import {Value} from "./typescript.ts"

// Rule can check if non-type import exists. If yes, then adds inline type imports there. gets fixed to the following:
import {Value, type MyType, type Bar} from "./typescript.ts"
```

Questions:

1) How to handle the cases where there are 2 spaces left when "type" is removed from separate import type. I could not figure out the token for the spaces. Seems like spaces are completely ignored from estree?

```javascript

// option === 'inline'

// input
import type {MyType, Bar} from "./typescript.ts"

//output
import  {type MyType, type Bar} from "./typescript.ts" // there are 2 spaces after import
``` 





