### PR TITLE
[Fix] `newline-after-import`: fix `considerComments` option when require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`no-extraneous-dependencies`]: allow wrong path ([#3012], thanks [@chabb])
 - [`no-cycle`]: use scc algorithm to optimize ([#2998], thanks [@soryy708])
 - [`no-duplicates`]: Removing duplicates breaks in TypeScript ([#3033], thanks [@yesl-kim])
+- [`newline-after-import`]: fix considerComments option when require ([#2952], thanks [@developer-bandi])
 
 ### Changed
 - [Docs] `no-extraneous-dependencies`: Make glob pattern description more explicit ([#2944], thanks [@mulztob])
@@ -1136,6 +1137,7 @@ for info on changes for earlier releases.
 [#2987]: https://github.com/import-js/eslint-plugin-import/pull/2987
 [#2985]: https://github.com/import-js/eslint-plugin-import/pull/2985
 [#2982]: https://github.com/import-js/eslint-plugin-import/pull/2982
+[#2952]: https://github.com/import-js/eslint-plugin-import/pull/2952
 [#2944]: https://github.com/import-js/eslint-plugin-import/pull/2944
 [#2942]: https://github.com/import-js/eslint-plugin-import/pull/2942
 [#2919]: https://github.com/import-js/eslint-plugin-import/pull/2919
@@ -1742,6 +1744,7 @@ for info on changes for earlier releases.
 [@bicstone]: https://github.com/bicstone
 [@Blasz]: https://github.com/Blasz
 [@bmish]: https://github.com/bmish
+[@developer-bandi]: https://github.com/developer-bandi
 [@borisyankov]: https://github.com/borisyankov
 [@bradennapier]: https://github.com/bradennapier
 [@bradzacher]: https://github.com/bradzacher

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -8,6 +8,7 @@ import { getTSParsers, parsers, testVersion } from '../utils';
 const IMPORT_ERROR_MESSAGE = 'Expected 1 empty line after import statement not followed by another import.';
 const IMPORT_ERROR_MESSAGE_MULTIPLE = (count) => `Expected ${count} empty lines after import statement not followed by another import.`;
 const REQUIRE_ERROR_MESSAGE = 'Expected 1 empty line after require statement not followed by another require.';
+const REQUIRE_ERROR_MESSAGE_MULTIPLE = (count) => `Expected ${count} empty lines after require statement not followed by another require.`;
 
 const ruleTester = new RuleTester();
 
@@ -202,7 +203,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       options: [{ count: 4, exactCount: true }],
     },
     {
-      code: `var foo = require('foo-module');\n\n\n\n// Some random comment\nvar foo = 'bar';`,
+      code: `var foo = require('foo-module');\n\n\n\n\n// Some random comment\nvar foo = 'bar';`,
       parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
       options: [{ count: 4, exactCount: true, considerComments: true }],
     },
@@ -393,6 +394,19 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         var bar = 42;
       `,
       parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+    },
+    {
+      code: `var foo = require('foo-module');\n\n\n// Some random comment\nvar foo = 'bar';`,
+      options: [{ count: 2, considerComments: true }],
+    },
+    {
+      code: `var foo = require('foo-module');\n\n\n/**\n * Test comment\n */\nvar foo = 'bar';`,
+      options: [{ count: 2, considerComments: true }],
+    },
+    {
+      code: `const foo = require('foo');\n\n\n// some random comment\nconst bar = function() {};`,
+      options: [{ count: 2, exactCount: true, considerComments: true }],
+      parserOptions: { ecmaVersion: 2015 },
     },
   ),
 
@@ -825,7 +839,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       errors: [{
         line: 1,
         column: 1,
-        message: 'Expected 2 empty lines after require statement not followed by another require.',
+        message: REQUIRE_ERROR_MESSAGE_MULTIPLE(2),
       }],
       parserOptions: { ecmaVersion: 2015 },
     },
@@ -836,7 +850,7 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       errors: [{
         line: 1,
         column: 1,
-        message: 'Expected 2 empty lines after require statement not followed by another require.',
+        message: REQUIRE_ERROR_MESSAGE_MULTIPLE(2),
       }],
       parserOptions: { ecmaVersion: 2015 },
     },
@@ -852,14 +866,26 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       parserOptions: { ecmaVersion: 2015, considerComments: true, sourceType: 'module' },
     },
     {
-      code: `const foo = require('foo');\n\n\n// some random comment\nconst bar = function() {};`,
-      options: [{ count: 2, exactCount: true, considerComments: true }],
+      code: `var foo = require('foo-module');\nvar foo = require('foo-module');\n\n// Some random comment\nvar foo = 'bar';`,
+      output: `var foo = require('foo-module');\nvar foo = require('foo-module');\n\n\n// Some random comment\nvar foo = 'bar';`,
+      errors: [{
+        line: 2,
+        column: 1,
+        message: REQUIRE_ERROR_MESSAGE_MULTIPLE(2),
+      }],
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+      options: [{ considerComments: true, count: 2 }],
+    },
+    {
+      code: `var foo = require('foo-module');\n\n/**\n * Test comment\n */\nvar foo = 'bar';`,
+      output: `var foo = require('foo-module');\n\n\n/**\n * Test comment\n */\nvar foo = 'bar';`,
       errors: [{
         line: 1,
         column: 1,
-        message: 'Expected 2 empty lines after require statement not followed by another require.',
+        message: REQUIRE_ERROR_MESSAGE_MULTIPLE(2),
       }],
       parserOptions: { ecmaVersion: 2015 },
+      options: [{ considerComments: true, count: 2 }],
     },
   ),
 });


### PR DESCRIPTION
fix #2905 

- new var in test file  use multiple space when require
- fix or remove invalid test cases
- add feature considerComments is applied normally when use require 