### PR TITLE
[Fix] `consistent-type-specifier-style`: fix accidental removal of comma in certain cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Fixed
 - [`no-duplicates`]: remove duplicate identifiers in duplicate imports ([#2577], thanks [@joe-matsec])
 - TypeScript config: fix resolver extension settings (thanks [@gajus])
+- [`consistent-type-specifier-style`]: fix accidental removal of comma in certain cases ([#2754], thanks [@bradzacher])
 
 ### Changed
 - [Docs] [`no-duplicates`]: fix example schema ([#2684], thanks [@simmo])
@@ -1065,6 +1066,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2754]: https://github.com/import-js/eslint-plugin-import/pull/2754
 [#2699]: https://github.com/import-js/eslint-plugin-import/pull/2699
 [#2664]: https://github.com/import-js/eslint-plugin-import/pull/2664
 [#2613]: https://github.com/import-js/eslint-plugin-import/pull/2613

--- a/src/rules/consistent-type-specifier-style.js
+++ b/src/rules/consistent-type-specifier-style.js
@@ -7,9 +7,9 @@ function isComma(token) {
 function removeSpecifiers(fixes, fixer, sourceCode, specifiers) {
   for (const specifier of specifiers) {
     // remove the trailing comma
-    const comma = sourceCode.getTokenAfter(specifier, isComma);
-    if (comma) {
-      fixes.push(fixer.remove(comma));
+    const token = sourceCode.getTokenAfter(specifier);
+    if (token && isComma(token)) {
+      fixes.push(fixer.remove(token));
     }
     fixes.push(fixer.remove(specifier));
   }

--- a/tests/src/rules/consistent-type-specifier-style.js
+++ b/tests/src/rules/consistent-type-specifier-style.js
@@ -168,6 +168,33 @@ const COMMON_TESTS = {
         type: 'ImportSpecifier',
       }],
     },
+    // https://github.com/import-js/eslint-plugin-import/issues/2753
+    {
+      code: `\
+import { Component, type ComponentProps } from "package-1";
+import {
+  Component1,
+  Component2,
+  Component3,
+  Component4,
+  Component5,
+} from "package-2";`,
+      output: `\
+import { Component  } from "package-1";
+import type {ComponentProps} from "package-1";
+import {
+  Component1,
+  Component2,
+  Component3,
+  Component4,
+  Component5,
+} from "package-2";`,
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only import instead of inline type specifiers.',
+        type: 'ImportSpecifier',
+      }],
+    },
 
     //
     // prefer-inline


### PR DESCRIPTION
Fixes #2753

When passed the second argument - `getTokenAfter` will keep searching until it finds a token that matches that token - so in this bug it meant it kept scanning to the next import declaration.
Using the single-arg form means it will just grab the next token and we can then check to see if that token is a comma or not (it'll either be a `}` or a `,`).