### PR TITLE
Fix invalid YAML in import/parsers example

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ directly using webpack, for example:
 # .eslintrc.yml
 settings:
   import/parsers:
-    @typescript-eslint/parser: [ .ts, .tsx ]
+    "@typescript-eslint/parser": [ .ts, .tsx ]
 ```
 
 In this case, [`@typescript-eslint/parser`](https://www.npmjs.com/package/@typescript-eslint/parser)


### PR DESCRIPTION
YAML keys can not start with `@` as that will result in such a parser error:

```
bad indentation of a mapping entry (4:5)

 1 | settings:
 2 |   import/extensions: [.js, .jsx, .ts ...
 3 |   import/parsers:
 4 |     @typescript-eslint/parser: [ .ts ...
---------^
```