### PR TITLE
[New] TypeScript config: add .cts and .mts extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## [Unreleased]
 
+### Added
+- TypeScript config: add .cts and .mts extensions ([#2851], thanks [@Zamiell])
+
 ## [2.28.1] - 2023-08-18
 
 ### Fixed
@@ -1088,6 +1091,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#2854]: https://github.com/import-js/eslint-plugin-import/pull/2854
+[#2851]: https://github.com/import-js/eslint-plugin-import/pull/2851
 [#2850]: https://github.com/import-js/eslint-plugin-import/pull/2850
 [#2842]: https://github.com/import-js/eslint-plugin-import/pull/2842
 [#2835]: https://github.com/import-js/eslint-plugin-import/pull/2835
@@ -1896,4 +1900,5 @@ for info on changes for earlier releases.
 [@xpl]: https://github.com/xpl
 [@yndajas]: https://github.com/yndajas
 [@yordis]: https://github.com/yordis
+[@Zamiell]: https://github.com/Zamiell
 [@zloirock]: https://github.com/zloirock

--- a/config/typescript.js
+++ b/config/typescript.js
@@ -1,19 +1,22 @@
 /**
- * Adds `.jsx`, `.ts` and `.tsx` as an extension, and enables JSX/TSX parsing.
+ * This config:
+ * 1) adds `.jsx`, `.ts`, `.cts`, `.mts`, and `.tsx` as an extension
+ * 2) enables JSX/TSX parsing
  */
 
 // Omit `.d.ts` because 1) TypeScript compilation already confirms that
 // types are resolved, and 2) it would mask an unresolved
 // `.ts`/`.tsx`/`.js`/`.jsx` implementation.
-const allExtensions = ['.ts', '.tsx', '.js', '.jsx'];
+const typeScriptExtensions = ['.ts', '.cts', '.mts', '.tsx'];
+
+const allExtensions = [...typeScriptExtensions, '.js', '.jsx'];
 
 module.exports = {
-
   settings: {
     'import/extensions': allExtensions,
     'import/external-module-folders': ['node_modules', 'node_modules/@types'],
     'import/parsers': {
-      '@typescript-eslint/parser': ['.ts', '.tsx'],
+      '@typescript-eslint/parser': typeScriptExtensions,
     },
     'import/resolver': {
       node: {


### PR DESCRIPTION
This PR is pretty self explanatory.
`.cts` and `.mts` are common file extensions used in projects that are not fully CJS or not fully ESM.
So I added those to the config.
I also fixed some of the grammar and made the comments wrap to 100 characters.