### PR TITLE
[meta] issue template with guidance for bug reports

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,10 @@
+<!-- Reporting a bug? -->
+<!--
+  Please provide the output of running ESLint with this environment variable: `DEBUG=eslint-plugin-import:*`
+  Windows:      `set DEBUG=eslint-plugin-import:* & eslint .`
+  Linux/Mac: `export DEBUG=eslint-plugin-import:* & eslint .`
+
+  It will also be helpful if you can provide a minimal reproducible example
+  Preferably a GitHub repository containing all the code & ESLint config required
+  https://stackoverflow.com/help/minimal-reproducible-example
+-->


### PR DESCRIPTION
In relation to a bug report about the plugin failing silently in some edge case: https://github.com/import-js/eslint-plugin-import/issues/3107

It's unclear how to make `eslint-plugin-import` show its detailed logs, which would have made the failure not silent, and saved contributor time in triage and debugging.

Lets add an issue template, with instructions that will guide the issue author to:
- Enable debug logging for the plugin, to narrow down what failed
- Provide an [MCVE](https://stackoverflow.com/help/minimal-reproducible-example)