### PR TITLE
fix lint errors in export map builder

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -229,7 +229,6 @@
         {
             "files": [
                 "utils/**", // TODO
-                "src/exportMapBuilder.js", // TODO
             ],
             "rules": {
                 "no-use-before-define": "off",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [Docs] `order`: Add a quick note on how unbound imports and --fix ([#2640], thanks [@minervabot])
 - [Tests] appveyor -> GHA (run tests on Windows in both pwsh and WSL + Ubuntu) ([#2987], thanks [@joeyguerra])
 - [actions] migrate OSX tests to GHA ([ljharb#37], thanks [@aks-])
+- [Refactor] `exportMapBuilder`: avoid hoisting ([#2989], thanks [@soryy708])
 
 ## [2.29.1] - 2023-12-14
 
@@ -1113,6 +1114,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#2989]: https://github.com/import-js/eslint-plugin-import/pull/2989
 [#2987]: https://github.com/import-js/eslint-plugin-import/pull/2987
 [#2985]: https://github.com/import-js/eslint-plugin-import/pull/2985
 [#2982]: https://github.com/import-js/eslint-plugin-import/pull/2982


### PR DESCRIPTION
[`exportMapBuilder.js`](https://github.com/import-js/eslint-plugin-import/blob/38f8d25ef710747fe318d99b3f42e70bd1efc0f4/src/exportMapBuilder.js) currently has [ESLint "no-use-before-define" rule suppressed](https://github.com/import-js/eslint-plugin-import/blob/38f8d25ef710747fe318d99b3f42e70bd1efc0f4/.eslintrc#L232).

Lets fix the lint errors & un-suppress it for the file.