### PR TITLE
[Fix] `extensions`: handle `.` and `..` properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [Perf] `ExportMap`: Improve `ExportMap.for` performance on larger codebases ([#2756], thanks [@leipert])
 - [`no-extraneous-dependencies`]/TypeScript: do not error when importing inline type from dev dependencies ([#1820], thanks [@andyogo])
 - [`newline-after-import`]/TypeScript: do not error when re-exporting a namespaced import ([#2832], thanks [@laurens-dg])
-* [`order`]: partial fix for [#2687] (thanks [@ljharb])
+- [`order`]: partial fix for [#2687] (thanks [@ljharb])
 - [`no-duplicates`]: Detect across type and regular imports ([#2835], thanks [@benkrejci])
+- [`extensions`]: handle `.` and `..` properly ([#2778], thanks [@benasher44])
 
 ### Changed
 - [Docs] [`no-duplicates`]: fix example schema ([#2684], thanks [@simmo])
@@ -1076,6 +1077,7 @@ for info on changes for earlier releases.
 
 [#2835]: https://github.com/import-js/eslint-plugin-import/pull/2835
 [#2832]: https://github.com/import-js/eslint-plugin-import/pull/2832
+[#2778]: https://github.com/import-js/eslint-plugin-import/pull/2778
 [#2756]: https://github.com/import-js/eslint-plugin-import/pull/2756
 [#2754]: https://github.com/import-js/eslint-plugin-import/pull/2754
 [#2748]: https://github.com/import-js/eslint-plugin-import/pull/2748
@@ -1649,6 +1651,7 @@ for info on changes for earlier releases.
 [@BarryThePenguin]: https://github.com/BarryThePenguin
 [@be5invis]: https://github.com/be5invis
 [@beatrizrezener]: https://github.com/beatrizrezener
+[@benasher44]: https://github.com/benasher44
 [@benkrejci]: https://github.com/benkrejci
 [@benmosher]: https://github.com/benmosher
 [@benmunro]: https://github.com/benmunro

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -130,6 +130,7 @@ module.exports = {
     }
 
     function isExternalRootModule(file) {
+      if (file === '.' || file === '..') { return false; }
       const slashCount = file.split('/').length - 1;
 
       if (slashCount === 0)  { return true; }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,1 @@
+export * from './files';

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -268,6 +268,26 @@ ruleTester.run('extensions', rule, {
 
     test({
       code: [
+        'import barjs from "."',
+        'import barjs2 from ".."',
+      ].join('\n'),
+      options: [ 'always' ],
+      errors: [
+        {
+          message: 'Missing file extension "js" for "."',
+          line: 1,
+          column: 19,
+        },
+        {
+          message: 'Missing file extension "js" for ".."',
+          line: 2,
+          column: 20,
+        },
+      ],
+    }),
+
+    test({
+      code: [
         'import barjs from "./bar.js"',
         'import barjson from "./bar.json"',
         'import barnone from "./bar"',
@@ -591,6 +611,35 @@ ruleTester.run('extensions', rule, {
         {
           message: 'Unexpected use of file extension "js" for "@test-scope/some-module/index.js"',
           line: 3,
+        },
+      ],
+    }),
+
+    // TODO: properly ignore packages resolved via relative imports
+    test({
+      code: [
+        'import * as test from "."',
+      ].join('\n'),
+      filename: testFilePath('./internal-modules/test.js'),
+      options: [ 'ignorePackages' ],
+      errors: [
+        {
+          message: 'Missing file extension for "."',
+          line: 1,
+        },
+      ],
+    }),
+    // TODO: properly ignore packages resolved via relative imports
+    test({
+      code: [
+        'import * as test from ".."',
+      ].join('\n'),
+      filename: testFilePath('./internal-modules/plugins/plugin.js'),
+      options: [ 'ignorePackages' ],
+      errors: [
+        {
+          message: 'Missing file extension for ".."',
+          line: 1,
         },
       ],
     }),


### PR DESCRIPTION
The issue was `isExternalRootModule` was returning `true` for these, since they had no `/` in them. This fixes that.

Closes #2777 