### PR TITLE
[Fix] Vulnerable tsconfig-paths dependency update

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,6 @@
     "minimatch": "^3.1.2",
     "object.values": "^1.1.6",
     "resolve": "^1.22.1",
-    "tsconfig-paths": "^3.14.1"
+    "tsconfig-paths": "^4.1.2"
   }
 }


### PR DESCRIPTION
### Issue 
Prototype Pollution in package minimist
### Dependency
eslint-plugin-import 
### Path
`eslint-plugin-import > tsconfig-paths > json5 > minimist`
### Patched in
minimist version >=1.2.6
### More info
https://www.npmjs.com/advisories/1067342