### PR TITLE
[Fix] `ExportMap` / flat config: include `languageOptions` in context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## [Unreleased]
 
+### Fixed
+- `ExportMap` / flat config: include `languageOptions` in context ([#3052], thanks [@michaelfaith])
+
 ## [2.30.0] - 2024-09-02
 
 ### Added
@@ -1129,6 +1132,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3052]: https://github.com/import-js/eslint-plugin-import/pull/3052
 [#3036]: https://github.com/import-js/eslint-plugin-import/pull/3036
 [#3033]: https://github.com/import-js/eslint-plugin-import/pull/3033
 [#3018]: https://github.com/import-js/eslint-plugin-import/pull/3018

--- a/src/exportMap/childContext.js
+++ b/src/exportMap/childContext.js
@@ -10,7 +10,7 @@ let prevSettings = '';
  * also calculate a cacheKey, where parts of the cacheKey hash are memoized
  */
 export default function childContext(path, context) {
-  const { settings, parserOptions, parserPath } = context;
+  const { settings, parserOptions, parserPath, languageOptions } = context;
 
   if (JSON.stringify(settings) !== prevSettings) {
     settingsHash = hashObject({ settings }).digest('hex');
@@ -28,5 +28,6 @@ export default function childContext(path, context) {
     parserOptions,
     parserPath,
     path,
+    languageOptions,
   };
 }

--- a/tests/src/exportMap/childContext.js
+++ b/tests/src/exportMap/childContext.js
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+
+import childContext from '../../../src/exportMap/childContext';
+
+describe('childContext', () => {
+  const settings = {
+    setting1: true,
+    setting2: false,
+  };
+  const parserOptions = {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  };
+  const parserPath = 'path/to/parser';
+  const path = 'path/to/src/file';
+  const languageOptions = {
+    ecmaVersion: 2024,
+    sourceType: 'module',
+    parser: {},
+  };
+
+  // https://github.com/import-js/eslint-plugin-import/issues/3051
+  it('should pass context properties through, if present', () => {
+    const mockContext = {
+      settings,
+      parserOptions,
+      parserPath,
+      languageOptions,
+    };
+
+    const result = childContext(path, mockContext);
+
+    expect(result.settings).to.deep.equal(settings);
+    expect(result.parserOptions).to.deep.equal(parserOptions);
+    expect(result.parserPath).to.equal(parserPath);
+    expect(result.languageOptions).to.deep.equal(languageOptions);
+  });
+
+  it('should add path and cacheKey to context', () => {
+    const mockContext = {
+      settings,
+      parserOptions,
+      parserPath,
+    };
+
+    const result = childContext(path, mockContext);
+
+    expect(result.path).to.equal(path);
+    expect(result.cacheKey).to.be.a('string');
+  });
+});


### PR DESCRIPTION
This change fixes a bug with flat config support.  There is a function called `childContext` that's used by the ExportBuilder to "cleanse" the context object.  This function wasn't including the new `languageOptions` object, which contains the parser.  So by the time this cleansed context made it to the parse function, `languageOptions` wasn't there anymore.

Since `parserPath` was still being included in non-flat config scenarios, the parse function made it through ok and used `parserPath`.  However, once you shift to flat config, `parserPath` is no longer defined, and the actual parser object needs to be there.

Fixes #3051