### PR TITLE
[New] `import/order`: add support for named imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## [Unreleased]
 
+### Added
+- [`order`]: allow validating named imports ([#3043], thanks [@manuth])
+
 ### Fixed
 - `ExportMap` / flat config: include `languageOptions` in context ([#3052], thanks [@michaelfaith])
 
@@ -1133,6 +1136,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#3052]: https://github.com/import-js/eslint-plugin-import/pull/3052
+[#3043]: https://github.com/import-js/eslint-plugin-import/pull/3043
 [#3036]: https://github.com/import-js/eslint-plugin-import/pull/3036
 [#3033]: https://github.com/import-js/eslint-plugin-import/pull/3033
 [#3018]: https://github.com/import-js/eslint-plugin-import/pull/3018

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -285,6 +285,78 @@ import index from './';
 import sibling from './foo';
 ```
 
+### `named: true|false|{ enabled: true|false, import: true|false, export: true|false, require: true|false, cjsExports: true|false, types: mixed|types-first|types-last }`
+
+Enforce ordering of names within imports and exports:
+
+ - If set to `true`, named imports must be ordered according to the `alphabetize` options
+ - If set to `false`, named imports can occur in any order
+
+`enabled` enables the named ordering for all expressions by default.
+Use `import`, `export` and `require` and `cjsExports` to override the enablement for the following kind of expressions:
+
+ - `import`:
+
+   ```ts
+   import { Readline } from "readline";
+   ```
+
+ - `export`:
+
+   ```ts
+   export { Readline };
+   // and
+   export { Readline } from "readline";
+   ```
+
+ - `require`
+
+   ```ts
+   const { Readline } = require("readline");
+   ```
+
+ - `cjsExports`
+
+   ```ts
+   module.exports.Readline = Readline;
+   // and
+   module.exports = { Readline };
+   ```
+
+The `types` option allows you to specify the order of `import`s and `export`s of `type` specifiers.
+Following values are possible:
+
+ - `types-first`: forces `type` specifiers to occur first
+ - `types-last`: forces value specifiers to occur first
+ - `mixed`: sorts all specifiers in alphabetical order
+
+The default value is `false`.
+
+Example setting:
+
+```ts
+{
+  named: true,
+  alphabetize: {
+    order: 'asc'
+  }
+}
+```
+
+This will fail the rule check:
+
+```ts
+/* eslint import/order: ["error", {"named": true, "alphabetize": {"order": "asc"}}] */
+import { compose, apply } from 'xcompose';
+```
+
+While this will pass:
+
+```ts
+/* eslint import/order: ["error", {"named": true, "alphabetize": {"order": "asc"}}] */
+import { apply, compose } from 'xcompose';
+```
+
 ### `alphabetize: {order: asc|desc|ignore, orderImportKind: asc|desc|ignore, caseInsensitive: true|false}`
 
 Sort the order within each group in alphabetical manner based on **import path**:

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "object.groupby": "^1.0.3",
     "object.values": "^1.2.0",
     "semver": "^6.3.1",
+    "string.prototype.trimend": "^1.0.8",
     "tsconfig-paths": "^3.15.0"
   }
 }


### PR DESCRIPTION
## `import/order`: add support for named imports
Changes made in this PR change the `import/order` rule to allow configuring the order of named specifiers in `import`, `export` and `require` statements.

This will report errors and automatically fix expressions as shown in this example:
***Reports error:***
```ts
import { Bravo, Alpha } from 'foo';
const { Delta, Charlie } = require('foo');
export { Foxtrot, Echo } from 'foo';
export { Alpha as Hotel, India, Alpha as Golf };
```

***Fixed code:***
```ts
import { Alpha, Bravo } from 'foo';
const { Charlie, Delta } = require('foo');
export { Echo, Foxtrot } from 'foo';
export { Alpha as Golf, Alpha as Hotel, India } from 'foo';
```

This feature heavily uses the pre-existing functions used for re-ordering import/export statements and thus does not require a lot of changes.

To address the requirement brought forward by @ronparkdev, there are 3 options `named.import`, `named.export` and `named.require` for individually forcing ordering of named items for the specified category.

Furthermore, in response to the comment written by @JensDll, there is an option `types` which allows to specify the order of the specifiers based on their category:
  - `mixed`: all specifiers are ordered alphabetically
  - `types-first`: `type` imports must occur first
  - `types-last`: value imports must occur first

With this option, one could force `type` imports to occur last by setting the options of the `order` rule to the following:

```json
{
  "named": {
    "enabled": true,
    "types": "types-last"
  },
  "alphabetize": { "order": "asc" }
}
```

## Things to consider
  - ~~Following tiny bit of code makes use of `RegExp`:
    https://github.com/import-js/eslint-plugin-import/blob/60b04933341a4c9eb5f2f3484e9a0bdd685c0df9/src/rules/order.js#L239
    https://github.com/import-js/eslint-plugin-import/blob/60b04933341a4c9eb5f2f3484e9a0bdd685c0df9/src/rules/order.js#L250~~
  - ~~The lines between the `default` and the `type`/`value` groups are a little blurred as a `default` re-export technically still is either a `value` or a `type` export. `default` will take highest priority which means that both `export { type default as Readline } from 'foo'` and ` export { default as Readline } from 'foo'` will have their group set to `default`.~~
  - named specifiers are not only sorted by their source name, but also by their alias
  - When two specifiers have the same source name (like, say, `const { Alpha: Bravo, Alpha } = require('foo');`), error messages will contain both the original name and the alilas for preventing confusion:
    `` `Alpha` import should occur before import of `Alpha as Bravo` ``
  - For enabling forced ordering for all kinds of expressions, the `named` or the `named.enabled` option can be set to `true`. However, `named.all` might be a more suitable option name (?)

## Related
  - #2553, the original proposal
  - #1787 (tagging @andrewbranch, bc this PR might be interesting to you)

Merging this PR will fix #2553 and fix #1787