### PR TITLE
[Docs] add flat config guide for using `tseslint.config()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Changed
 - [Docs] [`extensions`], [`order`]: improve documentation ([#3106], thanks [@Xunnamius])
+- [Docs] add flat config guide for using `tseslint.config()` ([#3125], thanks [@lnuvy])
 
 ## [2.31.0] - 2024-10-03
 
@@ -1161,6 +1162,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3125]: https://github.com/import-js/eslint-plugin-import/pull/3125
 [#3106]: https://github.com/import-js/eslint-plugin-import/pull/3106
 [#3097]: https://github.com/import-js/eslint-plugin-import/pull/3097
 [#3073]: https://github.com/import-js/eslint-plugin-import/pull/3073
@@ -1913,6 +1915,7 @@ for info on changes for earlier releases.
 [@liuxingbaoyu]: https://github.com/liuxingbaoyu
 [@ljharb]: https://github.com/ljharb
 [@ljqx]: https://github.com/ljqx
+[@lnuvy]: https://github.com/lnuvy
 [@lo1tuma]: https://github.com/lo1tuma
 [@loganfsmyth]: https://github.com/loganfsmyth
 [@luczsoma]: https://github.com/luczsoma

--- a/README.md
+++ b/README.md
@@ -191,6 +191,26 @@ Make sure you have installed [`@typescript-eslint/parser`] and [`eslint-import-r
 [`@typescript-eslint/parser`]: https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/parser
 [`eslint-import-resolver-typescript`]: https://github.com/import-js/eslint-import-resolver-typescript
 
+### Config - Flat with `config()` in `typescript-eslint`
+
+If you are using the `config` method from [`typescript-eslint`](https://github.com/typescript-eslint/typescript-eslint), ensure that the `flatConfig` is included within the `extends` array.
+
+```js
+import tseslint from 'typescript-eslint';
+import importPlugin from 'eslint-plugin-import';
+import js from '@eslint/js';
+
+export default tseslint.config(
+  js.configs.recommended,
+  // other configs...
+  {
+    files: ['**/*.{ts,tsx}'],
+    extends: [importPlugin.flatConfigs.recommended],
+    // other configs...
+  }
+);
+```
+
 ## Resolvers
 
 With the advent of module bundlers and the current state of modules and module


### PR DESCRIPTION
I added a guide for using the `config()` method from `typescript-eslint` when setting flat config with eslint.config.js in a TypeScript project.

Related issue: #3123