### PR TITLE
[utils] [fix] `parse`: espree parser isn't working with flat config

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -14,6 +14,7 @@
 		"resolvers/*/test",
 		"scripts",
 		"memo-parser",
-		"lib"
+		"lib",
+		"examples"
 	]
 }

--- a/examples/flat/eslint.config.mjs
+++ b/examples/flat/eslint.config.mjs
@@ -20,6 +20,7 @@ export default [
       'import/no-dynamic-require': 'warn',
       'import/no-nodejs-modules': 'warn',
       'import/no-unused-modules': ['warn', { unusedExports: true }],
+      'import/no-cycle': 'warn',
     },
   },
 ];

--- a/examples/flat/src/depth-zero.js
+++ b/examples/flat/src/depth-zero.js
@@ -1,0 +1,3 @@
+import { foo } from "./es6/depth-one-dynamic";
+
+foo();

--- a/examples/flat/src/es6/depth-one-dynamic.js
+++ b/examples/flat/src/es6/depth-one-dynamic.js
@@ -1,0 +1,3 @@
+export function foo() {}
+
+export const bar = () => import("../depth-zero").then(({foo}) => foo);

--- a/examples/legacy/.eslintrc.cjs
+++ b/examples/legacy/.eslintrc.cjs
@@ -20,5 +20,6 @@ module.exports = {
     'import/no-dynamic-require': 'warn',
     'import/no-nodejs-modules': 'warn',
     'import/no-unused-modules': ['warn', { unusedExports: true }],
+    'import/no-cycle': 'warn',
   },
 };

--- a/examples/legacy/src/depth-zero.js
+++ b/examples/legacy/src/depth-zero.js
@@ -1,0 +1,3 @@
+import { foo } from "./es6/depth-one-dynamic";
+
+foo();

--- a/examples/legacy/src/es6/depth-one-dynamic.js
+++ b/examples/legacy/src/es6/depth-one-dynamic.js
@@ -1,0 +1,3 @@
+export function foo() {}
+
+export const bar = () => import("../depth-zero").then(({ foo }) => foo);

--- a/tests/src/core/parse.js
+++ b/tests/src/core/parse.js
@@ -138,4 +138,18 @@ describe('parse(content, { settings, ecmaFeatures })', function () {
     parseStubParser.parse = parseSpy;
     expect(parse.bind(null, path, content, { settings: {}, parserPath: 'espree', languageOptions: { parserOptions: { sourceType: 'module', ecmaVersion: 2015, ecmaFeatures: { jsx: true } } }, parserOptions: { sourceType: 'script' } })).not.to.throw(Error);
   });
+
+  it('passes ecmaVersion and sourceType from languageOptions to parser', () => {
+    const parseSpy = sinon.spy();
+    const languageOptions = { ecmaVersion: 'latest', sourceType: 'module', parserOptions: { ecmaFeatures: { jsx: true } } };
+    parseStubParser.parse = parseSpy;
+    parse(path, content, { settings: {}, parserPath: parseStubParserPath, languageOptions });
+    expect(parseSpy.args[0][1], 'custom parser to clone the parserOptions object').to.not.equal(languageOptions);
+    expect(parseSpy.args[0][1], 'custom parser to get ecmaFeatures in parserOptions which is a clone of ecmaFeatures passed in')
+      .to.have.property('ecmaFeatures')
+      .that.is.eql(languageOptions.parserOptions.ecmaFeatures)
+      .and.is.not.equal(languageOptions.parserOptions.ecmaFeatures);
+    expect(parseSpy.args[0][1], 'custom parser to get ecmaVersion in parserOptions from languageOptions').to.have.property('ecmaVersion', languageOptions.ecmaVersion);
+    expect(parseSpy.args[0][1], 'custom parser to get sourceType in parserOptions from languageOptions').to.have.property('sourceType', languageOptions.sourceType);
+  });
 });

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -7,6 +7,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Fixed
 - `parse`: remove unneeded extra backticks ([#3057], thanks [@G-Rath])
+- `parse`: espree parser isn't working with flat config ([#3061], thanks [@michaelfaith])
 
 ## v2.11.0 - 2024-09-05
 
@@ -168,6 +169,7 @@ Yanked due to critical issue with cache key resulting from #839.
 ### Fixed
 - `unambiguous.test()` regex is now properly in multiline mode
 
+[#3061]: https://github.com/import-js/eslint-plugin-import/pull/3061
 [#3057]: https://github.com/import-js/eslint-plugin-import/pull/3057
 [#3049]: https://github.com/import-js/eslint-plugin-import/pull/3049
 [#3039]: https://github.com/import-js/eslint-plugin-import/pull/3039

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -8,6 +8,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Fixed
 - `parse`: remove unneeded extra backticks ([#3057], thanks [@G-Rath])
 - `parse`: espree parser isn't working with flat config ([#3061], thanks [@michaelfaith])
+- `parse`: add `ecmaVersion` and `sourceType` to `parserOptions` ([#3061], thanks [@michaelfaith])
 
 ## v2.11.0 - 2024-09-05
 

--- a/utils/parse.js
+++ b/utils/parse.js
@@ -29,11 +29,17 @@ function keysFromParser(parserPath, parserInstance, parsedResult) {
   if (parsedResult && parsedResult.visitorKeys) {
     return parsedResult.visitorKeys;
   }
-  if (typeof parserPath === 'string' && (/.*espree.*/).test(parserPath)) {
-    return parserInstance.VisitorKeys;
-  }
+  // The old babel parser doesn't have a `parseForESLint` eslint function, so we don't end
+  // up with a `parsedResult` here.  It also doesn't expose the visitor keys on the parser itself,
+  // so we have to try and infer the visitor-keys module from the parserPath.
+  // This is NOT supported in flat config!
   if (typeof parserPath === 'string' && (/.*babel-eslint.*/).test(parserPath)) {
     return getBabelEslintVisitorKeys(parserPath);
+  }
+  // The espree parser doesn't have the `parseForESLint` function, so we don't ended up with a
+  // `parsedResult` here, but it does expose the visitor keys on the parser instance that we can use.
+  if (parserInstance && parserInstance.VisitorKeys) {
+    return parserInstance.VisitorKeys;
   }
   return null;
 }


### PR DESCRIPTION
This change addresses an issue with using the espree parser with flat config.  `keysFromParser` is responsible for finding the `visitorKeys` from a combination of the parser instance, parserPath, and the results of a call to `parseForESLint`.  When using flat config, the `parserPath` will not be on the context object, and when using the espree parser there are no results from `parseForESLint`.  The espree parser _does_ provide visitor keys as a  prop on the parser itself.  However, this logic was only returning it when it found that "espree" was somewhere in the `parserPath` (which doesn't exist on flat config).

I changed it so that it first does the check for the old-school babel parser using parser path, and then just checks the parser instance for the presence of `VisitorKeys`, rather than using parserPath at all. The reason for the re-order is that if the old babel-eslint parser, for some reason has `VisitorKeys`, having the new condition first, would change the behavior.