### PR TITLE
[utils] [fix] `unambiguous`: detect modules exported from minified code

### DIFF
--- a/tests/files/minified/no-newline.js
+++ b/tests/files/minified/no-newline.js
@@ -1,0 +1,3 @@
+function y() {
+    console.log("y");
+}export {y};

--- a/tests/files/minified/one-line-no-semi-renamed.js
+++ b/tests/files/minified/one-line-no-semi-renamed.js
@@ -1,0 +1,1 @@
+function a(){console.log('foo')}export{a as foo};

--- a/tests/files/minified/one-line-no-semi.js
+++ b/tests/files/minified/one-line-no-semi.js
@@ -1,0 +1,1 @@
+function a(){return true}export{a};

--- a/tests/files/minified/one-line.js
+++ b/tests/files/minified/one-line.js
@@ -1,0 +1,1 @@
+function a(){console.log("foo")};export{a};

--- a/tests/src/core/getExports.js
+++ b/tests/src/core/getExports.js
@@ -465,6 +465,10 @@ describe('ExportMap', function () {
       ['bar.js', true],
       ['deep-es7/b.js', true],
       ['common.js', false],
+      ['./minified/no-newline.js', true],
+      ['./minified/one-line-no-semi-renamed.js', true],
+      ['./minified/one-line-no-semi.js', true],
+      ['./minified/one-line.js', true],
     ];
 
     for (const [testFile, expectedRegexResult] of testFiles) {

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -5,6 +5,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Fixed
+- `unambiguous`: detect modules exported from minified code ([#3124], thanks [@michaelfaith])
+
 ### Changed
 - [refactor] `parse`: avoid using a regex here (thanks [@ljharb])
 
@@ -180,6 +183,7 @@ Yanked due to critical issue with cache key resulting from #839.
 ### Fixed
 - `unambiguous.test()` regex is now properly in multiline mode
 
+[#3124]: https://github.com/import-js/eslint-plugin-import/pull/3124
 [#3072]: https://github.com/import-js/eslint-plugin-import/pull/3072
 [#3061]: https://github.com/import-js/eslint-plugin-import/pull/3061
 [#3057]: https://github.com/import-js/eslint-plugin-import/pull/3057
@@ -230,6 +234,7 @@ Yanked due to critical issue with cache key resulting from #839.
 [@JounQin]: https://github.com/JounQin
 [@kaiyoma]: https://github.com/kaiyoma
 [@leipert]: https://github.com/leipert
+[@ljharb]: https://github.com/ljharb
 [@manuth]: https://github.com/manuth
 [@maxkomarychev]: https://github.com/maxkomarychev
 [@mgwalker]: https://github.com/mgwalker
@@ -238,6 +243,7 @@ Yanked due to critical issue with cache key resulting from #839.
 [@nicolo-ribaudo]: https://github.com/nicolo-ribaudo
 [@pmcelhaney]: https://github.com/pmcelhaney
 [@sergei-startsev]: https://github.com/sergei-startsev
+[@silverwind]: https://github.com/silverwind
 [@sompylasar]: https://github.com/sompylasar
 [@timkraut]: https://github.com/timkraut
 [@vikr01]: https://github.com/vikr01

--- a/utils/unambiguous.js
+++ b/utils/unambiguous.js
@@ -2,7 +2,7 @@
 
 exports.__esModule = true;
 
-const pattern = /(^|;)\s*(export|import)((\s+\w)|(\s*[{*=]))|import\(/m;
+const pattern = /(^|[;})])\s*(export|import)((\s+\w)|(\s*[{*=]))|import\(/m;
 /**
  * detect possible imports/exports without a full parse.
  *


### PR DESCRIPTION
This change adjusts the regex pattern used to detect modules to support detection on minified code.

![image](https://github.com/user-attachments/assets/e66fc8a9-131f-4701-8af3-b84984c1cfe9)

Closes #3107 
