### PR TITLE
fix: array.prototype.flatmap as prod dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## [Unreleased]
 
+### Fixed
+- `array.prototype.flatmap` should be a prod dep ([#2664], thanks [@cristobal])
+
 ## [2.27.0] - 2023-01-11
 
 ### Added
@@ -1032,6 +1035,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2664]: https://github.com/import-js/eslint-plugin-import/pull/2664
 [#2613]: https://github.com/import-js/eslint-plugin-import/pull/2613
 [#2608]: https://github.com/import-js/eslint-plugin-import/pull/2608
 [#2605]: https://github.com/import-js/eslint-plugin-import/pull/2605
@@ -1604,6 +1608,7 @@ for info on changes for earlier releases.
 [@chrislloyd]: https://github.com/chrislloyd
 [@christianvuerings]: https://github.com/christianvuerings
 [@christophercurrie]: https://github.com/christophercurrie
+[@cristobal]: https://github.com/cristobal
 [@DamienCassou]: https://github.com/DamienCassou
 [@danny-andrews]: https://github.com/dany-andrews
 [@darkartur]: https://github.com/darkartur

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@eslint/import-test-order-redirect-scoped": "file:./tests/files/order-redirect-scoped",
     "@test-scope/some-module": "file:./tests/files/symlinked-module",
     "@typescript-eslint/parser": "^2.23.0 || ^3.3.0 || ^4.29.3 || ^5.10.0",
-    "array.prototype.flatmap": "^1.3.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "=8.0.3 || ^8.2.6",
@@ -104,6 +103,7 @@
   "dependencies": {
     "array-includes": "^3.1.6",
     "array.prototype.flat": "^1.3.1",
+    "array.prototype.flatmap": "^1.3.0",    
     "debug": "^3.2.7",
     "doctrine": "^2.1.0",
     "eslint-import-resolver-node": "^0.3.7",


### PR DESCRIPTION
The `array.prototype.flatmap` dependency is used as prod dependency after bumping to from [v2.26.0..v2.27.0](https://github.com/import-js/eslint-plugin-import/compare/v2.26.0...v2.27.0) in several of the rules:

![Screenshot 2023-01-12 at 01 13 21](https://user-images.githubusercontent.com/155505/211945299-164bbde0-5e18-4973-9b65-850eb7c15496.png)
![Screenshot 2023-01-12 at 01 13 35](https://user-images.githubusercontent.com/155505/211945340-cc11ea76-d65f-493c-91ed-8c10eeeee669.png)


Fixes #2663