### PR TITLE
resolve lint warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -237,6 +237,16 @@
         },
         {
             "files": [
+                "resolvers/webpack/index.js",
+                "resolvers/webpack/test/example.js",
+                "utils/parse.js",
+            ],
+            "rules": {
+                "no-console": "off",
+            },
+        },
+        {
+            "files": [
                 "resolvers/*/test/**/*",
             ],
             "env": {


### PR DESCRIPTION
When running the tests / ci, ESLint complains about warnings related to the `no-console` rule.

The places where we have that console make sense to have console, so it's a false-positive.

Lets mark those specific places to be ignored by eslint, to reduce noise from the linter output.