### PR TITLE
[Fix] `no-duplicates`: Prefer combined type and regular imports when using `prefer-inline`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`no-extraneous-dependencies`]/TypeScript: do not error when importing inline type from dev dependencies ([#1820], thanks [@andyogo])
 - [`newline-after-import`]/TypeScript: do not error when re-exporting a namespaced import ([#2832], thanks [@laurens-dg])
 * [`order`]: partial fix for [#2687] (thanks [@ljharb])
+- [`no-duplicates`]: Detect across type and regular imports ([#2835], thanks [@benkrejci])
 
 ### Changed
 - [Docs] [`no-duplicates`]: fix example schema ([#2684], thanks [@simmo])
@@ -1073,6 +1074,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2835]: https://github.com/import-js/eslint-plugin-import/pull/2835
 [#2832]: https://github.com/import-js/eslint-plugin-import/pull/2832
 [#2756]: https://github.com/import-js/eslint-plugin-import/pull/2756
 [#2754]: https://github.com/import-js/eslint-plugin-import/pull/2754
@@ -1647,6 +1649,7 @@ for info on changes for earlier releases.
 [@BarryThePenguin]: https://github.com/BarryThePenguin
 [@be5invis]: https://github.com/be5invis
 [@beatrizrezener]: https://github.com/beatrizrezener
+[@benkrejci]: https://github.com/benkrejci
 [@benmosher]: https://github.com/benmosher
 [@benmunro]: https://github.com/benmunro
 [@BenoitZugmeyer]: https://github.com/BenoitZugmeyer

--- a/docs/rules/no-duplicates.md
+++ b/docs/rules/no-duplicates.md
@@ -84,12 +84,17 @@ Config:
 ```js
 import { AValue, type AType } from './mama-mia'
 import type { BType } from './mama-mia'
+
+import { CValue } from './papa-mia'
+import type { CType } from './papa-mia'
 ```
 
 ✅ Valid with `["error", {"prefer-inline": true}]`
 
 ```js
 import { AValue, type AType, type BType } from './mama-mia'
+
+import { CValue, type CType } from './papa-mia'
 ```
 
 <!--tabs-->

--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -318,10 +318,11 @@ module.exports = {
         });
       }
       const map = moduleMaps.get(n.parent);
-      if (n.importKind === 'type') {
+      const preferInline = context.options[0] && context.options[0]['prefer-inline'];
+      if (!preferInline && n.importKind === 'type') {
         return n.specifiers.length > 0 && n.specifiers[0].type === 'ImportDefaultSpecifier' ? map.defaultTypesImported : map.namedTypesImported;
       }
-      if (n.specifiers.some((spec) => spec.importKind === 'type')) {
+      if (!preferInline && n.specifiers.some((spec) => spec.importKind === 'type')) {
         return map.namedTypesImported;
       }
 

--- a/tests/src/rules/no-duplicates.js
+++ b/tests/src/rules/no-duplicates.js
@@ -711,6 +711,25 @@ context('TypeScript', function () {
             },
           ],
         }),
+        // #2834 Detect duplicates across type and regular imports
+        test({
+          code: "import {AValue} from './foo'; import type {AType} from './foo'",
+          ...parserConfig,
+          options: [{ 'prefer-inline': true }],
+          output: `import {AValue,type AType} from './foo'; `,
+          errors: [
+            {
+              line: 1,
+              column: 22,
+              message: "'./foo' imported multiple times.",
+            },
+            {
+              line: 1,
+              column: 56,
+              message: "'./foo' imported multiple times.",
+            },
+          ],
+        }),
       ]);
 
       ruleTester.run('no-duplicates', rule, {


### PR DESCRIPTION
…refer-inline

Fixes #2834

I would expect that when using [no-duplicates](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md) with "prefer-inline" option, the following would be detected as an error:

```ts
import type { Type } from "mod";
import { value } from "mod";
```

And would fix to:

```ts
import { type Type, value } from "mod";
```