### PR TITLE
bump tsconfig-paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-import",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "description": "Import with sanity.",
   "engines": {
     "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -114,6 +114,6 @@
     "minimatch": "^3.1.2",
     "object.values": "^1.1.6",
     "resolve": "^1.22.1",
-    "tsconfig-paths": "^3.14.1"
+    "tsconfig-paths": "^4.1.1"
   }
 }


### PR DESCRIPTION
bump `tsconfig-paths` to `4.1.1` to resolve high severity vulnerabilities reported by `npm audit`.
```
npm audit

json5  <2.2.2
Severity: high
Prototype Pollution in JSON5 via Parse Method - https://github.com/advisories/GHSA-9c47-m6qq-7p4h
node_modules/tsconfig-paths/node_modules/json5
  tsconfig-paths  3.5.0 - 3.9.0 || 3.11.0 - 3.14.1
  Depends on vulnerable versions of json5
  node_modules/tsconfig-paths
    eslint-plugin-import  >=2.24.2
    Depends on vulnerable versions of tsconfig-paths
    node_modules/eslint-plugin-import
      eslint-config-airbnb-base  >=15.0.0
      Depends on vulnerable versions of eslint-plugin-import
      node_modules/eslint-config-airbnb-base
        eslint-config-airbnb-typescript  >=16.0.0
        Depends on vulnerable versions of eslint-config-airbnb-base
        Depends on vulnerable versions of eslint-plugin-import
        node_modules/eslint-config-airbnb-typescript
```