### PR TITLE
Bump tsconfig-paths to latest 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,6 @@
     "minimatch": "^3.1.2",
     "object.values": "^1.1.6",
     "resolve": "^1.22.1",
-    "tsconfig-paths": "^3.14.1"
+    "tsconfig-paths": "^4.1.2"
   }
 }


### PR DESCRIPTION
[tsconfig-paths](https://www.npmjs.com/package/tsconfig-paths) is a dependency of `eslint-plugin-import`. 

`tsconfig-paths` has a dependency on `json5`. 

`json5` recently had a[ security vulnerability published](https://github.com/advisories/GHSA-9c47-m6qq-7p4h), and a patch released on version `2.2.2`.

tsconfig-paths [just updated their json5](https://github.com/dividab/tsconfig-paths/pull/232) dependency, available for version `4.1.2`. 

This PR bumps `eslint-plugin-import`'s dependency on tsconfig-paths, removing the vulnerability.