### PR TITLE
upgrade minimatch to @5

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "has": "^1.0.3",
     "is-core-module": "^2.11.0",
     "is-glob": "^4.0.3",
-    "minimatch": "^3.1.2",
+    "minimatch": "^5.1.4",
     "object.values": "^1.1.6",
     "resolve": "^1.22.1",
     "semver": "^6.3.0",

--- a/tests/src/rules/no-internal-modules.js
+++ b/tests/src/rules/no-internal-modules.js
@@ -77,7 +77,7 @@ ruleTester.run('no-internal-modules', rule, {
       code: 'import b from "app/a"',
       filename: testFilePath('./internal-modules/plugins/plugin2/internal.js'),
       options: [ {
-        forbid: [ 'app/**/**' ],
+        forbid: [ 'app/' ],
       } ],
     }),
     test({
@@ -153,7 +153,7 @@ ruleTester.run('no-internal-modules', rule, {
       code: 'export * from "app/a"',
       filename: testFilePath('./internal-modules/plugins/plugin2/internal.js'),
       options: [ {
-        forbid: [ 'app/**/**' ],
+        forbid: [ 'app/' ],
       } ],
     }),
     test({


### PR DESCRIPTION
minimatch has fixed some bugs so I upgraded it to v5.
This includes breaking changes, and I think some of them are correct behavior as the glob pattern but I'am not sure that all of them are
https://www.digitalocean.com/community/tools/glob?comments=true&glob=app%2F%2A%2A%2F%2A%2A&matches=false&tests=app%2Fa

My main interest is [this bug](https://github.com/isaacs/minimatch/issues/188).
