### PR TITLE
`import/order` Fix group ranks order when alphabetizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## [Unreleased]
 
+### Fixed
+- [`order]`: Fix group ranks order when alphabetizing ([#2674], thanks [@Pearce-Ropion])
+
 ## [2.27.4] - 2023-01-11
 
 ### Fixed
@@ -1376,6 +1379,7 @@ for info on changes for earlier releases.
 [#211]: https://github.com/import-js/eslint-plugin-import/pull/211
 [#164]: https://github.com/import-js/eslint-plugin-import/pull/164
 [#157]: https://github.com/import-js/eslint-plugin-import/pull/157
+[#2674]: https://github.com/import-js/eslint-plugin-import/issues/2674
 [#2668]: https://github.com/import-js/eslint-plugin-import/issues/2668
 [#2666]: https://github.com/import-js/eslint-plugin-import/issues/2666
 [#2665]: https://github.com/import-js/eslint-plugin-import/issues/2665

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -334,9 +334,12 @@ function mutateRanksToAlphabetize(imported, alphabetizeOptions) {
     return acc;
   }, {});
 
-  const groupRanks = Object.keys(groupedByRanks);
-
   const sorterFn = getSorter(alphabetizeOptions);
+
+  // sort group keys so that they can be iterated on in order
+  const groupRanks = Object.keys(groupedByRanks).sort(function (a, b) {
+    return a - b;
+  });
 
   // sort imports locally within their group
   groupRanks.forEach(function (groupRank) {
@@ -345,7 +348,7 @@ function mutateRanksToAlphabetize(imported, alphabetizeOptions) {
 
   // assign globally unique rank to each import
   let newRank = 0;
-  const alphabetizedRanks = groupRanks.sort().reduce(function (acc, groupRank) {
+  const alphabetizedRanks = groupRanks.reduce(function (acc, groupRank) {
     groupedByRanks[groupRank].forEach(function (importedItem) {
       acc[`${importedItem.value}|${importedItem.node.importKind}`] = parseInt(groupRank, 10) + newRank;
       newRank += 1;

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -2280,6 +2280,8 @@ ruleTester.run('order', rule, {
         },
       ],
     }),
+
+    // pathGroups overflowing to previous/next groups
     test({
       code: `
         import path from 'path';
@@ -2347,6 +2349,47 @@ ruleTester.run('order', rule, {
         'import/internal-regex': '^(a|b|c|d|e|f|g|h|i|j|k)(\\/|$)',
       },
       errors: Array.from({ length: 11 }, () => 'There should be at least one empty line between import groups'),
+    }),
+
+    // rankings that overflow to double-digit ranks
+    test({
+      code: `
+        import external from 'external';
+        import a from '@namespace/a';
+        import b from '@namespace/b';
+        import { parent } from '../../parent';
+        import local from './local';
+        import './side-effect';`,
+      output: `
+        import external from 'external';
+
+        import a from '@namespace/a';
+        import b from '@namespace/b';
+
+        import { parent } from '../../parent';
+
+        import local from './local';
+        import './side-effect';`,
+      options: [
+        {
+          alphabetize: {
+            order: 'asc',
+            caseInsensitive: true,
+          },
+          groups: ['type', 'builtin', 'external', 'internal', 'parent', 'sibling', 'index', 'object'],
+          'newlines-between': 'always',
+          pathGroups: [
+            { pattern: '@namespace', group: 'external', position: 'after' },
+            { pattern: '@namespace/**', group: 'external', position: 'after' },
+          ],
+          pathGroupsExcludedImportTypes: ['@namespace'],
+        },
+      ],
+      errors: [
+        'There should be at least one empty line between import groups',
+        'There should be at least one empty line between import groups',
+        'There should be at least one empty line between import groups',
+      ],
     }),
 
     // reorder fix cannot cross non import or require


### PR DESCRIPTION
Resolves #2671 

Correctly sorts `groupRanks` in numerical order when alphabetizing. This bug would occur for groups where the `rank` overflowed to double digits (eg. `"10"` is sorted before `"4"`). This is a bug with the original code and not necessarily caused by #2506. There just previously wasn't a case where enough groups were added to get to the double digit ranks.

The test case I made for this is similar to the example case shown in #2671 but it isn't the most general test case. It's just a case that would fail without this change.

I also went ahead and added a description comment to my previous PR's test case since it was missing one