### PR TITLE
[Docs] remove duplicate fixable notices in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## [Unreleased]
 
+### Changed
+- [Docs] remove duplicate fixable notices in docs ([#2850], thanks [@bmish])
+
 ## [2.28.0] - 2023-07-27
 
 ### Fixed
@@ -1079,6 +1082,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2850]: https://github.com/import-js/eslint-plugin-import/pull/2850
 [#2842]: https://github.com/import-js/eslint-plugin-import/pull/2842
 [#2835]: https://github.com/import-js/eslint-plugin-import/pull/2835
 [#2832]: https://github.com/import-js/eslint-plugin-import/pull/2832

--- a/docs/rules/newline-after-import.md
+++ b/docs/rules/newline-after-import.md
@@ -5,11 +5,10 @@
 <!-- end auto-generated rule header -->
 
 Enforces having one or more empty lines after the last top-level import statement or require call.
-+(fixable) The `--fix` option on the [command line] automatically fixes problems reported by this rule.
 
 ## Rule Details
 
-This rule supports the following options: 
+This rule supports the following options:
 - `count` which sets the number of newlines that are enforced after the last top-level import statement or require call. This option defaults to `1`.
 
 - `considerComments` which enforces the rule on comments after the last import-statement as well when set to true. This option defaults to `false`.

--- a/docs/rules/no-duplicates.md
+++ b/docs/rules/no-duplicates.md
@@ -7,7 +7,6 @@
 <!-- end auto-generated rule header -->
 
 Reports if a resolved path is imported more than once.
-+(fixable) The `--fix` option on the [command line] automatically fixes some problems reported by this rule.
 
 ESLint core has a similar rule ([`no-duplicate-imports`](https://eslint.org/docs/rules/no-duplicate-imports)), but this version
 is different in two key ways:

--- a/docs/rules/no-namespace.md
+++ b/docs/rules/no-namespace.md
@@ -6,8 +6,7 @@
 
 Enforce a convention of not using namespace (a.k.a. "wildcard" `*`) imports.
 
-+(fixable) The `--fix` option on the [command line] automatically fixes problems reported by this rule, provided that the namespace object is only used for direct member access, e.g. `namespace.a`.
-The `--fix` functionality for this rule requires ESLint 5 or newer.
+The rule is auto-fixable when the namespace object is only used for direct member access, e.g. `namespace.a`.
 
 ### Options
 

--- a/docs/rules/no-relative-packages.md
+++ b/docs/rules/no-relative-packages.md
@@ -9,8 +9,6 @@ Use this rule to prevent importing packages through relative paths.
 It's useful in Yarn/Lerna workspaces, were it's possible to import a sibling
 package using `../package` relative path, while direct `package` is the correct one.
 
-+(fixable) The `--fix` option on the [command line] automatically fixes problems reported by this rule.
-
 ### Examples
 
 Given the following folder structure:

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -5,7 +5,6 @@
 <!-- end auto-generated rule header -->
 
 Enforce a convention in the order of `require()` / `import` statements.
-+(fixable) The `--fix` option on the [command line] automatically fixes problems reported by this rule.
 
 With the [`groups`](#groups-array) option set to `["builtin", "external", "internal", "parent", "sibling", "index", "object", "type"]` the order is as shown in the following example:
 


### PR DESCRIPTION
I noticed this issue randomly.

The automatic fixable notices are already handled by eslint-doc-generator from:
* https://github.com/import-js/eslint-plugin-import/pull/2582.