### PR TITLE
FIx  Key "plugins": Cannot redefine plugin "import". when used in fla…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ const importPlugin = {
 const createFlatConfig = (baseConfig, configName) => ({
   ...baseConfig,
   name: `import/${configName}`,
-  plugins: { import: importPlugin },
+  plugins: { 'import': importPlugin },
 });
 
 export const flatConfigs = {


### PR DESCRIPTION
Fix for:
Oops! Something went wrong! :(

ESLint: 9.12.0

ConfigError: Config (unnamed): Key "plugins": Cannot redefine plugin "import".
    at rethrowConfigError (/Users/atrzeciak/workspace/uber/uber-paste/uber-paste/node_modules/@eslint/config-array/dist/cjs/index.cjs:303:8)
    