### PR TITLE
[New] add TypeScript types

### DIFF
--- a/.github/workflows/node-pretest.yml
+++ b/.github/workflows/node-pretest.yml
@@ -18,6 +18,19 @@ jobs:
   #         skip-ls-check: true
   #     - run: npm run pretest
 
+  types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ljharb/actions/node/install@main
+        name: 'npm install'
+        with:
+          skip-ls-check: true
+      # for some reason we've got to force typescript to install here
+      # even though the npm script has `typescript@latest`
+      - run: npm i --force typescript@latest
+      - run: npm run test-types
+
   posttest:
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Added
 - add [`enforce-node-protocol-usage`] rule and `import/node-version` setting ([#3024], thanks [@GoldStrikeArch] and [@sevenc-nanashi])
+- add TypeScript types ([#3097], thanks [@G-Rath])
 
 ### Changed
 - [Docs] [`extensions`], [`order`]: improve documentation ([#3106], thanks [@Xunnamius])
@@ -1161,6 +1162,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#3106]: https://github.com/import-js/eslint-plugin-import/pull/3106
+[#3097]: https://github.com/import-js/eslint-plugin-import/pull/3097
 [#3073]: https://github.com/import-js/eslint-plugin-import/pull/3073
 [#3072]: https://github.com/import-js/eslint-plugin-import/pull/3072
 [#3071]: https://github.com/import-js/eslint-plugin-import/pull/3071

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,33 @@
+import { ESLint, Linter, Rule } from 'eslint';
+
+declare const plugin: ESLint.Plugin & {
+  meta: {
+    name: string;
+    version: string;
+  };
+  configs: {
+    'recommended': Linter.LegacyConfig;
+    'errors': Linter.LegacyConfig;
+    'warnings': Linter.LegacyConfig;
+    'stage-0': Linter.LegacyConfig;
+    'react': Linter.LegacyConfig;
+    'react-native': Linter.LegacyConfig;
+    'electron': Linter.LegacyConfig;
+    'typescript': Linter.LegacyConfig;
+  };
+  flatConfigs: {
+    'recommended': Linter.FlatConfig;
+    'errors': Linter.FlatConfig;
+    'warnings': Linter.FlatConfig;
+    'stage-0': Linter.FlatConfig;
+    'react': Linter.FlatConfig;
+    'react-native': Linter.FlatConfig;
+    'electron': Linter.FlatConfig;
+    'typescript': Linter.FlatConfig;
+  };
+  rules: {
+    [key: string]: Rule.RuleModule;
+  };
+};
+
+export = plugin;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=4"
   },
   "main": "lib/index.js",
+  "types": "index.d.ts",
   "directories": {
     "test": "tests"
   },
@@ -16,7 +17,8 @@
     "docs",
     "lib",
     "config",
-    "memo-parser/{*.js,LICENSE,*.md}"
+    "memo-parser/{*.js,LICENSE,*.md}",
+    "index.d.ts"
   ],
   "scripts": {
     "prebuild": "rimraf lib",
@@ -34,6 +36,7 @@
     "test-examples": "npm run build && npm run test-example:legacy && npm run test-example:flat",
     "test-example:legacy": "cd examples/legacy && npm install && npm run lint",
     "test-example:flat": "cd examples/flat && npm install && npm run lint",
+    "test-types": "npx --package typescript@latest tsc --noEmit index.d.ts",
     "prepublishOnly": "safe-publish-latest && npm run build",
     "prepublish": "not-in-publish || npm run prepublishOnly",
     "preupdate:eslint-docs": "npm run build",
@@ -63,6 +66,7 @@
     "@angular-eslint/template-parser": "^13.5.0",
     "@eslint/import-test-order-redirect-scoped": "file:./tests/files/order-redirect-scoped",
     "@test-scope/some-module": "file:./tests/files/symlinked-module",
+    "@types/eslint": "^8.56.12",
     "@typescript-eslint/parser": "^2.23.0 || ^3.3.0 || ^4.29.3 || ^5.10.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",


### PR DESCRIPTION
For now I've just typed these out manually based on what we're using internally - while it would be good to have some tests at some point, I'm hoping/recommending not blocking on that for now as I think the types are small enough to be easy to maintain manually for the time being.

Resolves #3090