### PR TITLE
[Fix] `no-extraneous-dependencies`: ignore `export type { ... } from '...'` when `includeTypes` is `false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## [Unreleased]
 
+### Fixed
+- [`no-extraneous-dependencies`]: ignore `export type { ... } from '...'` when `includeTypes` is `false` ([#2919], thanks [@Pandemic1617])
+
 ## [2.29.0] - 2023-10-22
 
 ### Added
@@ -1094,6 +1097,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2919]: https://github.com/import-js/eslint-plugin-import/pull/2919
 [#2884]: https://github.com/import-js/eslint-plugin-import/pull/2884
 [#2854]: https://github.com/import-js/eslint-plugin-import/pull/2854
 [#2851]: https://github.com/import-js/eslint-plugin-import/pull/2851
@@ -1830,6 +1834,7 @@ for info on changes for earlier releases.
 [@ntdb]: https://github.com/ntdb
 [@nwalters512]: https://github.com/nwalters512
 [@ombene]: https://github.com/ombene
+[@Pandemic1617]: https://github.com/Pandemic1617
 [@ota-meshi]: https://github.com/ota-meshi
 [@OutdatedVersion]: https://github.com/OutdatedVersion
 [@panrafal]: https://github.com/panrafal

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -177,6 +177,7 @@ function reportIfMissing(context, deps, depsOptions, node, name) {
     && (
       node.importKind === 'type'
       || node.importKind === 'typeof'
+      || node.exportKind === 'type'
       || Array.isArray(node.specifiers) && node.specifiers.length && node.specifiers.every((specifier) => specifier.importKind === 'type' || specifier.importKind === 'typeof')
     )
   ) {

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -427,6 +427,18 @@ describe('TypeScript', () => {
             options: [{ packageDir: packageDirWithTypescriptDevDependencies, devDependencies: false }],
             ...parserConfig,
           }),
+
+          test({
+            code: 'import type { T } from "a"; export type { T };',
+            options: [{ packageDir: packageDirWithTypescriptDevDependencies, devDependencies: false }],
+            ...parserConfig,
+          }),
+
+          test({
+            code: 'export type { T } from "a";',
+            options: [{ packageDir: packageDirWithTypescriptDevDependencies, devDependencies: false }],
+            ...parserConfig,
+          }),
         ],
         invalid: [
           test({


### PR DESCRIPTION
## Summary

The `no-extraneous-dependencies` rule still checks a the dependency of `export type { T } from 'a-dev-dependency'` even when it is supposed to exclude type only imports

## Example
This triggers an error
```typescript
export type { T } from "a-dev-dependency";
``` 


This doesn't
```typescript
import type { T } from "a-dev-dependency"; 
export type { T };
``` 

`package.json`
```json
{
    "devDependencies": {
        "a-dev-dependency": "*"
    }
}
```
rule:
```json
{
    "devDependencies": false,
    "includeTypes": false // false by default
 }
```

## Fix

Check if the export statement's kind is `type` and if so, treat it like an `import type` statement.
