### PR TITLE
fixed vulnerability in json5

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,6 @@
     "minimatch": "^3.1.2",
     "object.values": "^1.1.6",
     "resolve": "^1.22.1",
-    "tsconfig-paths": "^3.14.1"
+    "tsconfig-paths": "^4.1.1"
   }
 }


### PR DESCRIPTION
When installing the package, it brings with it `tsconfig-paths@^3` which in turns brings `json5@^1` which is vulnerable under https://github.com/advisories/GHSA-9c47-m6qq-7p4h

I've just bumped `tsconfig-paths` to latest and it fixes it (for prod deps only).

I've ran the tests and they work just fine, lmk if there is anything else I should do.