### PR TITLE
[utils] [fix] `parse`: Also delete parserOptions.projectService

### DIFF
--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -8,6 +8,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Changed
 - [types] use shared config (thanks [@ljharb])
 
+### Fixed
+- `parse`: also delete `parserOptions.projectService` ([#3039], thanks [@Mysak0CZ])
+
 ## v2.8.1 - 2024-02-26
 
 ### Fixed
@@ -142,6 +145,7 @@ Yanked due to critical issue with cache key resulting from #839.
 ### Fixed
 - `unambiguous.test()` regex is now properly in multiline mode
 
+[#3039]: https://github.com/import-js/eslint-plugin-import/pull/3039
 [#2963]: https://github.com/import-js/eslint-plugin-import/pull/2963
 [#2755]: https://github.com/import-js/eslint-plugin-import/pull/2755
 [#2714]: https://github.com/import-js/eslint-plugin-import/pull/2714
@@ -188,6 +192,7 @@ Yanked due to critical issue with cache key resulting from #839.
 [@manuth]: https://github.com/manuth
 [@maxkomarychev]: https://github.com/maxkomarychev
 [@mgwalker]: https://github.com/mgwalker
+[@Mysak0CZ]: https://github.com/Mysak0CZ
 [@nicolo-ribaudo]: https://github.com/nicolo-ribaudo
 [@pmcelhaney]: https://github.com/pmcelhaney
 [@sergei-startsev]: https://github.com/sergei-startsev

--- a/utils/parse.js
+++ b/utils/parse.js
@@ -134,6 +134,7 @@ exports.default = function parse(path, content, context) {
   // only parse one file in isolate mode, which is much, much faster.
   // https://github.com/import-js/eslint-plugin-import/issues/1408#issuecomment-509298962
   delete parserOptions.EXPERIMENTAL_useProjectService;
+  delete parserOptions.projectService;
   delete parserOptions.project;
   delete parserOptions.projects;
 


### PR DESCRIPTION
Recently typescript-eslint released version 8. One of the breaking changes introduced there was renaming `EXPERIMENTAL_useProjectService` to `projectService`.
xref: https://typescript-eslint.io/blog/announcing-typescript-eslint-v8-beta/#project-service

This fix deletes the new property as well to let this plugin be compatible with v8. During my testing I didn't encounter any other issues than this.

Change is based on prior change to get project service option working:
ref #2963