### PR TITLE
[New] `no-unused-modules`: Add `ignoreUnusedTypeExports` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Added
 - [`dynamic-import-chunkname`]: add `allowEmpty` option to allow empty leading comments ([#2942], thanks [@JiangWeixian])
 - [`dynamic-import-chunkname`]: Allow empty chunk name when webpackMode: 'eager' is set; add suggestions to remove name in eager mode ([#3004], thanks [@amsardesai])
+- [`no-unused-modules`]: Add `ignoreUnusedTypeExports` option ([#3011], thanks [@silverwind])
 
 ### Fixed
 - [`no-extraneous-dependencies`]: allow wrong path ([#3012], thanks [@chabb])
@@ -1120,6 +1121,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#3012]: https://github.com/import-js/eslint-plugin-import/pull/3012
+[#3011]: https://github.com/import-js/eslint-plugin-import/pull/3011
 [#3004]: https://github.com/import-js/eslint-plugin-import/pull/3004
 [#2991]: https://github.com/import-js/eslint-plugin-import/pull/2991
 [#2989]: https://github.com/import-js/eslint-plugin-import/pull/2989
@@ -1915,6 +1917,7 @@ for info on changes for earlier releases.
 [@sergei-startsev]: https://github.com/sergei-startsev
 [@sharmilajesupaul]: https://github.com/sharmilajesupaul
 [@sheepsteak]: https://github.com/sheepsteak
+[@silverwind]: https://github.com/silverwind
 [@silviogutierrez]: https://github.com/silviogutierrez
 [@SimenB]: https://github.com/SimenB
 [@simmo]: https://github.com/simmo

--- a/docs/rules/no-unused-modules.md
+++ b/docs/rules/no-unused-modules.md
@@ -29,8 +29,9 @@ This rule takes the following option:
 
  - **`missingExports`**: if `true`, files without any exports are reported (defaults to `false`)
  - **`unusedExports`**: if `true`, exports without any static usage within other modules are reported (defaults to `false`)
- - `src`: an array with files/paths to be analyzed. It only applies to unused exports. Defaults to `process.cwd()`, if not provided
- - `ignoreExports`: an array with files/paths for which unused exports will not be reported (e.g module entry points in a published package)
+ - **`ignoreUnusedTypeExports`**: if `true`, TypeScript type exports without any static usage within other modules are reported (defaults to `false` and has no effect unless `unusedExports` is `true`)
+ - **`src`**: an array with files/paths to be analyzed. It only applies to unused exports. Defaults to `process.cwd()`, if not provided
+ - **`ignoreExports`**: an array with files/paths for which unused exports will not be reported (e.g module entry points in a published package)
 
 ### Example for missing exports
 
@@ -114,6 +115,16 @@ export function doAnything() {
 }  // will not be reported
 
 export default 5 // will not be reported
+```
+
+### Unused exports with `ignoreUnusedTypeExports` set to `true`
+
+The following will not be reported:
+
+```ts
+export type Foo = {}; // will not be reported
+export interface Foo = {}; // will not be reported
+export enum Foo {}; // will not be reported
 ```
 
 #### Important Note

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -38,6 +38,13 @@ const unusedExportsTypescriptOptions = [{
   ignoreExports: undefined,
 }];
 
+const unusedExportsTypescriptIgnoreUnusedTypesOptions = [{
+  unusedExports: true,
+  ignoreUnusedTypeExports: true,
+  src: [testFilePath('./no-unused-modules/typescript')],
+  ignoreExports: undefined,
+}];
+
 const unusedExportsJsxOptions = [{
   unusedExports: true,
   src: [testFilePath('./no-unused-modules/jsx')],
@@ -1205,6 +1212,66 @@ context('TypeScript', function () {
           ],
         }),
       ),
+    });
+  });
+});
+
+describe('ignoreUnusedTypeExports', () => {
+  getTSParsers().forEach((parser) => {
+    typescriptRuleTester.run('no-unused-modules', rule, {
+      valid: [
+        // unused vars should not report
+        test({
+          options: unusedExportsTypescriptIgnoreUnusedTypesOptions,
+          code: `export interface c {};`,
+          parser,
+          filename: testFilePath(
+            './no-unused-modules/typescript/file-ts-c-unused.ts',
+          ),
+        }),
+        test({
+          options: unusedExportsTypescriptIgnoreUnusedTypesOptions,
+          code: `export type d = {};`,
+          parser,
+          filename: testFilePath(
+            './no-unused-modules/typescript/file-ts-d-unused.ts',
+          ),
+        }),
+        test({
+          options: unusedExportsTypescriptIgnoreUnusedTypesOptions,
+          code: `export enum e { f };`,
+          parser,
+          filename: testFilePath(
+            './no-unused-modules/typescript/file-ts-e-unused.ts',
+          ),
+        }),
+        // used vars should not report
+        test({
+          options: unusedExportsTypescriptIgnoreUnusedTypesOptions,
+          code: `export interface c {};`,
+          parser,
+          filename: testFilePath(
+            './no-unused-modules/typescript/file-ts-c-used-as-type.ts',
+          ),
+        }),
+        test({
+          options: unusedExportsTypescriptIgnoreUnusedTypesOptions,
+          code: `export type d = {};`,
+          parser,
+          filename: testFilePath(
+            './no-unused-modules/typescript/file-ts-d-used-as-type.ts',
+          ),
+        }),
+        test({
+          options: unusedExportsTypescriptIgnoreUnusedTypesOptions,
+          code: `export enum e { f };`,
+          parser,
+          filename: testFilePath(
+            './no-unused-modules/typescript/file-ts-e-used-as-type.ts',
+          ),
+        }),
+      ],
+      invalid: [],
     });
   });
 });


### PR DESCRIPTION
Fixes: https://github.com/import-js/eslint-plugin-import/issues/2694