### PR TITLE
[Fix] import/order: Support side-effect modules

### DIFF
--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -162,7 +162,7 @@ function isSupportedRequireModule(node) {
 }
 
 function isPlainImportModule(node) {
-  return node.type === 'ImportDeclaration' && node.specifiers != null && node.specifiers.length > 0;
+  return node.type === 'ImportDeclaration' && node.specifiers != null && node.specifiers.length >= 0;
 }
 
 function isPlainImportEquals(node) {


### PR DESCRIPTION
Per the spec, imports without specifiers are valid, and `import/order` should be able to sort them.

Spec:
https://tc39.es/ecma262/#table-import-forms-mapping-to-importentry-records

MDN:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#import_a_module_for_its_side_effects_only