### PR TITLE
[Docs] `no-cycle`: add `disableScc` to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Changed
 - [Docs] [`no-relative-packages`]: fix typo ([#3066], thanks [@joshuaobrien])
 - [Performance] [`no-cycle`]: dont scc for each linted file ([#3068], thanks [@soryy708])
+- [Docs] [`no-cycle`]: add `disableScc` to docs ([#3070], thanks [@soryy708])
 
 ## [2.30.0] - 2024-09-02
 
@@ -1141,6 +1142,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3070]: https://github.com/import-js/eslint-plugin-import/pull/3070
 [#3068]: https://github.com/import-js/eslint-plugin-import/pull/3068
 [#3066]: https://github.com/import-js/eslint-plugin-import/pull/3066
 [#3065]: https://github.com/import-js/eslint-plugin-import/pull/3065

--- a/docs/rules/no-cycle.md
+++ b/docs/rules/no-cycle.md
@@ -94,6 +94,14 @@ export function getBar() { return import('./bar'); }
 
 > Cyclic dependency are **always** a dangerous anti-pattern as discussed extensively in [#2265](https://github.com/import-js/eslint-plugin-import/issues/2265). Please be extra careful about using this option.
 
+#### `disableScc`
+
+This option disables a pre-processing step that calculates [Strongly Connected Components](https://en.wikipedia.org/wiki/Strongly_connected_component), which are used for avoiding unnecessary work checking files in different SCCs for cycles.
+
+However, under some configurations, this pre-processing may be more expensive than the time it saves.
+
+When this option is `true`, we don't calculate any SCC graph, and check all files for cycles (leading to higher time-complexity). Default is `false`.
+
 ## When Not To Use It
 
 This rule is comparatively computationally expensive. If you are pressed for lint


### PR DESCRIPTION
https://github.com/import-js/eslint-plugin-import/pull/2998 introduces a `disableScc` option to the `no-cycle` rule, but there's no reference to it in the rule's docs at https://github.com/import-js/eslint-plugin-import/blob/f72f2072f4245f2c3494816d7c14352fc9e07c0a/docs/rules/no-cycle.md

It's an error of omission, and we need to add it to the docs, so that users know about the escape hatch and what it does, without digging through issues/PRs about it.

Fixes #3063