### PR TITLE
ci: cancel in-progress runs when new changes are pushed up

### DIFF
--- a/.github/workflows/native-wsl.yml
+++ b/.github/workflows/native-wsl.yml
@@ -2,6 +2,10 @@ name: Native and WSL
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/node-4+.yml
+++ b/.github/workflows/node-4+.yml
@@ -2,6 +2,10 @@ name: 'Tests: node.js'
 
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -2,6 +2,10 @@ name: 'Tests: packages'
 
 on: [pull_request, push]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
I personally think this is a good idea especially given this projects CI involves over 250+ jobs but I can understand if someone has an alternative workflow that makes it undesirable so feel free to close if you're not a fan 🙂 

Related docs: https://docs.github.com/en/actions/using-jobs/using-concurrency