### PR TITLE
[Test] add explicit marker for trailing whitespace in cases

### DIFF
--- a/tests/src/rules/dynamic-import-chunkname.js
+++ b/tests/src/rules/dynamic-import-chunkname.js
@@ -1001,7 +1001,7 @@ ruleTester.run('dynamic-import-chunkname', rule, {
           {
             desc: 'Remove webpackChunkName',
             output: `import(
-        
+        ${''}
         /* webpackMode: "eager" */
         'someModule'
       )`,
@@ -1010,7 +1010,7 @@ ruleTester.run('dynamic-import-chunkname', rule, {
             desc: 'Remove webpackMode',
             output: `import(
         /* webpackChunkName: "someModule" */
-        
+        ${''}
         'someModule'
       )`,
           },

--- a/tests/src/rules/no-duplicates.js
+++ b/tests/src/rules/no-duplicates.js
@@ -455,28 +455,28 @@ import {x,y} from './foo'
         import {
           BULK_ACTIONS_ENABLED
         } from '../constants';
-        
+        ${''}
         const TestComponent = () => {
           return <div>
           </div>;
         }
-        
+        ${''}
         export default TestComponent;
       `,
       output: `
         import {
           DEFAULT_FILTER_KEYS,
           BULK_DISABLED,
-        
+        ${''}
           BULK_ACTIONS_ENABLED
         } from '../constants';
         import React from 'react';
-                
+                ${''}
         const TestComponent = () => {
           return <div>
           </div>;
         }
-        
+        ${''}
         export default TestComponent;
       `,
       errors: ["'../constants' imported multiple times.", "'../constants' imported multiple times."],

--- a/tests/src/rules/no-import-module-exports.js
+++ b/tests/src/rules/no-import-module-exports.js
@@ -74,13 +74,13 @@ ruleTester.run('no-import-module-exports', rule, {
         import fs from 'fs/promises';
 
         const subscriptions = new Map();
-        
+        ${''}
         export default async (client) => {
             /**
              * loads all modules and their subscriptions
              */
             const modules = await fs.readdir('./src/modules');
-        
+        ${''}
             await Promise.all(
                 modules.map(async (moduleName) => {
                     // Loads the module
@@ -97,7 +97,7 @@ ruleTester.run('no-import-module-exports', rule, {
                     }
                 })
             );
-        
+        ${''}
             /**
              * Setting up all events.
              * binds all events inside the subscriptions map to call all functions provided


### PR DESCRIPTION
This ensures that IDEs like Webstorm won't trim trailing whitespace that is expected as part of test output