### PR TITLE
[Fix/New] Node resolver: Try to use `require.resolve` when suitable

### DIFF
--- a/resolvers/node/index.js
+++ b/resolvers/node/index.js
@@ -60,6 +60,19 @@ exports.resolve = function (source, file, config) {
     return { found: true, path: null };
   }
 
+  // If this looks like a bare package name (not relative, not qualified
+  // with an extension) and we're on a fresh enough version of Node.js
+  // to have `require.resolve`, attempt that first.
+  if (require.resolve && source.indexOf('.') === -1) {
+    try {
+      resolvedPath = require.resolve(source);
+      log('Resolved to:', resolvedPath);
+      return { found: true, path: resolvedPath };
+    } catch (err) {
+      log('require.resolve threw error:', err);
+    }
+  }
+
   try {
     const cachedFilter = function (pkg, pkgFileOrDir, maybeDir) { return packageFilter(pkg, maybeDir || pkgFileOrDir, config); };
     resolvedPath = resolve(source, opts(file, config, cachedFilter));


### PR DESCRIPTION
This PR proposes to have the Node resolver use [`require.resolve`](https://nodejs.org/api/modules.html#requireresolverequest-options) when possible; among other things, this enables support for packages that only have `exports.main` (when the underlying Node.js version supports them) (see https://github.com/import-js/eslint-plugin-import/issues/2132).

I don't know if there are subtleties to this, but I feel like this could work.