### PR TITLE
`extensions`: use the `extensionAlias` option of `import-resolver-typescript`

### DIFF
--- a/tests/files/typescript-tsx.tsx
+++ b/tests/files/typescript-tsx.tsx
@@ -1,0 +1,1 @@
+export const foo = <div>Foo</div>;

--- a/tests/files/typescript-with-index/index.ts
+++ b/tests/files/typescript-with-index/index.ts
@@ -1,0 +1,1 @@
+export const foo = "foo";

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -3,6 +3,15 @@ import rule from 'rules/extensions';
 import { getTSParsers, test, testFilePath, parsers } from '../utils';
 
 const ruleTester = new RuleTester();
+const ruleTesterWithTypeScriptImports = new RuleTester({
+  settings: {
+    'import/resolver': {
+      typescript: {
+        alwaysTryTypes: true,
+      },
+    },
+  },
+});
 
 ruleTester.run('extensions', rule, {
   valid: [
@@ -639,6 +648,65 @@ describe('TypeScript', () => {
               { ts: 'never', tsx: 'never', js: 'never', jsx: 'never' },
             ],
             parser,
+          }),
+        ],
+      });
+
+      ruleTesterWithTypeScriptImports.run(`${parser}: allow importing JS extension when a TS file is resolved`, rule, {
+        valid: [
+          test({
+            code: 'import { foo } from "./typescript.js";',
+            options: [
+              'always',
+            ],
+          }),
+          test({
+            code: 'import { foo } from "./typescript-tsx.jsx";',
+            options: [
+              'always',
+            ],
+          }),
+          test({
+            code: 'import { foo } from "./typescript-tsx.js";',
+            options: [
+              'always',
+            ],
+          }),
+          test({
+            code: 'import { foo } from "./typescript-with-index/index.js";',
+            options: [
+              'always',
+            ],
+          }),
+          test({
+            code: 'import { foo } from "./typescript.js";',
+            options: [
+              'always',
+              { ts: 'never', tsx: 'never', js: 'always', jsx: 'always' },
+            ],
+          }),
+        ],
+        invalid: [
+          test({
+            code: 'import { foo } from "./typescript";',
+            errors: ['Missing file extension "ts" for "./typescript"'],
+            options: [
+              'always',
+            ],
+          }),
+          test({
+            code: 'import { foo } from "./typescript-tsx";',
+            errors: ['Missing file extension "tsx" for "./typescript-tsx"'],
+            options: [
+              'always',
+            ],
+          }),
+          test({
+            code: 'import { foo } from "./typescript-with-index";',
+            errors: ['Missing file extension "ts" for "./typescript-with-index"'],
+            options: [
+              'always',
+            ],
           }),
         ],
       });


### PR DESCRIPTION
TypeScript with `moduleResolution: "node16"` requires imports like `import { foo } from './tsFile.js'` while on the disk, there is actually a `./tsFile.ts`.  
The idea here is that a module import needs a file extension and that TypeScript will not change the import statement during transpilation.

Currently, this does not work with the `import/extensions` rule if the `eslint-import-resolver-typescript` is set up - the resolver will return the original file name with the `.ts` extension, and the eslint rule will error since `"js" !== "ts"`.

This PR modifies the `import/extensions` rule to take the `extensionAlias` setting into account if the `typescript` resolver is configured.

Related issues: #2729 and #2776