### PR TITLE
chore: upgrade image to Visual Studio 2022

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
     # - nodejs_version: "6"
     # - nodejs_version: "4"
 
-image: Visual Studio 2019
+image: Visual Studio 2022
 matrix:
   fast_finish: false
   exclude:


### PR DESCRIPTION
workarounds #2737 

Just trying to use a later image
- https://www.appveyor.com/docs/windows-images-software/#visual-studio-2022
- https://www.appveyor.com/docs/windows-images-software/#wsl

I can't seem to find more about appveyor and WSL support that this blog post 🤔 
https://www.appveyor.com/blog/2019/10/11/vs2019-image-with-docker-wsl-preheated/#windows-subsystem-for-linux-wsl