### PR TITLE
[Docs] `dynamic-import-chunkname`:  fix typo in usage of the rule

### DIFF
--- a/docs/rules/dynamic-import-chunkname.md
+++ b/docs/rules/dynamic-import-chunkname.md
@@ -15,7 +15,7 @@ You can also configure the regex format you'd like to accept for the webpackChun
 
  ```javascript
 {
-  "dynamic-import-chunkname": [2, {
+  "import/dynamic-import-chunkname": [2, {
     importFunctions: ["dynamicImport"],
     webpackChunknameFormat: "[a-zA-Z0-57-9-/_]+",
     allowEmpty: false


### PR DESCRIPTION
when setting up the rule in my app, I found out that there is a typo in the usage example of the `dynamic-import-chunkname` rule