### PR TITLE
[import/no-unused-modules] Report error on export specifier node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`order`]: partial fix for [#2687] (thanks [@ljharb])
 - [`no-duplicates`]: Detect across type and regular imports ([#2835], thanks [@benkrejci])
 - [`extensions`]: handle `.` and `..` properly ([#2778], thanks [@benasher44])
- - [`no-unused-modules`]: improve schema (thanks [@ljharb])
+- [`no-unused-modules`]: improve schema (thanks [@ljharb])
+- [`no-unused-modules`]: report error on binding instead of parent export ([#2842], thanks [@Chamion])
 
 ### Changed
 - [Docs] [`no-duplicates`]: fix example schema ([#2684], thanks [@simmo])
@@ -1076,6 +1077,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2842]: https://github.com/import-js/eslint-plugin-import/pull/2842
 [#2835]: https://github.com/import-js/eslint-plugin-import/pull/2835
 [#2832]: https://github.com/import-js/eslint-plugin-import/pull/2832
 [#2778]: https://github.com/import-js/eslint-plugin-import/pull/2778
@@ -1666,6 +1668,7 @@ for info on changes for earlier releases.
 [@bradzacher]: https://github.com/bradzacher
 [@brendo]: https://github.com/brendo
 [@brettz9]: https://github.com/brettz9
+[@Chamion]: https://github.com/Chamion
 [@charlessuh]: https://github.com/charlessuh
 [@charpeni]: https://github.com/charpeni
 [@cherryblossom000]: https://github.com/cherryblossom000

--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -931,7 +931,7 @@ module.exports = {
       },
       ExportNamedDeclaration(node) {
         node.specifiers.forEach((specifier) => {
-          checkUsage(node, specifier.exported.name || specifier.exported.value);
+          checkUsage(specifier, specifier.exported.name || specifier.exported.value);
         });
         forEachDeclarationIdentifier(node.declaration, (name) => {
           checkUsage(node, name);

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -164,24 +164,38 @@ ruleTester.run('no-unused-modules', rule, {
   invalid: [
     test({
       options: unusedExportsOptions,
-      code: `import eslint from 'eslint'
-           import fileA from './file-a'
-           import { b } from './file-b'
-           import { c1, c2 } from './file-c'
-           import { d } from './file-d'
-           import { e } from './file-e'
-           import { e2 } from './file-e'
-           import { h2 } from './file-h'
-           import * as l from './file-l'
-           export * from './file-n'
-           export { default, o0, o3 } from './file-o'
-           export { p } from './file-p'
-           import s from './file-s'`,
+      code: `
+        import eslint from 'eslint'
+        import fileA from './file-a'
+        import { b } from './file-b'
+        import { c1, c2 } from './file-c'
+        import { d } from './file-d'
+        import { e } from './file-e'
+        import { e2 } from './file-e'
+        import { h2 } from './file-h'
+        import * as l from './file-l'
+        export * from './file-n'
+        export { default, o0, o3 } from './file-o'
+        export { p } from './file-p'
+        import s from './file-s'
+      `,
       filename: testFilePath('./no-unused-modules/file-0.js'),
       errors: [
-        error(`exported declaration 'default' not used within other modules`),
-        error(`exported declaration 'o0' not used within other modules`),
-        error(`exported declaration 'o3' not used within other modules`),
+        {
+          message: `exported declaration 'default' not used within other modules`,
+          line: 12,
+          column: 9,
+        },
+        {
+          message: `exported declaration 'o0' not used within other modules`,
+          line: 12,
+          column: 9,
+        },
+        {
+          message: `exported declaration 'o3' not used within other modules`,
+          line: 12,
+          column: 9,
+        },
         error(`exported declaration 'p' not used within other modules`),
       ],
     }),

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -184,17 +184,17 @@ ruleTester.run('no-unused-modules', rule, {
         {
           message: `exported declaration 'default' not used within other modules`,
           line: 12,
-          column: 9,
+          column: 18,
         },
         {
           message: `exported declaration 'o0' not used within other modules`,
           line: 12,
-          column: 9,
+          column: 27,
         },
         {
           message: `exported declaration 'o3' not used within other modules`,
           line: 12,
-          column: 9,
+          column: 31,
         },
         error(`exported declaration 'p' not used within other modules`),
       ],


### PR DESCRIPTION
I noticed when an export declaration has multiple specifiers of which only a subset is unused the rule reports the error on the whole statement. In my code editor this draws a red squiggly under the whole statement. I can read which specifier is unused from the message of the reported error. Wouldn't it be nicer if the error was reported only on the specifier that is unused? That way I wouldn't necessarily need to even read and can let the red squiggly lead my monkey brain.

Consider the following export declaration

```js
export { foo, bar } from './foo';
```

Assume `foo` is used, `bar` is unused. Usually the fix would be to remove `bar`. I'd expect the reported error to point to that node as it would make it slightly more intuitive to attack it directly.

I'd imagine this change isn't breaking as the same errors still get reported for the same reasons, just pointing to different nodes.

I couldn't think of a reason one would want the report on the parent declaration instead but if there is one please educate me.

I changed the test assertions that have to do with a declaration that has multiple specifiers to also assert a specific location for the reported errors. I changed the node the errors are reported on to make the tests pass again. I then reverted the test changes because CI disagreed even though they passed locally :shrug:.