### PR TITLE
[utils] [new] `parse`: support flat config

### DIFF
--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -7,6 +7,11 @@ import fs from 'fs';
 import eslintPkg from 'eslint/package.json';
 import semver from 'semver';
 
+let FlatRuleTester;
+try {
+  ({ FlatRuleTester } = require('eslint/use-at-your-own-risk'));
+} catch (e) { /**/ }
+
 // TODO: figure out why these tests fail in eslint 4 and 5
 const isESLint4TODO = semver.satisfies(eslintPkg.version, '^4 || ^5');
 
@@ -1369,5 +1374,22 @@ describe('parser ignores prefixes like BOM and hashbang', () => {
       }),
     ],
     invalid: [],
+  });
+});
+
+describe('supports flat eslint', { skip: !FlatRuleTester }, () => {
+  const flatRuleTester = new FlatRuleTester();
+  flatRuleTester.run('no-unused-modules', rule, {
+    valid: [{
+      options: unusedExportsOptions,
+      code: 'import { o2 } from "./file-o";export default () => 12',
+      filename: testFilePath('./no-unused-modules/file-a.js'),
+    }],
+    invalid: [{
+      options: unusedExportsOptions,
+      code: 'export default () => 13',
+      filename: testFilePath('./no-unused-modules/file-f.js'),
+      errors: [error(`exported declaration 'default' not used within other modules`)],
+    }],
   });
 });


### PR DESCRIPTION
Flat ESLint [no longer supports](https://eslint/eslint/issues/16878) `context.parserPath` which is required for [utils/parse](https://github.com/import-js/eslint-plugin-import/blob/d5fc8b670dc8e6903dbb7b0894452f60c03089f5/utils/parse.js#L60).
This PR uses `context.languageOptions.parse` which has the loaded parser as an alternative.
Some notes:
- Backwards compatible as it only checks if `context.parserPath` is unset
- Currently it does check if `parse` or `parseForESLint` in `context.languageOptions.parser` is a function (I do not if "constructed" context objects are officially supported)
- I added a test to the rule to no-unused-modules for testing with flat eslint rule tester