### PR TITLE
fix: changed resolvedPath check to check if its not a string

### DIFF
--- a/src/rules/no-useless-path-segments.js
+++ b/src/rules/no-useless-path-segments.js
@@ -115,7 +115,7 @@ module.exports = {
       }
 
       // Path is not existing --> Return directly (following code requires path to be defined)
-      if (resolvedPath === undefined) {
+      if (typeof resolvedPath !== "string") {
         return;
       }
 


### PR DESCRIPTION
The "eslint-module-utils/resolve" returns 3 different types

- the full module filesystem path
- null if package is core
- undefined if not found

if null is returned from the resolve function the path.relative throws a error that i expects a string

> TypeError [ERR_INVALID_ARG_TYPE]: The "to" argument must be of type string. Received null

Data passed into the resolve function.

```
resolve("../dist/postinstall", {
  id: 'import/no-useless-path-segments',
  options: [ { commonjs: true, noUselessIndex: true } ],
  report: [Function: report]
});
```
