### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   "dependencies": {
     "array-includes": "^3.1.6",
     "array.prototype.flat": "^1.3.1",
-    "debug": "^2.6.9",
+    "debug": "^3.1.0",
     "doctrine": "^2.1.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-module-utils": "^2.7.4",


### PR DESCRIPTION
Update version of debug dependency to solve the error: Regular Expression Denial of Service (ReDoS) [Low Severity][https://security.snyk.io/vuln/SNYK-JS-DEBUG-3227433] in debug@2.6.9 introduced by eslint-plugin-import@2.26.0 > debug@2.6.9 and 1 other path(s). This issue was fixed in versions: 3.1.0.

This error block project deploy on Github workflow.