### PR TITLE
update semver npm dependency to address npm audit message

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "object.fromentries": "^2.0.6",
     "object.values": "^1.1.6",
     "resolve": "^1.22.3",
-    "semver": "^6.3.0",
+    "semver": "^7.5.4",
     "tsconfig-paths": "^3.14.2"
   }
 }


### PR DESCRIPTION
Fixes:

```
semver  <7.5.2
Severity: moderate
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
```

Tests pass with this change in place. According to the semver changelog the 7.0 changes are small:

"Refactor module into separate files for better tree-shaking
Drop support for very old node versions, use const/let, => functions, and classes."

By "old versions" they mean very old — "engines" still only specifies 10.x or better.
