### PR TITLE
Add "eslint-plugin" to the list of keywords in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "keywords": [
     "eslint",
     "eslintplugin",
+    "eslint-plugin",
     "es6",
     "jsnext",
     "modules",


### PR DESCRIPTION
Most plugins on npm seem to specify both [eslintplugin](https://www.npmjs.com/search?q=keywords:eslintplugin) and [eslint-plugin](https://www.npmjs.com/search?q=keywords:eslint-plugin) keywords. I have just looked up the list of top plugins using the latter, and got surprised that `eslint-plugin-import` was nowhere to be found.