### PR TITLE
[Performance] `no-cycle`: dont scc for each linted file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Changed
 - [Docs] [`no-relative-packages`]: fix typo ([#3066], thanks [@joshuaobrien])
+- [Performance] [`no-cycle`]: dont scc for each linted file ([#3068], thanks [@soryy708])
 
 ## [2.30.0] - 2024-09-02
 
@@ -1140,6 +1141,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3068]: https://github.com/import-js/eslint-plugin-import/pull/3068
 [#3066]: https://github.com/import-js/eslint-plugin-import/pull/3066
 [#3065]: https://github.com/import-js/eslint-plugin-import/pull/3065
 [#3052]: https://github.com/import-js/eslint-plugin-import/pull/3052

--- a/src/scc.js
+++ b/src/scc.js
@@ -18,12 +18,18 @@ export default class StronglyConnectedComponentsBuilder {
   }
 
   static for(context) {
-    const cacheKey = context.cacheKey || hashObject(context).digest('hex');
+    const settingsHash = hashObject({
+      settings: context.settings,
+      parserOptions: context.parserOptions,
+      parserPath: context.parserPath,
+    }).digest('hex');
+    const cacheKey = context.path + settingsHash;
     if (cache.has(cacheKey)) {
       return cache.get(cacheKey);
     }
     const scc = StronglyConnectedComponentsBuilder.calculate(context);
-    cache.set(cacheKey, scc);
+    const visitedFiles = Object.keys(scc);
+    visitedFiles.forEach((filePath) => cache.set(filePath + settingsHash, scc));
     return scc;
   }
 


### PR DESCRIPTION
I noticed that `no-cycle` has a cache miss on SCC very often,
turns out that each linted file builds its own SCC, which is unnecessary.
Lets speed things up, by using the already cached SCC, as long as the context is similar (excluding linted file path)