### PR TITLE
[Fix] `no-extraneous-dependencies`: allow incorrect paths in packageDir 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`dynamic-import-chunkname`]: add `allowEmpty` option to allow empty leading comments ([#2942], thanks [@JiangWeixian])
 - [`dynamic-import-chunkname`]: Allow empty chunk name when webpackMode: 'eager' is set; add suggestions to remove name in eager mode ([#3004], thanks [@amsardesai])
 
+### Fixed
+- [`no-extraneous-dependencies`]: allow wrong path ([#3012], thanks [@chabb])
+
 ### Changed
 - [Docs] `no-extraneous-dependencies`: Make glob pattern description more explicit ([#2944], thanks [@mulztob])
 - [`no-unused-modules`]: add console message to help debug [#2866]
@@ -1116,6 +1119,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3012]: https://github.com/import-js/eslint-plugin-import/pull/3012
 [#3004]: https://github.com/import-js/eslint-plugin-import/pull/3004
 [#2991]: https://github.com/import-js/eslint-plugin-import/pull/2991
 [#2989]: https://github.com/import-js/eslint-plugin-import/pull/2989
@@ -1733,6 +1737,7 @@ for info on changes for earlier releases.
 [@bradzacher]: https://github.com/bradzacher
 [@brendo]: https://github.com/brendo
 [@brettz9]: https://github.com/brettz9
+[@chabb]: https://github.com/chabb
 [@Chamion]: https://github.com/Chamion
 [@charlessuh]: https://github.com/charlessuh
 [@charpeni]: https://github.com/charpeni

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -42,8 +42,11 @@ function extractDepFields(pkg) {
 
 function getPackageDepFields(packageJsonPath, throwAtRead) {
   if (!depFieldCache.has(packageJsonPath)) {
-    const depFields = extractDepFields(readJSON(packageJsonPath, throwAtRead));
-    depFieldCache.set(packageJsonPath, depFields);
+    const packageJson = readJSON(packageJsonPath, throwAtRead);
+    if (packageJson) {
+      const depFields = extractDepFields(packageJson);
+      depFieldCache.set(packageJsonPath, depFields);
+    }
   }
 
   return depFieldCache.get(packageJsonPath);
@@ -72,10 +75,12 @@ function getDependencies(context, packageDir) {
       // use rule config to find package.json
       paths.forEach((dir) => {
         const packageJsonPath = path.join(dir, 'package.json');
-        const _packageContent = getPackageDepFields(packageJsonPath, true);
-        Object.keys(packageContent).forEach((depsKey) => {
-          Object.assign(packageContent[depsKey], _packageContent[depsKey]);
-        });
+        const _packageContent = getPackageDepFields(packageJsonPath, paths.length === 1);
+        if (_packageContent) {
+          Object.keys(packageContent).forEach((depsKey) => {
+            Object.assign(packageContent[depsKey], _packageContent[depsKey]);
+          });
+        }
       });
     } else {
       const packageJsonPath = pkgUp({

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -26,6 +26,7 @@ const packageDirWithEmpty = path.join(__dirname, '../../files/empty');
 const packageDirBundleDeps = path.join(__dirname, '../../files/bundled-dependencies/as-array-bundle-deps');
 const packageDirBundledDepsAsObject = path.join(__dirname, '../../files/bundled-dependencies/as-object');
 const packageDirBundledDepsRaceCondition = path.join(__dirname, '../../files/bundled-dependencies/race-condition');
+const emptyPackageDir = path.join(__dirname, '../../files/empty-folder');
 
 const {
   dependencies: deps,
@@ -103,6 +104,14 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     test({
       code: 'import leftpad from "left-pad";',
       options: [{ packageDir: packageDirMonoRepoRoot }],
+    }),
+    test({
+      code: 'import leftpad from "left-pad";',
+      options: [{ packageDir: [emptyPackageDir, packageDirMonoRepoRoot] }],
+    }),
+    test({
+      code: 'import leftpad from "left-pad";',
+      options: [{ packageDir: [packageDirMonoRepoRoot, emptyPackageDir] }],
     }),
     test({
       code: 'import react from "react";',


### PR DESCRIPTION
This rule can potentially fails ( = reports incorrect errors ) in a monorepo settings; this is due to the fact that the building of the map of the available installed dependencies stops when there is an error ( e.g when the path to the package.json does not point to an existing package.json file )

-  If you pass only one path to a package.json file, then this path should be correct, this is ok 
- If you pass multiple paths, there are some situations when those paths point to a wrong path, this happens typically in a nx monorepo. The problem is that the parsing of the package.json files stop is one of the path is wrong, and then the rule will give us false positive. One example is a nx monorepo with a pre-commit hook that runs eslint
-- NX will run eslint in the projects folder, so we need to grab the root package.json
-- The pre-commit hook will run eslint in the root folder, so one of the path given will be an incorrect path, but we do not want to throw there, otherwise the rull will fail