### PR TITLE
[Docs] add TS import/parsers settings to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ extends:
 # the following lines do the trick
   - plugin:import/typescript
 settings:
+  import/parsers:
+    # Your paths may differ, this example parses all Typescript files within cwd
+    '@typescript-eslint/parser': ['**/.ts', '**/.tsx']
   import/resolver:
     # You will also need to install and configure the TypeScript resolver
     # See also https://github.com/import-js/eslint-import-resolver-typescript#configuration


### PR DESCRIPTION
Just a line from the `eslint-import-resolver-typescript` readme, which is already linked in a nearby code comment; it took me way too long to figure out critical stuff was in that linked readme. Proposing this as it may help others, not sure if it applies for all typescript uses or not.