### PR TITLE
[Fix] `order`: ensure arcane imports do not cause undefined behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Fixed
 - [`no-unused-modules`]: provide more meaningful error message when no .eslintrc is present ([#3116], thanks [@michaelfaith])
 - configs: added missing name attribute for eslint config inspector ([#3151], thanks [@NishargShah])
+- [`order`]: ensure arcane imports do not cause undefined behavior ([#3128], thanks [@Xunnamius])
 
 ### Changed
 - [Docs] [`extensions`], [`order`]: improve documentation ([#3106], thanks [@Xunnamius])
@@ -1173,6 +1174,7 @@ for info on changes for earlier releases.
 
 [#3151]: https://github.com/import-js/eslint-plugin-import/pull/3151
 [#3138]: https://github.com/import-js/eslint-plugin-import/pull/3138
+[#3128]: https://github.com/import-js/eslint-plugin-import/pull/3128
 [#3127]: https://github.com/import-js/eslint-plugin-import/pull/3127
 [#3125]: https://github.com/import-js/eslint-plugin-import/pull/3125
 [#3122]: https://github.com/import-js/eslint-plugin-import/pull/3122

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -535,6 +535,10 @@ function computeRank(context, ranks, importEntry, excludedImportTypes, isSorting
 
   if (typeof rank === 'undefined') {
     rank = ranks.groups[impType];
+
+    if (typeof rank === 'undefined') {
+      return -1;
+    }
   }
 
   if (isTypeOnlyImport && isSortingTypesGroup) {

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -3115,7 +3115,6 @@ context('TypeScript', function () {
           }),
           // Option alphabetize: {order: 'asc'} with type group & path group
           test({
-            // only: true,
             code: `
               import c from 'Bar';
               import a from 'foo';
@@ -3145,7 +3144,6 @@ context('TypeScript', function () {
           }),
           // Option alphabetize: {order: 'asc'} with path group
           test({
-            // only: true,
             code: `
               import c from 'Bar';
               import type { A } from 'foo';
@@ -3736,6 +3734,36 @@ context('TypeScript', function () {
                 sortTypesGroup: true,
                 'newlines-between': 'never',
                 'newlines-between-types': 'always',
+              },
+            ],
+          }),
+          // Ensure the rule doesn't choke and die on absolute paths trying to pass NaN around
+          test({
+            code: `
+              import fs from 'fs';
+
+              import '@scoped/package';
+              import type { B } from 'fs';
+
+              import type { A1 } from '/bad/bad/bad/bad';
+              import './a/b/c';
+              import type { A2 } from '/bad/bad/bad/bad';
+              import type { A3 } from '/bad/bad/bad/bad';
+              import type { D1 } from '/bad/bad/not/good';
+              import type { D2 } from '/bad/bad/not/good';
+              import type { D3 } from '/bad/bad/not/good';
+
+              import type { C } from '@something/else';
+
+              import type { E } from './index.js';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: { order: 'asc' },
+                groups: ['builtin', 'type', 'unknown', 'external'],
+                sortTypesGroup: true,
+                'newlines-between': 'always',
               },
             ],
           }),


### PR DESCRIPTION
Depends on #3127

**This PR implements in `import/order`: a fix to ensure `NaN` is never passed into rank-computing functions, which can result in undefined behavior.**

A demo package containing this fix is temporarily available for easy testing:

```bash
npm install --save-dev eslint-plugin-import@npm:@-xun/eslint-plugin-import-experimental
```

## Ensure strange imports do not cause strange behavior

There are certain edge cases where a `NaN` rank gets passed around, such as using an import with an absolute specifier under certain configurations. The fix concerns the `computeRank` function.

This PR includes a unit test to catch potential regressions.