### PR TITLE
[Fix] `order`: do not compare first path segment for relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`no-cycle`]: use scc algorithm to optimize ([#2998], thanks [@soryy708])
 - [`no-duplicates`]: Removing duplicates breaks in TypeScript ([#3033], thanks [@yesl-kim])
 - [`newline-after-import`]: fix considerComments option when require ([#2952], thanks [@developer-bandi])
+- [`order`]: do not compare first path segment for relative paths ([#2682]) ([#2885], thanks [@mihkeleidast])
 
 ### Changed
 - [Docs] `no-extraneous-dependencies`: Make glob pattern description more explicit ([#2944], thanks [@mulztob])
@@ -1141,6 +1142,7 @@ for info on changes for earlier releases.
 [#2944]: https://github.com/import-js/eslint-plugin-import/pull/2944
 [#2942]: https://github.com/import-js/eslint-plugin-import/pull/2942
 [#2919]: https://github.com/import-js/eslint-plugin-import/pull/2919
+[#2885]: https://github.com/import-js/eslint-plugin-import/pull/2885
 [#2884]: https://github.com/import-js/eslint-plugin-import/pull/2884
 [#2866]: https://github.com/import-js/eslint-plugin-import/pull/2866
 [#2854]: https://github.com/import-js/eslint-plugin-import/pull/2854
@@ -1486,6 +1488,7 @@ for info on changes for earlier releases.
 [#2930]: https://github.com/import-js/eslint-plugin-import/issues/2930
 [#2687]: https://github.com/import-js/eslint-plugin-import/issues/2687
 [#2684]: https://github.com/import-js/eslint-plugin-import/issues/2684
+[#2682]: https://github.com/import-js/eslint-plugin-import/issues/2682
 [#2674]: https://github.com/import-js/eslint-plugin-import/issues/2674
 [#2668]: https://github.com/import-js/eslint-plugin-import/issues/2668
 [#2666]: https://github.com/import-js/eslint-plugin-import/issues/2666
@@ -1880,6 +1883,7 @@ for info on changes for earlier releases.
 [@mgwalker]: https://github.com/mgwalker
 [@mhmadhamster]: https://github.com/MhMadHamster
 [@michaelfaith]: https://github.com/michaelfaith
+[@mihkeleidast]: https://github.com/mihkeleidast
 [@MikeyBeLike]: https://github.com/MikeyBeLike
 [@minervabot]: https://github.com/minervabot
 [@mpint]: https://github.com/mpint

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -302,6 +302,12 @@ function getSorter(alphabetizeOptions) {
       const b = B.length;
 
       for (let i = 0; i < Math.min(a, b); i++) {
+        // Skip comparing the first path segment, if they are relative segments for both imports
+        if (i === 0 && ((A[i] === '.' || A[i] === '..') && (B[i] === '.' || B[i] === '..'))) {
+          // If one is sibling and the other parent import, no need to compare at all, since the paths belong in different groups
+          if (A[i] !== B[i]) { break; }
+          continue;
+        }
         result = compareString(A[i], B[i]);
         if (result) { break; }
       }

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -169,6 +169,34 @@ ruleTester.run('order', rule, {
         ['sibling', 'parent', 'external'],
       ] }],
     }),
+    // Grouping import types and alphabetize
+    test({
+      code: `
+        import async from 'async';
+        import fs from 'fs';
+        import path from 'path';
+
+        import index from '.';
+        import relParent3 from '../';
+        import relParent1 from '../foo';
+        import sibling from './foo';
+      `,
+      options: [{ groups: [
+        ['builtin', 'external'],
+      ], alphabetize: { order: 'asc', caseInsensitive: true } }],
+    }),
+    test({
+      code: `
+      import { fooz } from '../baz.js'
+      import { foo } from './bar.js'
+      `,
+      options: [{
+        alphabetize: { order: 'asc', caseInsensitive: true },
+        groups: ['builtin', 'external', 'internal', ['parent', 'sibling', 'index'], 'object'],
+        'newlines-between': 'always',
+        warnOnUnassignedImports: true,
+      }],
+    }),
     // Omitted types should implicitly be considered as the last type
     test({
       code: `


### PR DESCRIPTION
Should fix the regression in #2682.

The gist of the fix is that for relative paths, siblings always start with "." and parents always start with "..".  When comparing them, it will always result in "." being first, which was the bug. The sorting based on subpath segments should start from the second path segment, when there is a possibility that one of them is different.