### PR TITLE
separate export map from its builder

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -229,7 +229,7 @@
         {
             "files": [
                 "utils/**", // TODO
-                "src/ExportMap.js", // TODO
+                "src/exportMapBuilder.js", // TODO
             ],
             "rules": {
                 "no-use-before-define": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [Docs] `no-extraneous-dependencies`: Make glob pattern description more explicit ([#2944], thanks [@mulztob])
 - [`no-unused-modules`]: add console message to help debug [#2866]
 - [Refactor] `ExportMap`: make procedures static instead of monkeypatching exportmap ([#2982], thanks [@soryy708])
+- [Refactor] `ExportMap`: separate ExportMap instance from its builder logic ([#2985], thanks [@soryy708])
 
 ## [2.29.1] - 2023-12-14
 
@@ -1109,6 +1110,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2985]: https://github.com/import-js/eslint-plugin-import/pull/2985
 [#2982]: https://github.com/import-js/eslint-plugin-import/pull/2982
 [#2944]: https://github.com/import-js/eslint-plugin-import/pull/2944
 [#2942]: https://github.com/import-js/eslint-plugin-import/pull/2942

--- a/src/exportMap.js
+++ b/src/exportMap.js
@@ -1,0 +1,178 @@
+export default class ExportMap {
+  constructor(path) {
+    this.path = path;
+    this.namespace = new Map();
+    // todo: restructure to key on path, value is resolver + map of names
+    this.reexports = new Map();
+    /**
+     * star-exports
+     * @type {Set<() => ExportMap>}
+     */
+    this.dependencies = new Set();
+    /**
+     * dependencies of this module that are not explicitly re-exported
+     * @type {Map<string, () => ExportMap>}
+     */
+    this.imports = new Map();
+    this.errors = [];
+    /**
+     * type {'ambiguous' | 'Module' | 'Script'}
+     */
+    this.parseGoal = 'ambiguous';
+  }
+
+  get hasDefault() { return this.get('default') != null; } // stronger than this.has
+
+  get size() {
+    let size = this.namespace.size + this.reexports.size;
+    this.dependencies.forEach((dep) => {
+      const d = dep();
+      // CJS / ignored dependencies won't exist (#717)
+      if (d == null) { return; }
+      size += d.size;
+    });
+    return size;
+  }
+
+  /**
+   * Note that this does not check explicitly re-exported names for existence
+   * in the base namespace, but it will expand all `export * from '...'` exports
+   * if not found in the explicit namespace.
+   * @param  {string}  name
+   * @return {boolean} true if `name` is exported by this module.
+   */
+  has(name) {
+    if (this.namespace.has(name)) { return true; }
+    if (this.reexports.has(name)) { return true; }
+
+    // default exports must be explicitly re-exported (#328)
+    if (name !== 'default') {
+      for (const dep of this.dependencies) {
+        const innerMap = dep();
+
+        // todo: report as unresolved?
+        if (!innerMap) { continue; }
+
+        if (innerMap.has(name)) { return true; }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * ensure that imported name fully resolves.
+   * @param  {string} name
+   * @return {{ found: boolean, path: ExportMap[] }}
+   */
+  hasDeep(name) {
+    if (this.namespace.has(name)) { return { found: true, path: [this] }; }
+
+    if (this.reexports.has(name)) {
+      const reexports = this.reexports.get(name);
+      const imported = reexports.getImport();
+
+      // if import is ignored, return explicit 'null'
+      if (imported == null) { return { found: true, path: [this] }; }
+
+      // safeguard against cycles, only if name matches
+      if (imported.path === this.path && reexports.local === name) {
+        return { found: false, path: [this] };
+      }
+
+      const deep = imported.hasDeep(reexports.local);
+      deep.path.unshift(this);
+
+      return deep;
+    }
+
+    // default exports must be explicitly re-exported (#328)
+    if (name !== 'default') {
+      for (const dep of this.dependencies) {
+        const innerMap = dep();
+        if (innerMap == null) { return { found: true, path: [this] }; }
+        // todo: report as unresolved?
+        if (!innerMap) { continue; }
+
+        // safeguard against cycles
+        if (innerMap.path === this.path) { continue; }
+
+        const innerValue = innerMap.hasDeep(name);
+        if (innerValue.found) {
+          innerValue.path.unshift(this);
+          return innerValue;
+        }
+      }
+    }
+
+    return { found: false, path: [this] };
+  }
+
+  get(name) {
+    if (this.namespace.has(name)) { return this.namespace.get(name); }
+
+    if (this.reexports.has(name)) {
+      const reexports = this.reexports.get(name);
+      const imported = reexports.getImport();
+
+      // if import is ignored, return explicit 'null'
+      if (imported == null) { return null; }
+
+      // safeguard against cycles, only if name matches
+      if (imported.path === this.path && reexports.local === name) { return undefined; }
+
+      return imported.get(reexports.local);
+    }
+
+    // default exports must be explicitly re-exported (#328)
+    if (name !== 'default') {
+      for (const dep of this.dependencies) {
+        const innerMap = dep();
+        // todo: report as unresolved?
+        if (!innerMap) { continue; }
+
+        // safeguard against cycles
+        if (innerMap.path === this.path) { continue; }
+
+        const innerValue = innerMap.get(name);
+        if (innerValue !== undefined) { return innerValue; }
+      }
+    }
+
+    return undefined;
+  }
+
+  forEach(callback, thisArg) {
+    this.namespace.forEach((v, n) => { callback.call(thisArg, v, n, this); });
+
+    this.reexports.forEach((reexports, name) => {
+      const reexported = reexports.getImport();
+      // can't look up meta for ignored re-exports (#348)
+      callback.call(thisArg, reexported && reexported.get(reexports.local), name, this);
+    });
+
+    this.dependencies.forEach((dep) => {
+      const d = dep();
+      // CJS / ignored dependencies won't exist (#717)
+      if (d == null) { return; }
+
+      d.forEach((v, n) => {
+        if (n !== 'default') {
+          callback.call(thisArg, v, n, this);
+        }
+      });
+    });
+  }
+
+  // todo: keys, values, entries?
+
+  reportErrors(context, declaration) {
+    const msg = this.errors
+      .map((e) => `${e.message} (${e.lineNumber}:${e.column})`)
+      .join(', ');
+    context.report({
+      node: declaration.source,
+      message: `Parse errors in imported module '${declaration.source.value}': ${msg}`,
+    });
+  }
+}

--- a/src/exportMapBuilder.js
+++ b/src/exportMapBuilder.js
@@ -18,6 +18,7 @@ import * as unambiguous from 'eslint-module-utils/unambiguous';
 import { tsConfigLoader } from 'tsconfig-paths/lib/tsconfig-loader';
 
 import includes from 'array-includes';
+import ExportMap from './exportMap';
 
 let ts;
 
@@ -117,189 +118,12 @@ const availableDocStyleParsers = {
 
 const supportedImportTypes = new Set(['ImportDefaultSpecifier', 'ImportNamespaceSpecifier']);
 
-export default class ExportMap {
-  constructor(path) {
-    this.path = path;
-    this.namespace = new Map();
-    // todo: restructure to key on path, value is resolver + map of names
-    this.reexports = new Map();
-    /**
-     * star-exports
-     * @type {Set} of () => ExportMap
-     */
-    this.dependencies = new Set();
-    /**
-     * dependencies of this module that are not explicitly re-exported
-     * @type {Map} from path = () => ExportMap
-     */
-    this.imports = new Map();
-    this.errors = [];
-    /**
-     * type {'ambiguous' | 'Module' | 'Script'}
-     */
-    this.parseGoal = 'ambiguous';
-  }
-
-  get hasDefault() { return this.get('default') != null; } // stronger than this.has
-
-  get size() {
-    let size = this.namespace.size + this.reexports.size;
-    this.dependencies.forEach((dep) => {
-      const d = dep();
-      // CJS / ignored dependencies won't exist (#717)
-      if (d == null) { return; }
-      size += d.size;
-    });
-    return size;
-  }
-
-  /**
-   * Note that this does not check explicitly re-exported names for existence
-   * in the base namespace, but it will expand all `export * from '...'` exports
-   * if not found in the explicit namespace.
-   * @param  {string}  name
-   * @return {Boolean} true if `name` is exported by this module.
-   */
-  has(name) {
-    if (this.namespace.has(name)) { return true; }
-    if (this.reexports.has(name)) { return true; }
-
-    // default exports must be explicitly re-exported (#328)
-    if (name !== 'default') {
-      for (const dep of this.dependencies) {
-        const innerMap = dep();
-
-        // todo: report as unresolved?
-        if (!innerMap) { continue; }
-
-        if (innerMap.has(name)) { return true; }
-      }
-    }
-
-    return false;
-  }
-
-  /**
-   * ensure that imported name fully resolves.
-   * @param  {string} name
-   * @return {{ found: boolean, path: ExportMap[] }}
-   */
-  hasDeep(name) {
-    if (this.namespace.has(name)) { return { found: true, path: [this] }; }
-
-    if (this.reexports.has(name)) {
-      const reexports = this.reexports.get(name);
-      const imported = reexports.getImport();
-
-      // if import is ignored, return explicit 'null'
-      if (imported == null) { return { found: true, path: [this] }; }
-
-      // safeguard against cycles, only if name matches
-      if (imported.path === this.path && reexports.local === name) {
-        return { found: false, path: [this] };
-      }
-
-      const deep = imported.hasDeep(reexports.local);
-      deep.path.unshift(this);
-
-      return deep;
-    }
-
-    // default exports must be explicitly re-exported (#328)
-    if (name !== 'default') {
-      for (const dep of this.dependencies) {
-        const innerMap = dep();
-        if (innerMap == null) { return { found: true, path: [this] }; }
-        // todo: report as unresolved?
-        if (!innerMap) { continue; }
-
-        // safeguard against cycles
-        if (innerMap.path === this.path) { continue; }
-
-        const innerValue = innerMap.hasDeep(name);
-        if (innerValue.found) {
-          innerValue.path.unshift(this);
-          return innerValue;
-        }
-      }
-    }
-
-    return { found: false, path: [this] };
-  }
-
-  get(name) {
-    if (this.namespace.has(name)) { return this.namespace.get(name); }
-
-    if (this.reexports.has(name)) {
-      const reexports = this.reexports.get(name);
-      const imported = reexports.getImport();
-
-      // if import is ignored, return explicit 'null'
-      if (imported == null) { return null; }
-
-      // safeguard against cycles, only if name matches
-      if (imported.path === this.path && reexports.local === name) { return undefined; }
-
-      return imported.get(reexports.local);
-    }
-
-    // default exports must be explicitly re-exported (#328)
-    if (name !== 'default') {
-      for (const dep of this.dependencies) {
-        const innerMap = dep();
-        // todo: report as unresolved?
-        if (!innerMap) { continue; }
-
-        // safeguard against cycles
-        if (innerMap.path === this.path) { continue; }
-
-        const innerValue = innerMap.get(name);
-        if (innerValue !== undefined) { return innerValue; }
-      }
-    }
-
-    return undefined;
-  }
-
-  forEach(callback, thisArg) {
-    this.namespace.forEach((v, n) => { callback.call(thisArg, v, n, this); });
-
-    this.reexports.forEach((reexports, name) => {
-      const reexported = reexports.getImport();
-      // can't look up meta for ignored re-exports (#348)
-      callback.call(thisArg, reexported && reexported.get(reexports.local), name, this);
-    });
-
-    this.dependencies.forEach((dep) => {
-      const d = dep();
-      // CJS / ignored dependencies won't exist (#717)
-      if (d == null) { return; }
-
-      d.forEach((v, n) => {
-        if (n !== 'default') {
-          callback.call(thisArg, v, n, this);
-        }
-      });
-    });
-  }
-
-  // todo: keys, values, entries?
-
-  reportErrors(context, declaration) {
-    const msg = this.errors
-      .map((e) => `${e.message} (${e.lineNumber}:${e.column})`)
-      .join(', ');
-    context.report({
-      node: declaration.source,
-      message: `Parse errors in imported module '${declaration.source.value}': ${msg}`,
-    });
-  }
-
+export default class ExportMapBuilder {
   static get(source, context) {
     const path = resolve(source, context);
     if (path == null) { return null; }
 
-    return ExportMap.for(childContext(path, context));
+    return ExportMapBuilder.for(childContext(path, context));
   }
 
   static for(context) {
@@ -343,7 +167,7 @@ export default class ExportMap {
     }
 
     log('cache miss', cacheKey, 'for path', path);
-    exportMap = ExportMap.parse(path, content, context);
+    exportMap = ExportMapBuilder.parse(path, content, context);
 
     // ambiguous modules return null
     if (exportMap == null) {
@@ -447,7 +271,7 @@ export default class ExportMap {
     function resolveImport(value) {
       const rp = remotePath(value);
       if (rp == null) { return null; }
-      return ExportMap.for(childContext(rp, context));
+      return ExportMapBuilder.for(childContext(rp, context));
     }
 
     function getNamespace(identifier) {
@@ -738,7 +562,7 @@ export default class ExportMap {
  * caused memory leaks. See #1266.
  */
 function thunkFor(p, context) {
-  return () => ExportMap.for(childContext(p, context));
+  return () => ExportMapBuilder.for(childContext(p, context));
 }
 
 /**

--- a/src/rules/default.js
+++ b/src/rules/default.js
@@ -1,4 +1,4 @@
-import Exports from '../ExportMap';
+import ExportMapBuilder from '../exportMapBuilder';
 import docsUrl from '../docsUrl';
 
 module.exports = {
@@ -19,7 +19,7 @@ module.exports = {
       );
 
       if (!defaultSpecifier) { return; }
-      const imports = Exports.get(node.source.value, context);
+      const imports = ExportMapBuilder.get(node.source.value, context);
       if (imports == null) { return; }
 
       if (imports.errors.length) {

--- a/src/rules/export.js
+++ b/src/rules/export.js
@@ -1,4 +1,4 @@
-import ExportMap, { recursivePatternCapture } from '../ExportMap';
+import ExportMapBuilder, { recursivePatternCapture } from '../exportMapBuilder';
 import docsUrl from '../docsUrl';
 import includes from 'array-includes';
 import flatMap from 'array.prototype.flatmap';
@@ -197,7 +197,7 @@ module.exports = {
         // `export * as X from 'path'` does not conflict
         if (node.exported && node.exported.name) { return; }
 
-        const remoteExports = ExportMap.get(node.source.value, context);
+        const remoteExports = ExportMapBuilder.get(node.source.value, context);
         if (remoteExports == null) { return; }
 
         if (remoteExports.errors.length) {

--- a/src/rules/named.js
+++ b/src/rules/named.js
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import Exports from '../ExportMap';
+import ExportMapBuilder from '../exportMapBuilder';
 import docsUrl from '../docsUrl';
 
 module.exports = {
@@ -41,7 +41,7 @@ module.exports = {
         return; // no named imports/exports
       }
 
-      const imports = Exports.get(node.source.value, context);
+      const imports = ExportMapBuilder.get(node.source.value, context);
       if (imports == null || imports.parseGoal === 'ambiguous') {
         return;
       }
@@ -93,7 +93,7 @@ module.exports = {
       const call = node.init;
       const [source] = call.arguments;
       const variableImports = node.id.properties;
-      const variableExports = Exports.get(source.value, context);
+      const variableExports = ExportMapBuilder.get(source.value, context);
 
       if (
         // return if it's not a commonjs require statement

--- a/src/rules/namespace.js
+++ b/src/rules/namespace.js
@@ -1,5 +1,6 @@
 import declaredScope from 'eslint-module-utils/declaredScope';
-import Exports from '../ExportMap';
+import ExportMapBuilder from '../exportMapBuilder';
+import ExportMap from '../exportMap';
 import importDeclaration from '../importDeclaration';
 import docsUrl from '../docsUrl';
 
@@ -8,7 +9,7 @@ function processBodyStatement(context, namespaces, declaration) {
 
   if (declaration.specifiers.length === 0) { return; }
 
-  const imports = Exports.get(declaration.source.value, context);
+  const imports = ExportMapBuilder.get(declaration.source.value, context);
   if (imports == null) { return null; }
 
   if (imports.errors.length > 0) {
@@ -88,7 +89,7 @@ module.exports = {
       ExportNamespaceSpecifier(namespace) {
         const declaration = importDeclaration(context);
 
-        const imports = Exports.get(declaration.source.value, context);
+        const imports = ExportMapBuilder.get(declaration.source.value, context);
         if (imports == null) { return null; }
 
         if (imports.errors.length) {
@@ -122,7 +123,7 @@ module.exports = {
         let namespace = namespaces.get(dereference.object.name);
         const namepath = [dereference.object.name];
         // while property is namespace and parent is member expression, keep validating
-        while (namespace instanceof Exports && dereference.type === 'MemberExpression') {
+        while (namespace instanceof ExportMap && dereference.type === 'MemberExpression') {
           if (dereference.computed) {
             if (!allowComputed) {
               context.report(
@@ -161,7 +162,7 @@ module.exports = {
 
         // DFS traverse child namespaces
         function testKey(pattern, namespace, path = [init.name]) {
-          if (!(namespace instanceof Exports)) { return; }
+          if (!(namespace instanceof ExportMap)) { return; }
 
           if (pattern.type !== 'ObjectPattern') { return; }
 

--- a/src/rules/no-cycle.js
+++ b/src/rules/no-cycle.js
@@ -4,7 +4,7 @@
  */
 
 import resolve from 'eslint-module-utils/resolve';
-import Exports from '../ExportMap';
+import ExportMapBuilder from '../exportMapBuilder';
 import { isExternalModule } from '../core/importType';
 import moduleVisitor, { makeOptionsSchema } from 'eslint-module-utils/moduleVisitor';
 import docsUrl from '../docsUrl';
@@ -88,7 +88,7 @@ module.exports = {
         return; // ignore type imports
       }
 
-      const imported = Exports.get(sourceNode.value, context);
+      const imported = ExportMapBuilder.get(sourceNode.value, context);
 
       if (imported == null) {
         return;  // no-unresolved territory

--- a/src/rules/no-deprecated.js
+++ b/src/rules/no-deprecated.js
@@ -1,5 +1,6 @@
 import declaredScope from 'eslint-module-utils/declaredScope';
-import Exports from '../ExportMap';
+import ExportMapBuilder from '../exportMapBuilder';
+import ExportMap from '../exportMap';
 import docsUrl from '../docsUrl';
 
 function message(deprecation) {
@@ -31,7 +32,7 @@ module.exports = {
       if (node.type !== 'ImportDeclaration') { return; }
       if (node.source == null) { return; } // local export, ignore
 
-      const imports = Exports.get(node.source.value, context);
+      const imports = ExportMapBuilder.get(node.source.value, context);
       if (imports == null) { return; }
 
       const moduleDeprecation = imports.doc && imports.doc.tags.find((t) => t.title === 'deprecated');
@@ -114,7 +115,7 @@ module.exports = {
         let namespace = namespaces.get(dereference.object.name);
         const namepath = [dereference.object.name];
         // while property is namespace and parent is member expression, keep validating
-        while (namespace instanceof Exports && dereference.type === 'MemberExpression') {
+        while (namespace instanceof ExportMap && dereference.type === 'MemberExpression') {
           // ignore computed parts for now
           if (dereference.computed) { return; }
 

--- a/src/rules/no-named-as-default-member.js
+++ b/src/rules/no-named-as-default-member.js
@@ -4,7 +4,7 @@
  * @copyright 2016 Desmond Brand. All rights reserved.
  * See LICENSE in root directory for full license.
  */
-import Exports from '../ExportMap';
+import ExportMapBuilder from '../exportMapBuilder';
 import importDeclaration from '../importDeclaration';
 import docsUrl from '../docsUrl';
 
@@ -36,7 +36,7 @@ module.exports = {
     return {
       ImportDefaultSpecifier(node) {
         const declaration = importDeclaration(context);
-        const exportMap = Exports.get(declaration.source.value, context);
+        const exportMap = ExportMapBuilder.get(declaration.source.value, context);
         if (exportMap == null) { return; }
 
         if (exportMap.errors.length) {

--- a/src/rules/no-named-as-default.js
+++ b/src/rules/no-named-as-default.js
@@ -1,4 +1,4 @@
-import Exports from '../ExportMap';
+import ExportMapBuilder from '../exportMapBuilder';
 import importDeclaration from '../importDeclaration';
 import docsUrl from '../docsUrl';
 
@@ -20,7 +20,7 @@ module.exports = {
 
       const declaration = importDeclaration(context);
 
-      const imports = Exports.get(declaration.source.value, context);
+      const imports = ExportMapBuilder.get(declaration.source.value, context);
       if (imports == null) { return; }
 
       if (imports.errors.length) {

--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -13,7 +13,7 @@ import values from 'object.values';
 import includes from 'array-includes';
 import flatMap from 'array.prototype.flatmap';
 
-import Exports, { recursivePatternCapture } from '../ExportMap';
+import ExportMapBuilder, { recursivePatternCapture } from '../exportMapBuilder';
 import docsUrl from '../docsUrl';
 
 let FileEnumerator;
@@ -194,7 +194,7 @@ const prepareImportsAndExports = (srcFiles, context) => {
   srcFiles.forEach((file) => {
     const exports = new Map();
     const imports = new Map();
-    const currentExports = Exports.get(file, context);
+    const currentExports = ExportMapBuilder.get(file, context);
     if (currentExports) {
       const {
         dependencies,


### PR DESCRIPTION
`ExportMap` is currently a very large file that is hard to follow, and therefore hard to maintain.

I identified that its static methods, which are responsible for building instances of `ExportMap`, can be generalized to the [builder software design pattern](https://en.wikipedia.org/wiki/Builder_pattern).

Lets make the separation, to make it clear that instances of `ExportMap` aren't coupled to any of the globals or procedures that are currently in `ExportMap.js`.

It's also good to rename the files and classes appropriately.