### PR TITLE
Support 'node:' prefix in import/require statements. 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
     "plugins": [
         "eslint-plugin",
         "import",
+        "prefer-node-builtin-imports",
     ],
     "extends": [
         "eslint:recommended",
@@ -114,6 +115,7 @@
         }],
         "prefer-const": 2,
         "prefer-object-spread": 2,
+        "prefer-node-builtin-imports": 1,
         "prefer-rest-params": 2,
         "prefer-template": 2,
         "quote-props": [2, "as-needed", { "keywords": false }],

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "eslint-plugin-eslint-plugin": "^2.3.0",
     "eslint-plugin-import": "2.x",
     "eslint-plugin-json": "^2.1.2",
+    "eslint-plugin-prefer-node-builtin-imports": "^0.0.3",
     "fs-copy-file-sync": "^1.1.1",
     "glob": "^7.2.3",
     "in-publish": "^2.0.1",


### PR DESCRIPTION
Added plugin 'prefer-node-builtin-imports'. 
The plugin is based on 'prefer-node-protocol' rule from 'eslint-plugin-unicorn' plugin. 
This plugin has 0 dependencies and is very minimalistic. All test cases are copied from [eslint-plugin-unicorn_test](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/test/prefer-node-protocol.mjs)

