### PR TITLE
[Tests] use re-exported `RuleTester`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [Docs] [`no-relative-packages`]: fix typo ([#3066], thanks [@joshuaobrien])
 - [Performance] [`no-cycle`]: dont scc for each linted file ([#3068], thanks [@soryy708])
 - [Docs] [`no-cycle`]: add `disableScc` to docs ([#3070], thanks [@soryy708])
+- [Tests] use re-exported `RuleTester` ([#3071], thanks [@G-Rath])
 
 ## [2.30.0] - 2024-09-02
 
@@ -1143,6 +1144,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3071]: https://github.com/import-js/eslint-plugin-import/pull/3071
 [#3070]: https://github.com/import-js/eslint-plugin-import/pull/3070
 [#3068]: https://github.com/import-js/eslint-plugin-import/pull/3068
 [#3066]: https://github.com/import-js/eslint-plugin-import/pull/3066

--- a/tests/src/rule-tester.js
+++ b/tests/src/rule-tester.js
@@ -1,3 +1,5 @@
 export function withoutAutofixOutput(test) {
   return { ...test, output: test.code };
 }
+
+export { RuleTester } from 'eslint';

--- a/tests/src/rules/consistent-type-specifier-style.js
+++ b/tests/src/rules/consistent-type-specifier-style.js
@@ -1,4 +1,4 @@
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import { test, parsers, tsVersionSatisfies, eslintVersionSatisfies, typescriptEslintParserSatisfies } from '../utils';
 
 const rule = require('rules/consistent-type-specifier-style');

--- a/tests/src/rules/default.js
+++ b/tests/src/rules/default.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import { test, testVersion, SYNTAX_CASES, getTSParsers, parsers } from '../utils';
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import semver from 'semver';
 import { version as tsEslintVersion } from 'typescript-eslint-parser/package.json';
 

--- a/tests/src/rules/dynamic-import-chunkname.js
+++ b/tests/src/rules/dynamic-import-chunkname.js
@@ -1,6 +1,5 @@
 import { SYNTAX_CASES, getTSParsers, parsers } from '../utils';
-import { RuleTester } from 'eslint';
-import { withoutAutofixOutput } from '../rule-tester';
+import { RuleTester, withoutAutofixOutput } from '../rule-tester';
 import semver from 'semver';
 
 const rule = require('rules/dynamic-import-chunkname');

--- a/tests/src/rules/export.js
+++ b/tests/src/rules/export.js
@@ -1,6 +1,6 @@
 import { test, testFilePath, SYNTAX_CASES, getTSParsers, testVersion } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import eslintPkg from 'eslint/package.json';
 import semver from 'semver';
 import { version as tsEslintVersion } from 'typescript-eslint-parser/package.json';

--- a/tests/src/rules/exports-last.js
+++ b/tests/src/rules/exports-last.js
@@ -1,6 +1,6 @@
 import { test } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import rule from 'rules/exports-last';
 
 const ruleTester = new RuleTester();

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -1,4 +1,4 @@
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import rule from 'rules/extensions';
 import { getTSParsers, test, testFilePath, parsers } from '../utils';
 

--- a/tests/src/rules/first.js
+++ b/tests/src/rules/first.js
@@ -2,7 +2,7 @@ import { test, getTSParsers, testVersion } from '../utils';
 import fs from 'fs';
 import path from 'path';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/first');

--- a/tests/src/rules/group-exports.js
+++ b/tests/src/rules/group-exports.js
@@ -1,5 +1,5 @@
 import { test } from '../utils';
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import rule from 'rules/group-exports';
 import { resolve } from 'path';
 import { default as babelPresetFlow } from 'babel-preset-flow';

--- a/tests/src/rules/max-dependencies.js
+++ b/tests/src/rules/max-dependencies.js
@@ -1,6 +1,6 @@
 import { test, getTSParsers, parsers } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/max-dependencies');

--- a/tests/src/rules/named.js
+++ b/tests/src/rules/named.js
@@ -1,5 +1,5 @@
 import { test, SYNTAX_CASES, getTSParsers, testFilePath, testVersion, parsers } from '../utils';
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import path from 'path';
 
 import { CASE_SENSITIVE_FS } from 'eslint-module-utils/resolve';

--- a/tests/src/rules/namespace.js
+++ b/tests/src/rules/namespace.js
@@ -1,5 +1,5 @@
 import { test, SYNTAX_CASES, getTSParsers, testVersion, testFilePath, parsers } from '../utils';
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import flatMap from 'array.prototype.flatmap';
 
 const ruleTester = new RuleTester({ env: { es6: true } });

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -1,5 +1,4 @@
-import { RuleTester } from 'eslint';
-import { withoutAutofixOutput } from '../rule-tester';
+import { RuleTester, withoutAutofixOutput } from '../rule-tester';
 import flatMap from 'array.prototype.flatmap';
 import semver from 'semver';
 import { version as tsEslintVersion } from 'typescript-eslint-parser/package.json';

--- a/tests/src/rules/no-absolute-path.js
+++ b/tests/src/rules/no-absolute-path.js
@@ -1,6 +1,6 @@
 import { test } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/no-absolute-path');

--- a/tests/src/rules/no-amd.js
+++ b/tests/src/rules/no-amd.js
@@ -1,4 +1,4 @@
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import eslintPkg from 'eslint/package.json';
 import semver from 'semver';
 

--- a/tests/src/rules/no-anonymous-default-export.js
+++ b/tests/src/rules/no-anonymous-default-export.js
@@ -1,6 +1,6 @@
 import { test, testVersion, SYNTAX_CASES } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/no-anonymous-default-export');

--- a/tests/src/rules/no-commonjs.js
+++ b/tests/src/rules/no-commonjs.js
@@ -1,5 +1,4 @@
-import { RuleTester } from 'eslint';
-import { withoutAutofixOutput } from '../rule-tester';
+import { RuleTester, withoutAutofixOutput } from '../rule-tester';
 import eslintPkg from 'eslint/package.json';
 import semver from 'semver';
 

--- a/tests/src/rules/no-cycle.js
+++ b/tests/src/rules/no-cycle.js
@@ -1,6 +1,6 @@
 import { parsers, test as _test, testFilePath, testVersion as _testVersion } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import flatMap from 'array.prototype.flatmap';
 
 const ruleTester = new RuleTester();

--- a/tests/src/rules/no-default-export.js
+++ b/tests/src/rules/no-default-export.js
@@ -1,6 +1,6 @@
 import { parsers, test, testVersion } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/no-default-export');

--- a/tests/src/rules/no-deprecated.js
+++ b/tests/src/rules/no-deprecated.js
@@ -1,6 +1,6 @@
 import { test, SYNTAX_CASES, getTSParsers } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/no-deprecated');

--- a/tests/src/rules/no-duplicates.js
+++ b/tests/src/rules/no-duplicates.js
@@ -2,8 +2,7 @@ import * as path from 'path';
 import { test as testUtil, getNonDefaultParsers, parsers, tsVersionSatisfies, typescriptEslintParserSatisfies } from '../utils';
 import jsxConfig from '../../../config/react';
 
-import { RuleTester } from 'eslint';
-import { withoutAutofixOutput } from '../rule-tester';
+import { RuleTester, withoutAutofixOutput } from '../rule-tester';
 import eslintPkg from 'eslint/package.json';
 import semver from 'semver';
 import flatMap from 'array.prototype.flatmap';

--- a/tests/src/rules/no-dynamic-require.js
+++ b/tests/src/rules/no-dynamic-require.js
@@ -1,6 +1,6 @@
 import { parsers, test, testVersion } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import flatMap from 'array.prototype.flatmap';
 
 const ruleTester = new RuleTester();

--- a/tests/src/rules/no-empty-named-blocks.js
+++ b/tests/src/rules/no-empty-named-blocks.js
@@ -1,6 +1,6 @@
 import { parsers, test } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/no-empty-named-blocks');

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -3,7 +3,7 @@ import typescriptConfig from '../../../config/typescript';
 import path from 'path';
 import fs from 'fs';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import flatMap from 'array.prototype.flatmap';
 
 const ruleTester = new RuleTester();

--- a/tests/src/rules/no-import-module-exports.js
+++ b/tests/src/rules/no-import-module-exports.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 import { eslintVersionSatisfies, test, testVersion } from '../utils';
 

--- a/tests/src/rules/no-internal-modules.js
+++ b/tests/src/rules/no-internal-modules.js
@@ -1,4 +1,4 @@
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import flatMap from 'array.prototype.flatmap';
 import rule from 'rules/no-internal-modules';
 

--- a/tests/src/rules/no-mutable-exports.js
+++ b/tests/src/rules/no-mutable-exports.js
@@ -1,5 +1,5 @@
 import { parsers, test, testVersion } from '../utils';
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import rule from 'rules/no-mutable-exports';
 
 const ruleTester = new RuleTester();

--- a/tests/src/rules/no-named-as-default-member.js
+++ b/tests/src/rules/no-named-as-default-member.js
@@ -1,5 +1,5 @@
 import { test, testVersion, SYNTAX_CASES } from '../utils';
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import rule from 'rules/no-named-as-default-member';
 
 const ruleTester = new RuleTester();

--- a/tests/src/rules/no-named-as-default.js
+++ b/tests/src/rules/no-named-as-default.js
@@ -1,5 +1,5 @@
 import { test, testVersion, SYNTAX_CASES, parsers } from '../utils';
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/no-named-as-default');

--- a/tests/src/rules/no-named-default.js
+++ b/tests/src/rules/no-named-default.js
@@ -1,5 +1,5 @@
 import { test, testVersion, SYNTAX_CASES, parsers } from '../utils';
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/no-named-default');

--- a/tests/src/rules/no-named-export.js
+++ b/tests/src/rules/no-named-export.js
@@ -1,4 +1,4 @@
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import { parsers, test, testVersion } from '../utils';
 
 const ruleTester = new RuleTester();

--- a/tests/src/rules/no-namespace.js
+++ b/tests/src/rules/no-namespace.js
@@ -1,5 +1,4 @@
-import { RuleTester } from 'eslint';
-import { withoutAutofixOutput } from '../rule-tester';
+import { RuleTester, withoutAutofixOutput } from '../rule-tester';
 import eslintPkg from 'eslint/package.json';
 import semver from 'semver';
 import { test } from '../utils';

--- a/tests/src/rules/no-nodejs-modules.js
+++ b/tests/src/rules/no-nodejs-modules.js
@@ -1,6 +1,6 @@
 import { test } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 const isCore = require('is-core-module');
 
 const ruleTester = new RuleTester();

--- a/tests/src/rules/no-relative-packages.js
+++ b/tests/src/rules/no-relative-packages.js
@@ -1,4 +1,4 @@
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import rule from 'rules/no-relative-packages';
 import { normalize } from 'path';
 

--- a/tests/src/rules/no-relative-parent-imports.js
+++ b/tests/src/rules/no-relative-parent-imports.js
@@ -1,4 +1,4 @@
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import rule from 'rules/no-relative-parent-imports';
 import { parsers, test as _test, testFilePath } from '../utils';
 

--- a/tests/src/rules/no-restricted-paths.js
+++ b/tests/src/rules/no-restricted-paths.js
@@ -1,4 +1,4 @@
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import rule from 'rules/no-restricted-paths';
 
 import { getTSParsers, test, testFilePath } from '../utils';

--- a/tests/src/rules/no-self-import.js
+++ b/tests/src/rules/no-self-import.js
@@ -1,6 +1,6 @@
 import { test, testFilePath } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/no-self-import');

--- a/tests/src/rules/no-unassigned-import.js
+++ b/tests/src/rules/no-unassigned-import.js
@@ -1,7 +1,7 @@
 import { test } from '../utils';
 import * as path from 'path';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/no-unassigned-import');

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -4,7 +4,7 @@ import { getTSParsers, test, SYNTAX_CASES, testVersion, parsers } from '../utils
 
 import { CASE_SENSITIVE_FS } from 'eslint-module-utils/resolve';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/no-unresolved');

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -2,7 +2,7 @@ import { test, testVersion, testFilePath, getTSParsers, parsers } from '../utils
 import jsxConfig from '../../../config/react';
 import typescriptConfig from '../../../config/typescript';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import fs from 'fs';
 import eslintPkg from 'eslint/package.json';
 import semver from 'semver';

--- a/tests/src/rules/no-useless-path-segments.js
+++ b/tests/src/rules/no-useless-path-segments.js
@@ -1,5 +1,5 @@
 import { parsers, test } from '../utils';
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 const rule = require('rules/no-useless-path-segments');

--- a/tests/src/rules/no-webpack-loader-syntax.js
+++ b/tests/src/rules/no-webpack-loader-syntax.js
@@ -1,6 +1,6 @@
 import { test, getTSParsers, parsers } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import semver from 'semver';
 
 const ruleTester = new RuleTester();

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -1,7 +1,6 @@
 import { test, getTSParsers, getNonDefaultParsers, testFilePath, parsers } from '../utils';
 
-import { RuleTester } from 'eslint';
-import { withoutAutofixOutput } from '../rule-tester';
+import { RuleTester, withoutAutofixOutput } from '../rule-tester';
 import eslintPkg from 'eslint/package.json';
 import semver from 'semver';
 import flatMap from 'array.prototype.flatmap';

--- a/tests/src/rules/prefer-default-export.js
+++ b/tests/src/rules/prefer-default-export.js
@@ -1,6 +1,6 @@
 import { test, testVersion, getNonDefaultParsers, parsers } from '../utils';
 
-import { RuleTester } from 'eslint';
+import { RuleTester } from '../rule-tester';
 import semver from 'semver';
 import { version as tsEslintVersion } from 'typescript-eslint-parser/package.json';
 

--- a/tests/src/rules/unambiguous.js
+++ b/tests/src/rules/unambiguous.js
@@ -1,5 +1,4 @@
-import { RuleTester } from 'eslint';
-import { withoutAutofixOutput } from '../rule-tester';
+import { RuleTester, withoutAutofixOutput } from '../rule-tester';
 import { parsers } from '../utils';
 
 const ruleTester = new RuleTester();


### PR DESCRIPTION
This switches all tests over to sourcing `RuleTester` from an internal location which currently re-exports `RuleTester` from `eslint`, making it easier to later replace with a custom implementation to support ESLint v9 flat config

Also see #2996