### PR TITLE
[New] `order`: add `consolidateIslands` option to collapse excess spacing for aesthetically pleasing imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`extensions`]: add `pathGroupOverrides to allow enforcement decision overrides based on specifier ([#3105], thanks [@Xunnamius])
 - [`order`]: add `sortTypesGroup` option to allow intragroup sorting of type-only imports ([#3104], thanks [@Xunnamius])
 - [`order`]: add `newlines-between-types` option to control intragroup sorting of type-only imports ([#3127], thanks [@Xunnamius])
+- [`order`]: add `consolidateIslands` option to collapse excess spacing for aesthetically pleasing imports ([#3129], thanks [@Xunnamius])
 
 ### Fixed
 - [`no-unused-modules`]: provide more meaningful error message when no .eslintrc is present ([#3116], thanks [@michaelfaith])
@@ -1174,6 +1175,7 @@ for info on changes for earlier releases.
 
 [#3151]: https://github.com/import-js/eslint-plugin-import/pull/3151
 [#3138]: https://github.com/import-js/eslint-plugin-import/pull/3138
+[#3129]: https://github.com/import-js/eslint-plugin-import/pull/3129
 [#3128]: https://github.com/import-js/eslint-plugin-import/pull/3128
 [#3127]: https://github.com/import-js/eslint-plugin-import/pull/3127
 [#3125]: https://github.com/import-js/eslint-plugin-import/pull/3125

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -530,7 +530,7 @@ ruleTester.run('order', rule, {
         },
       ],
     }),
-    // Option newlines-between: 'always' with multiline imports #1
+    // Option newlines-between: 'always' with multi-line imports #1
     test({
       code: `
         import path from 'path';
@@ -546,7 +546,7 @@ ruleTester.run('order', rule, {
       `,
       options: [{ 'newlines-between': 'always' }],
     }),
-    // Option newlines-between: 'always' with multiline imports #2
+    // Option newlines-between: 'always' with multi-line imports #2
     test({
       code: `
         import path from 'path';
@@ -557,7 +557,7 @@ ruleTester.run('order', rule, {
       `,
       options: [{ 'newlines-between': 'always' }],
     }),
-    // Option newlines-between: 'always' with multiline imports #3
+    // Option newlines-between: 'always' with multi-line imports #3
     test({
       code: `
         import foo
@@ -668,6 +668,33 @@ ruleTester.run('order', rule, {
       options: [
         {
           'newlines-between': 'always-and-inside-groups',
+        },
+      ],
+    }),
+    // Option newlines-between: 'always-and-inside-groups' and consolidateIslands: true
+    test({
+      code: `
+        var fs = require('fs');
+        var path = require('path');
+        var util = require('util');
+
+        var async = require('async');
+
+        var relParent1 = require('../foo');
+
+        var {
+          relParent2 } = require('../');
+
+        var relParent3 = require('../bar');
+
+        var sibling = require('./foo');
+        var sibling2 = require('./bar');
+        var sibling3 = require('./foobar');
+      `,
+      options: [
+        {
+          'newlines-between': 'always-and-inside-groups',
+          consolidateIslands: 'inside-groups',
         },
       ],
     }),
@@ -1343,19 +1370,19 @@ ruleTester.run('order', rule, {
         message: '`fs` import should occur before import of `async`',
       }],
     }),
-    // fix order with multilines comments at the end and start of line
+    // fix order with multi-lines comments at the end and start of line
     test({
       code: `
-        /* multiline1
-          comment1 */  var async = require('async'); /* multiline2
-          comment2 */  var fs = require('fs'); /* multiline3
+        /* multi-line1
+          comment1 */  var async = require('async'); /* multi-line2
+          comment2 */  var fs = require('fs'); /* multi-line3
           comment3 */
       `,
       output: `
-        /* multiline1
+        /* multi-line1
           comment1 */  var fs = require('fs');` + ' '  + `
-  var async = require('async'); /* multiline2
-          comment2 *//* multiline3
+  var async = require('async'); /* multi-line2
+          comment2 *//* multi-line3
           comment3 */
       `,
       errors: [{
@@ -1376,7 +1403,7 @@ ruleTester.run('order', rule, {
         message: '`fs` import should occur before import of `async`',
       }],
     }),
-    // fix order of multiline import
+    // fix order of multi-line import
     test({
       code: `
         var async = require('async');
@@ -1901,10 +1928,10 @@ ruleTester.run('order', rule, {
         },
       ],
     }),
-    // Cannot fix newlines-between with multiline comment after
+    // Cannot fix newlines-between with multi-line comment after
     test(withoutAutofixOutput({
       code: `
-        var fs = require('fs'); /* multiline
+        var fs = require('fs'); /* multi-line
         comment */
 
         var index = require('./');
@@ -2952,7 +2979,7 @@ ruleTester.run('order', rule, {
         message: '`A.C` export should occur after export of `A.B`',
       }],
     }),
-    // multiline named specifiers & trailing commas
+    // multi-line named specifiers & trailing commas
     test({
       code: `
         const {
@@ -3032,6 +3059,156 @@ ruleTester.run('order', rule, {
         }],
       }),
     ],
+    // Option newlines-between: 'always-and-inside-groups' and consolidateIslands: true
+    test({
+      code: `
+        var fs = require('fs');
+        var path = require('path');
+        var { util1, util2, util3 } = require('util');
+        var async = require('async');
+        var relParent1 = require('../foo');
+        var {
+          relParent21,
+          relParent22,
+          relParent23,
+          relParent24,
+        } = require('../');
+        var relParent3 = require('../bar');
+        var { sibling1,
+          sibling2, sibling3 } = require('./foo');
+        var sibling2 = require('./bar');
+        var sibling3 = require('./foobar');
+      `,
+      output: `
+        var fs = require('fs');
+        var path = require('path');
+        var { util1, util2, util3 } = require('util');
+
+        var async = require('async');
+
+        var relParent1 = require('../foo');
+
+        var {
+          relParent21,
+          relParent22,
+          relParent23,
+          relParent24,
+        } = require('../');
+
+        var relParent3 = require('../bar');
+
+        var { sibling1,
+          sibling2, sibling3 } = require('./foo');
+
+        var sibling2 = require('./bar');
+        var sibling3 = require('./foobar');
+      `,
+      options: [
+        {
+          'newlines-between': 'always-and-inside-groups',
+          consolidateIslands: 'inside-groups',
+        },
+      ],
+      errors: [
+        {
+          message: 'There should be at least one empty line between import groups',
+          line: 4,
+        },
+        {
+          message: 'There should be at least one empty line between import groups',
+          line: 5,
+        },
+        {
+          message: 'There should be at least one empty line between this import and the multi-line import that follows it',
+          line: 6,
+        },
+        {
+          message: 'There should be at least one empty line between this multi-line import and the import that follows it',
+          line: 12,
+        },
+        {
+          message: 'There should be at least one empty line between import groups',
+          line: 13,
+        },
+        {
+          message: 'There should be at least one empty line between this multi-line import and the import that follows it',
+          line: 15,
+        },
+      ],
+    }),
+    test({
+      code: `
+        var fs = require('fs');
+
+        var path = require('path');
+
+        var { util1, util2, util3 } = require('util');
+
+        var async = require('async');
+
+        var relParent1 = require('../foo');
+
+        var {
+          relParent21,
+          relParent22,
+          relParent23,
+          relParent24,
+        } = require('../');
+
+        var relParent3 = require('../bar');
+
+        var { sibling1,
+          sibling2, sibling3 } = require('./foo');
+
+        var sibling2 = require('./bar');
+
+        var sibling3 = require('./foobar');
+      `,
+      output: `
+        var fs = require('fs');
+        var path = require('path');
+        var { util1, util2, util3 } = require('util');
+
+        var async = require('async');
+
+        var relParent1 = require('../foo');
+
+        var {
+          relParent21,
+          relParent22,
+          relParent23,
+          relParent24,
+        } = require('../');
+
+        var relParent3 = require('../bar');
+
+        var { sibling1,
+          sibling2, sibling3 } = require('./foo');
+
+        var sibling2 = require('./bar');
+        var sibling3 = require('./foobar');
+      `,
+      options: [
+        {
+          'newlines-between': 'always-and-inside-groups',
+          consolidateIslands: 'inside-groups',
+        },
+      ],
+      errors: [
+        {
+          message: 'There should be no empty lines between this single-line import and the single-line import that follows it',
+          line: 2,
+        },
+        {
+          message: 'There should be no empty lines between this single-line import and the single-line import that follows it',
+          line: 4,
+        },
+        {
+          message: 'There should be no empty lines between this single-line import and the single-line import that follows it',
+          line: 24,
+        },
+      ],
+    }),
   ].filter(Boolean),
 });
 
@@ -3767,6 +3944,1025 @@ context('TypeScript', function () {
               },
             ],
           }),
+          // Option: sortTypesGroup: true and newlines-between-types: 'always-and-inside-groups' and consolidateIslands: 'inside-groups'
+          test({
+            code: `
+              import c from 'Bar';
+              import d from 'bar';
+
+              import {
+                aa,
+                bb,
+                cc,
+                dd,
+                ee,
+                ff,
+                gg
+              } from 'baz';
+
+              import {
+                hh,
+                ii,
+                jj,
+                kk,
+                ll,
+                mm,
+                nn
+              } from 'fizz';
+
+              import a from 'foo';
+
+              import b from 'dirA/bar';
+
+              import index from './';
+
+              import type { AA,
+                BB, CC } from 'abc';
+
+              import type { Z } from 'fizz';
+
+              import type {
+                A,
+                B
+              } from 'foo';
+
+              import type { C2 } from 'dirB/Bar';
+
+              import type {
+                D2,
+                X2,
+                Y2
+              } from 'dirB/bar';
+
+              import type { E2 } from 'dirB/baz';
+
+              import type { C3 } from 'dirC/Bar';
+
+              import type {
+                D3,
+                X3,
+                Y3
+              } from 'dirC/bar';
+
+              import type { E3 } from 'dirC/baz';
+              import type { F3 } from 'dirC/caz';
+
+              import type { C1 } from 'dirA/Bar';
+
+              import type {
+                D1,
+                X1,
+                Y1
+              } from 'dirA/bar';
+
+              import type { E1 } from 'dirA/baz';
+
+              import type { F } from './index.js';
+
+              import type { G } from './aaa.js';
+              import type { H } from './bbb';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: { order: 'asc' },
+                groups: ['external', 'internal', 'index', 'type'],
+                pathGroups: [
+                  {
+                    pattern: 'dirA/**',
+                    group: 'internal',
+                    position: 'after',
+                  },
+                  {
+                    pattern: 'dirB/**',
+                    group: 'internal',
+                    position: 'before',
+                  },
+                  {
+                    pattern: 'dirC/**',
+                    group: 'internal',
+                  },
+                ],
+                'newlines-between': 'always-and-inside-groups',
+                'newlines-between-types': 'always-and-inside-groups',
+                pathGroupsExcludedImportTypes: [],
+                sortTypesGroup: true,
+                consolidateIslands: 'inside-groups',
+              },
+            ],
+          }),
+          // Option: sortTypesGroup: true and newlines-between-types: 'always-and-inside-groups' and consolidateIslands: 'never' (default)
+          test({
+            code: `
+              import c from 'Bar';
+              import d from 'bar';
+
+              import {
+                aa,
+                bb,
+                cc,
+                dd,
+                ee,
+                ff,
+                gg
+              } from 'baz';
+
+              import {
+                hh,
+                ii,
+                jj,
+                kk,
+                ll,
+                mm,
+                nn
+              } from 'fizz';
+
+              import a from 'foo';
+
+              import b from 'dirA/bar';
+
+              import index from './';
+
+              import type { AA,
+                BB, CC } from 'abc';
+
+              import type { Z } from 'fizz';
+
+              import type {
+                A,
+                B
+              } from 'foo';
+
+              import type { C2 } from 'dirB/Bar';
+
+              import type {
+                D2,
+                X2,
+                Y2
+              } from 'dirB/bar';
+
+              import type { E2 } from 'dirB/baz';
+
+              import type { C3 } from 'dirC/Bar';
+
+              import type {
+                D3,
+                X3,
+                Y3
+              } from 'dirC/bar';
+
+              import type { E3 } from 'dirC/baz';
+              import type { F3 } from 'dirC/caz';
+
+              import type { C1 } from 'dirA/Bar';
+
+              import type {
+                D1,
+                X1,
+                Y1
+              } from 'dirA/bar';
+
+              import type { E1 } from 'dirA/baz';
+
+              import type { F } from './index.js';
+
+              import type { G } from './aaa.js';
+              import type { H } from './bbb';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: { order: 'asc' },
+                groups: ['external', 'internal', 'index', 'type'],
+                pathGroups: [
+                  {
+                    pattern: 'dirA/**',
+                    group: 'internal',
+                    position: 'after',
+                  },
+                  {
+                    pattern: 'dirB/**',
+                    group: 'internal',
+                    position: 'before',
+                  },
+                  {
+                    pattern: 'dirC/**',
+                    group: 'internal',
+                  },
+                ],
+                'newlines-between': 'always-and-inside-groups',
+                'newlines-between-types': 'always-and-inside-groups',
+                pathGroupsExcludedImportTypes: [],
+                sortTypesGroup: true,
+                consolidateIslands: 'never',
+              },
+            ],
+          }),
+          // Ensure consolidateIslands: 'inside-groups', newlines-between: 'always-and-inside-groups', and newlines-between-types: 'never' do not fight for dominance
+          test({
+            code: `
+              import makeVanillaYargs from 'yargs/yargs';
+
+              import { createDebugLogger } from 'multiverse+rejoinder';
+
+              import { globalDebuggerNamespace } from 'rootverse+bfe:src/constant.ts';
+              import { ErrorMessage, type KeyValueEntry } from 'rootverse+bfe:src/error.ts';
+
+              import {
+                $artificiallyInvoked,
+                $canonical,
+                $exists,
+                $genesis
+              } from 'rootverse+bfe:src/symbols.ts';
+
+              import type {
+                Entries,
+                LiteralUnion,
+                OmitIndexSignature,
+                Promisable,
+                StringKeyOf
+              } from 'type-fest';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: {
+                  order: 'asc',
+                  orderImportKind: 'asc',
+                  caseInsensitive: true,
+                },
+                named: {
+                  enabled: true,
+                  types: 'types-last',
+                },
+                groups: [
+                  'builtin',
+                  'external',
+                  'internal',
+                  ['parent', 'sibling', 'index'],
+                  ['object', 'type'],
+                ],
+                pathGroups: [
+                  {
+                    pattern: 'multiverse{*,*/**}',
+                    group: 'external',
+                    position: 'after',
+                  },
+                  {
+                    pattern: 'rootverse{*,*/**}',
+                    group: 'external',
+                    position: 'after',
+                  },
+                  {
+                    pattern: 'universe{*,*/**}',
+                    group: 'external',
+                    position: 'after',
+                  },
+                ],
+                distinctGroup: true,
+                pathGroupsExcludedImportTypes: ['builtin', 'object'],
+                'newlines-between': 'always-and-inside-groups',
+                'newlines-between-types': 'never',
+                sortTypesGroup: true,
+                consolidateIslands: 'inside-groups',
+              },
+            ],
+          }),
+          // Ensure consolidateIslands: 'inside-groups', newlines-between: 'never', and newlines-between-types: 'always-and-inside-groups' do not fight for dominance
+          test({
+            code: `
+              import makeVanillaYargs from 'yargs/yargs';
+              import { createDebugLogger } from 'multiverse+rejoinder';
+              import { globalDebuggerNamespace } from 'rootverse+bfe:src/constant.ts';
+              import { ErrorMessage, type KeyValueEntry } from 'rootverse+bfe:src/error.ts';
+              import { $artificiallyInvoked } from 'rootverse+bfe:src/symbols.ts';
+
+              import type {
+                Entries,
+                LiteralUnion,
+                OmitIndexSignature,
+                Promisable,
+                StringKeyOf
+              } from 'type-fest';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: {
+                  order: 'asc',
+                  orderImportKind: 'asc',
+                  caseInsensitive: true,
+                },
+                named: {
+                  enabled: true,
+                  types: 'types-last',
+                },
+                groups: [
+                  'builtin',
+                  'external',
+                  'internal',
+                  ['parent', 'sibling', 'index'],
+                  ['object', 'type'],
+                ],
+                pathGroups: [
+                  {
+                    pattern: 'multiverse{*,*/**}',
+                    group: 'external',
+                    position: 'after',
+                  },
+                  {
+                    pattern: 'rootverse{*,*/**}',
+                    group: 'external',
+                    position: 'after',
+                  },
+                  {
+                    pattern: 'universe{*,*/**}',
+                    group: 'external',
+                    position: 'after',
+                  },
+                ],
+                distinctGroup: true,
+                pathGroupsExcludedImportTypes: ['builtin', 'object'],
+                'newlines-between': 'never',
+                'newlines-between-types': 'always-and-inside-groups',
+                sortTypesGroup: true,
+                consolidateIslands: 'inside-groups',
+              },
+            ],
+          }),
+          test({
+            code: `
+              import c from 'Bar';
+              import d from 'bar';
+
+              import {
+                aa,
+                bb,
+                cc,
+                dd,
+                ee,
+                ff,
+                gg
+              } from 'baz';
+
+              import {
+                hh,
+                ii,
+                jj,
+                kk,
+                ll,
+                mm,
+                nn
+              } from 'fizz';
+
+              import a from 'foo';
+              import b from 'dirA/bar';
+              import index from './';
+
+              import type { AA,
+                BB, CC } from 'abc';
+
+              import type { Z } from 'fizz';
+
+              import type {
+                A,
+                B
+              } from 'foo';
+
+              import type { C2 } from 'dirB/Bar';
+
+              import type {
+                D2,
+                X2,
+                Y2
+              } from 'dirB/bar';
+
+              import type { E2 } from 'dirB/baz';
+
+              import type { C3 } from 'dirC/Bar';
+
+              import type {
+                D3,
+                X3,
+                Y3
+              } from 'dirC/bar';
+
+              import type { E3 } from 'dirC/baz';
+              import type { F3 } from 'dirC/caz';
+
+              import type { C1 } from 'dirA/Bar';
+
+              import type {
+                D1,
+                X1,
+                Y1
+              } from 'dirA/bar';
+
+              import type { E1 } from 'dirA/baz';
+
+              import type { F } from './index.js';
+
+              import type { G } from './aaa.js';
+              import type { H } from './bbb';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: { order: 'asc' },
+                groups: ['external', 'internal', 'index', 'type'],
+                pathGroups: [
+                  {
+                    pattern: 'dirA/**',
+                    group: 'internal',
+                    position: 'after',
+                  },
+                  {
+                    pattern: 'dirB/**',
+                    group: 'internal',
+                    position: 'before',
+                  },
+                  {
+                    pattern: 'dirC/**',
+                    group: 'internal',
+                  },
+                ],
+                'newlines-between': 'never',
+                'newlines-between-types': 'always-and-inside-groups',
+                pathGroupsExcludedImportTypes: [],
+                sortTypesGroup: true,
+                consolidateIslands: 'inside-groups',
+              },
+            ],
+          }),
+          test({
+            code: `
+              import assert from 'assert';
+              import { isNativeError } from 'util/types';
+
+              import { runNoRejectOnBadExit } from '@-xun/run';
+              import { TrialError } from 'named-app-errors';
+              import { resolve as resolverLibrary } from 'resolve.exports';
+
+              import { ${supportsImportTypeSpecifiers ? 'toAbsolutePath, type AbsolutePath' : 'AbsolutePath, toAbsolutePath'} } from 'rootverse+project-utils:src/fs.ts';
+
+              import type { PackageJson } from 'type-fest';
+              // Some comment about remembering to do something
+              import type { XPackageJson } from 'rootverse:src/assets/config/_package.json.ts';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: {
+                  order: 'asc',
+                  orderImportKind: 'asc',
+                  caseInsensitive: true,
+                },
+                named: {
+                  enabled: true,
+                  types: 'types-last',
+                },
+                groups: [
+                  'builtin',
+                  'external',
+                  'internal',
+                  ['parent', 'sibling', 'index'],
+                  ['object', 'type'],
+                ],
+                pathGroups: [
+                  {
+                    pattern: 'rootverse{*,*/**}',
+                    group: 'external',
+                    position: 'after',
+                  },
+                ],
+                distinctGroup: true,
+                pathGroupsExcludedImportTypes: ['builtin', 'object'],
+                'newlines-between': 'always-and-inside-groups',
+                'newlines-between-types': 'never',
+                sortTypesGroup: true,
+                consolidateIslands: 'inside-groups',
+              },
+            ],
+          }),
+
+          // Documentation passing example #1 for newlines-between
+          test({
+            code: `
+              import fs from 'fs';
+              import path from 'path';
+
+              import sibling from './foo';
+
+              import index from './';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                'newlines-between': 'always',
+              },
+            ],
+          }),
+          // Documentation passing example #2 for newlines-between
+          test({
+            code: `
+              import fs from 'fs';
+
+              import path from 'path';
+
+              import sibling from './foo';
+
+              import index from './';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                'newlines-between': 'always-and-inside-groups',
+              },
+            ],
+          }),
+          // Documentation passing example #3 for newlines-between
+          test({
+            code: `
+              import fs from 'fs';
+              import path from 'path';
+              import sibling from './foo';
+              import index from './';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                'newlines-between': 'never',
+              },
+            ],
+          }),
+          // Documentation passing example #1 for alphabetize
+          test({
+            code: `
+              import blist2 from 'blist';
+              import blist from 'BList';
+              import * as classnames from 'classnames';
+              import aTypes from 'prop-types';
+              import React, { PureComponent } from 'react';
+              import { compose, apply } from 'xcompose';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: {
+                  order: 'asc',
+                  caseInsensitive: true,
+                },
+              },
+            ],
+          }),
+          // (not an example, but we also test caseInsensitive: false for completeness)
+          test({
+            code: `
+              import blist from 'BList';
+              import blist2 from 'blist';
+              import * as classnames from 'classnames';
+              import aTypes from 'prop-types';
+              import React, { PureComponent } from 'react';
+              import { compose, apply } from 'xcompose';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: {
+                  order: 'asc',
+                  caseInsensitive: false,
+                },
+              },
+            ],
+          }),
+          // Documentation passing example #1 for named
+          test({
+            code: `
+              import { apply, compose } from 'xcompose';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                named: true,
+                alphabetize: {
+                  order: 'asc',
+                },
+              },
+            ],
+          }),
+          // Documentation passing example #1 for warnOnUnassignedImports
+          test({
+            code: `
+              import fs from 'fs';
+              import path from 'path';
+              import './styles.css';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                warnOnUnassignedImports: true,
+              },
+            ],
+          }),
+          // Documentation passing example #1 for sortTypesGroup
+          test({
+            code: `
+              import type A from "fs";
+              import type B from "path";
+              import type C from "../foo.js";
+              import type D from "./bar.js";
+              import type E from './';
+
+              import a from "fs";
+              import b from "path";
+              import c from "../foo.js";
+              import d from "./bar.js";
+              import e from "./";
+            `,
+            ...parserConfig,
+            options: [
+              {
+                groups: ['type', 'builtin', 'parent', 'sibling', 'index'],
+                alphabetize: { order: 'asc' },
+                sortTypesGroup: true,
+              },
+            ],
+          }),
+          // (not an example, but we also test the reverse for completeness)
+          test({
+            code: `
+              import a from "fs";
+              import b from "path";
+              import c from "../foo.js";
+              import d from "./bar.js";
+              import e from "./";
+
+              import type A from "fs";
+              import type B from "path";
+              import type C from "../foo.js";
+              import type D from "./bar.js";
+              import type E from './';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                groups: ['builtin', 'parent', 'sibling', 'index', 'type'],
+                sortTypesGroup: true,
+              },
+            ],
+          }),
+          // Documentation passing example #1 for newlines-between-types
+          test({
+            code: `
+              import type A from "fs";
+              import type B from "path";
+              import type C from "../foo.js";
+              import type D from "./bar.js";
+              import type E from './';
+
+              import a from "fs";
+              import b from "path";
+
+              import c from "../foo.js";
+
+              import d from "./bar.js";
+
+              import e from "./";
+            `,
+            ...parserConfig,
+            options: [
+              {
+                groups: ['type', 'builtin', 'parent', 'sibling', 'index'],
+                sortTypesGroup: true,
+                'newlines-between': 'always',
+                'newlines-between-types': 'ignore',
+              },
+            ],
+          }),
+          // (not an example, but we also test the reverse for completeness)
+          test({
+            code: `
+              import a from "fs";
+              import b from "path";
+
+              import c from "../foo.js";
+
+              import d from "./bar.js";
+
+              import e from "./";
+
+              import type A from "fs";
+              import type B from "path";
+              import type C from "../foo.js";
+              import type D from "./bar.js";
+              import type E from './';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                groups: ['builtin', 'parent', 'sibling', 'index', 'type'],
+                sortTypesGroup: true,
+                'newlines-between': 'always',
+                'newlines-between-types': 'ignore',
+              },
+            ],
+          }),
+          // Documentation passing example #2 for newlines-between-types
+          test({
+            code: `
+              import type A from "fs";
+              import type B from "path";
+
+              import type C from "../foo.js";
+
+              import type D from "./bar.js";
+
+              import type E from './';
+
+              import a from "fs";
+              import b from "path";
+              import c from "../foo.js";
+              import d from "./bar.js";
+              import e from "./";
+            `,
+            ...parserConfig,
+            options: [
+              {
+                groups: ['type', 'builtin', 'parent', 'sibling', 'index'],
+                sortTypesGroup: true,
+                'newlines-between': 'never',
+                'newlines-between-types': 'always',
+              },
+            ],
+          }),
+          // (not an example, but we also test the reverse for completeness)
+          test({
+            code: `
+              import a from "fs";
+              import b from "path";
+              import c from "../foo.js";
+              import d from "./bar.js";
+              import e from "./";
+
+              import type A from "fs";
+              import type B from "path";
+
+              import type C from "../foo.js";
+
+              import type D from "./bar.js";
+
+              import type E from './';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                groups: ['builtin', 'parent', 'sibling', 'index', 'type'],
+                sortTypesGroup: true,
+                'newlines-between': 'never',
+                'newlines-between-types': 'always',
+              },
+            ],
+          }),
+          // Documentation passing example #1 for consolidateIslands
+          test({
+            code: `
+              var fs = require('fs');
+              var path = require('path');
+              var { util1, util2, util3 } = require('util');
+
+              var async = require('async');
+
+              var relParent1 = require('../foo');
+
+              var {
+                relParent21,
+                relParent22,
+                relParent23,
+                relParent24,
+              } = require('../');
+
+              var relParent3 = require('../bar');
+
+              var { sibling1,
+                sibling2, sibling3 } = require('./foo');
+
+              var sibling2 = require('./bar');
+              var sibling3 = require('./foobar');
+            `,
+            ...parserConfig,
+            options: [
+              {
+                'newlines-between': 'always-and-inside-groups',
+                consolidateIslands: 'inside-groups',
+              },
+            ],
+          }),
+          // Documentation passing example #2 for consolidateIslands
+          test({
+            code: `
+              import c from 'Bar';
+              import d from 'bar';
+
+              import {
+                aa,
+                bb,
+                cc,
+                dd,
+                ee,
+                ff,
+                gg
+              } from 'baz';
+
+              import {
+                hh,
+                ii,
+                jj,
+                kk,
+                ll,
+                mm,
+                nn
+              } from 'fizz';
+
+              import a from 'foo';
+
+              import b from 'dirA/bar';
+
+              import index from './';
+
+              import type { AA,
+                BB, CC } from 'abc';
+
+              import type { Z } from 'fizz';
+
+              import type {
+                A,
+                B
+              } from 'foo';
+
+              import type { C2 } from 'dirB/Bar';
+
+              import type {
+                D2,
+                X2,
+                Y2
+              } from 'dirB/bar';
+
+              import type { E2 } from 'dirB/baz';
+              import type { C3 } from 'dirC/Bar';
+
+              import type {
+                D3,
+                X3,
+                Y3
+              } from 'dirC/bar';
+
+              import type { E3 } from 'dirC/baz';
+              import type { F3 } from 'dirC/caz';
+              import type { C1 } from 'dirA/Bar';
+
+              import type {
+                D1,
+                X1,
+                Y1
+              } from 'dirA/bar';
+
+              import type { E1 } from 'dirA/baz';
+              import type { F } from './index.js';
+              import type { G } from './aaa.js';
+              import type { H } from './bbb';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: { order: 'asc' },
+                groups: ['external', 'internal', 'index', 'type'],
+                pathGroups: [
+                  {
+                    pattern: 'dirA/**',
+                    group: 'internal',
+                    position: 'after',
+                  },
+                  {
+                    pattern: 'dirB/**',
+                    group: 'internal',
+                    position: 'before',
+                  },
+                  {
+                    pattern: 'dirC/**',
+                    group: 'internal',
+                  },
+                ],
+                'newlines-between': 'always-and-inside-groups',
+                'newlines-between-types': 'never',
+                pathGroupsExcludedImportTypes: [],
+                sortTypesGroup: true,
+                consolidateIslands: 'inside-groups',
+              },
+            ],
+          }),
+          // (not an example, but we also test the reverse for completeness)
+          test({
+            code: `
+              import type { AA,
+                BB, CC } from 'abc';
+
+              import type { Z } from 'fizz';
+
+              import type {
+                A,
+                B
+              } from 'foo';
+
+              import type { C2 } from 'dirB/Bar';
+
+              import type {
+                D2,
+                X2,
+                Y2
+              } from 'dirB/bar';
+
+              import type { E2 } from 'dirB/baz';
+              import type { C3 } from 'dirC/Bar';
+
+              import type {
+                D3,
+                X3,
+                Y3
+              } from 'dirC/bar';
+
+              import type { E3 } from 'dirC/baz';
+              import type { F3 } from 'dirC/caz';
+              import type { C1 } from 'dirA/Bar';
+
+              import type {
+                D1,
+                X1,
+                Y1
+              } from 'dirA/bar';
+
+              import type { E1 } from 'dirA/baz';
+              import type { F } from './index.js';
+              import type { G } from './aaa.js';
+              import type { H } from './bbb';
+
+              import c from 'Bar';
+              import d from 'bar';
+
+              import {
+                aa,
+                bb,
+                cc,
+                dd,
+                ee,
+                ff,
+                gg
+              } from 'baz';
+
+              import {
+                hh,
+                ii,
+                jj,
+                kk,
+                ll,
+                mm,
+                nn
+              } from 'fizz';
+
+              import a from 'foo';
+
+              import b from 'dirA/bar';
+
+              import index from './';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: { order: 'asc' },
+                groups: ['type', 'external', 'internal', 'index'],
+                pathGroups: [
+                  {
+                    pattern: 'dirA/**',
+                    group: 'internal',
+                    position: 'after',
+                  },
+                  {
+                    pattern: 'dirB/**',
+                    group: 'internal',
+                    position: 'before',
+                  },
+                  {
+                    pattern: 'dirC/**',
+                    group: 'internal',
+                  },
+                ],
+                'newlines-between': 'always-and-inside-groups',
+                'newlines-between-types': 'never',
+                pathGroupsExcludedImportTypes: [],
+                sortTypesGroup: true,
+                consolidateIslands: 'inside-groups',
+              },
+            ],
+          }),
         ),
         invalid: [].concat(
           // Option alphabetize: {order: 'asc'}
@@ -4020,7 +5216,6 @@ context('TypeScript', function () {
               message: '`A` export should occur before export of `B`',
             }],
           }),
-
           // Options: sortTypesGroup + newlines-between-types example #1 from the documentation (fail)
           test({
             code: `
@@ -4081,7 +5276,6 @@ context('TypeScript', function () {
               },
             ],
           }),
-
           // Options: sortTypesGroup + newlines-between-types example #2 from the documentation (fail)
           test({
             code: `
@@ -4128,6 +5322,1330 @@ context('TypeScript', function () {
               {
                 message: 'There should be no empty line between import groups',
                 line: 6,
+              },
+            ],
+          }),
+          // Option: sortTypesGroup: true and newlines-between-types: 'always-and-inside-groups' and consolidateIslands: 'inside-groups' with all newlines
+          test({
+            code: `
+              import c from 'Bar';
+
+              import d from 'bar';
+
+              import {
+                aa,
+                bb,
+                cc,
+                dd,
+                ee,
+                ff,
+                gg
+              } from 'baz';
+
+              import {
+                hh,
+                ii,
+                jj,
+                kk,
+                ll,
+                mm,
+                nn
+              } from 'fizz';
+
+              import a from 'foo';
+
+              import b from 'dirA/bar';
+
+              import index from './';
+
+              import type { AA,
+                BB, CC } from 'abc';
+
+              import type { Z } from 'fizz';
+
+              import type {
+                A,
+                B
+              } from 'foo';
+
+              import type { C2 } from 'dirB/Bar';
+
+              import type {
+                D2,
+                X2,
+                Y2
+              } from 'dirB/bar';
+
+              import type { E2 } from 'dirB/baz';
+
+              import type { C3 } from 'dirC/Bar';
+
+              import type {
+                D3,
+                X3,
+                Y3
+              } from 'dirC/bar';
+
+              import type { E3 } from 'dirC/baz';
+
+              import type { F3 } from 'dirC/caz';
+
+              import type { C1 } from 'dirA/Bar';
+
+              import type {
+                D1,
+                X1,
+                Y1
+              } from 'dirA/bar';
+
+              import type { E1 } from 'dirA/baz';
+
+              import type { F } from './index.js';
+
+              import type { G } from './aaa.js';
+
+              import type { H } from './bbb';
+            `,
+            output: `
+              import c from 'Bar';
+              import d from 'bar';
+
+              import {
+                aa,
+                bb,
+                cc,
+                dd,
+                ee,
+                ff,
+                gg
+              } from 'baz';
+
+              import {
+                hh,
+                ii,
+                jj,
+                kk,
+                ll,
+                mm,
+                nn
+              } from 'fizz';
+
+              import a from 'foo';
+
+              import b from 'dirA/bar';
+
+              import index from './';
+
+              import type { AA,
+                BB, CC } from 'abc';
+
+              import type { Z } from 'fizz';
+
+              import type {
+                A,
+                B
+              } from 'foo';
+
+              import type { C2 } from 'dirB/Bar';
+
+              import type {
+                D2,
+                X2,
+                Y2
+              } from 'dirB/bar';
+
+              import type { E2 } from 'dirB/baz';
+
+              import type { C3 } from 'dirC/Bar';
+
+              import type {
+                D3,
+                X3,
+                Y3
+              } from 'dirC/bar';
+
+              import type { E3 } from 'dirC/baz';
+              import type { F3 } from 'dirC/caz';
+
+              import type { C1 } from 'dirA/Bar';
+
+              import type {
+                D1,
+                X1,
+                Y1
+              } from 'dirA/bar';
+
+              import type { E1 } from 'dirA/baz';
+
+              import type { F } from './index.js';
+
+              import type { G } from './aaa.js';
+              import type { H } from './bbb';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: { order: 'asc' },
+                groups: ['external', 'internal', 'index', 'type'],
+                pathGroups: [
+                  {
+                    pattern: 'dirA/**',
+                    group: 'internal',
+                    position: 'after',
+                  },
+                  {
+                    pattern: 'dirB/**',
+                    group: 'internal',
+                    position: 'before',
+                  },
+                  {
+                    pattern: 'dirC/**',
+                    group: 'internal',
+                  },
+                ],
+                'newlines-between': 'always-and-inside-groups',
+                'newlines-between-types': 'always-and-inside-groups',
+                pathGroupsExcludedImportTypes: [],
+                sortTypesGroup: true,
+                consolidateIslands: 'inside-groups',
+              },
+            ],
+            errors: [
+              {
+                message:
+                  'There should be no empty lines between this single-line import and the single-line import that follows it',
+                line: 2,
+              },
+              {
+                message:
+                  'There should be no empty lines between this single-line import and the single-line import that follows it',
+                line: 60,
+              },
+              {
+                message:
+                  'There should be no empty lines between this single-line import and the single-line import that follows it',
+                line: 76,
+              },
+            ],
+          }),
+          // Option: sortTypesGroup: true and newlines-between-types: 'always-and-inside-groups' and consolidateIslands: 'inside-groups' with no newlines
+          test({
+            code: `
+              import c from 'Bar';
+              import d from 'bar';
+              import {
+                aa,
+                bb,
+                cc,
+                dd,
+                ee,
+                ff,
+                gg
+              } from 'baz';
+              import {
+                hh,
+                ii,
+                jj,
+                kk,
+                ll,
+                mm,
+                nn
+              } from 'fizz';
+              import a from 'foo';
+              import b from 'dirA/bar';
+              import index from './';
+              import type { AA,
+                BB, CC } from 'abc';
+              import type { Z } from 'fizz';
+              import type {
+                A,
+                B
+              } from 'foo';
+              import type { C2 } from 'dirB/Bar';
+              import type {
+                D2,
+                X2,
+                Y2
+              } from 'dirB/bar';
+              import type { E2 } from 'dirB/baz';
+              import type { C3 } from 'dirC/Bar';
+              import type {
+                D3,
+                X3,
+                Y3
+              } from 'dirC/bar';
+              import type { E3 } from 'dirC/baz';
+              import type { F3 } from 'dirC/caz';
+              import type { C1 } from 'dirA/Bar';
+              import type {
+                D1,
+                X1,
+                Y1
+              } from 'dirA/bar';
+              import type { E1 } from 'dirA/baz';
+              import type { F } from './index.js';
+              import type { G } from './aaa.js';
+              import type { H } from './bbb';
+            `,
+            output: `
+              import c from 'Bar';
+              import d from 'bar';
+
+              import {
+                aa,
+                bb,
+                cc,
+                dd,
+                ee,
+                ff,
+                gg
+              } from 'baz';
+
+              import {
+                hh,
+                ii,
+                jj,
+                kk,
+                ll,
+                mm,
+                nn
+              } from 'fizz';
+
+              import a from 'foo';
+
+              import b from 'dirA/bar';
+
+              import index from './';
+
+              import type { AA,
+                BB, CC } from 'abc';
+
+              import type { Z } from 'fizz';
+
+              import type {
+                A,
+                B
+              } from 'foo';
+
+              import type { C2 } from 'dirB/Bar';
+
+              import type {
+                D2,
+                X2,
+                Y2
+              } from 'dirB/bar';
+
+              import type { E2 } from 'dirB/baz';
+
+              import type { C3 } from 'dirC/Bar';
+
+              import type {
+                D3,
+                X3,
+                Y3
+              } from 'dirC/bar';
+
+              import type { E3 } from 'dirC/baz';
+              import type { F3 } from 'dirC/caz';
+
+              import type { C1 } from 'dirA/Bar';
+
+              import type {
+                D1,
+                X1,
+                Y1
+              } from 'dirA/bar';
+
+              import type { E1 } from 'dirA/baz';
+
+              import type { F } from './index.js';
+
+              import type { G } from './aaa.js';
+              import type { H } from './bbb';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: { order: 'asc' },
+                groups: ['external', 'internal', 'index', 'type'],
+                pathGroups: [
+                  {
+                    pattern: 'dirA/**',
+                    group: 'internal',
+                    position: 'after',
+                  },
+                  {
+                    pattern: 'dirB/**',
+                    group: 'internal',
+                    position: 'before',
+                  },
+                  {
+                    pattern: 'dirC/**',
+                    group: 'internal',
+                  },
+                ],
+                'newlines-between': 'always-and-inside-groups',
+                'newlines-between-types': 'always-and-inside-groups',
+                pathGroupsExcludedImportTypes: [],
+                sortTypesGroup: true,
+                consolidateIslands: 'inside-groups',
+              },
+            ],
+            errors: [
+              {
+                message: 'There should be at least one empty line between this import and the multi-line import that follows it',
+                line: 3,
+              },
+              {
+                message: 'There should be at least one empty line between this import and the multi-line import that follows it',
+                line: 4,
+              },
+              {
+                message: 'There should be at least one empty line between this multi-line import and the import that follows it',
+                line: 13,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 22,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 23,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 24,
+              },
+              {
+                message: 'There should be at least one empty line between this multi-line import and the import that follows it',
+                line: 25,
+              },
+              {
+                message: 'There should be at least one empty line between this import and the multi-line import that follows it',
+                line: 27,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 28,
+              },
+              {
+                message: 'There should be at least one empty line between this import and the multi-line import that follows it',
+                line: 32,
+              },
+              {
+                message: 'There should be at least one empty line between this multi-line import and the import that follows it',
+                line: 33,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 38,
+              },
+              {
+                message: 'There should be at least one empty line between this import and the multi-line import that follows it',
+                line: 39,
+              },
+              {
+                message: 'There should be at least one empty line between this multi-line import and the import that follows it',
+                line: 40,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 46,
+              },
+              {
+                message: 'There should be at least one empty line between this import and the multi-line import that follows it',
+                line: 47,
+              },
+              {
+                message: 'There should be at least one empty line between this multi-line import and the import that follows it',
+                line: 48,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 53,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 54,
+              },
+            ],
+          }),
+          // Option: sortTypesGroup: true and newlines-between-types: 'always-and-inside-groups' and consolidateIslands: 'never' (default)
+          test({
+            code: `
+              import c from 'Bar';
+              import d from 'bar';
+              import {
+                aa,
+                bb,
+                cc,
+                dd,
+                ee,
+                ff,
+                gg
+              } from 'baz';
+              import {
+                hh,
+                ii,
+                jj,
+                kk,
+                ll,
+                mm,
+                nn
+              } from 'fizz';
+              import a from 'foo';
+              import b from 'dirA/bar';
+              import index from './';
+              import type { AA,
+                BB, CC } from 'abc';
+              import type { Z } from 'fizz';
+              import type {
+                A,
+                B
+              } from 'foo';
+              import type { C2 } from 'dirB/Bar';
+              import type {
+                D2,
+                X2,
+                Y2
+              } from 'dirB/bar';
+              import type { E2 } from 'dirB/baz';
+              import type { C3 } from 'dirC/Bar';
+              import type {
+                D3,
+                X3,
+                Y3
+              } from 'dirC/bar';
+              import type { E3 } from 'dirC/baz';
+              import type { F3 } from 'dirC/caz';
+              import type { C1 } from 'dirA/Bar';
+              import type {
+                D1,
+                X1,
+                Y1
+              } from 'dirA/bar';
+              import type { E1 } from 'dirA/baz';
+              import type { F } from './index.js';
+              import type { G } from './aaa.js';
+              import type { H } from './bbb';
+            `,
+            output: `
+              import c from 'Bar';
+              import d from 'bar';
+              import {
+                aa,
+                bb,
+                cc,
+                dd,
+                ee,
+                ff,
+                gg
+              } from 'baz';
+              import {
+                hh,
+                ii,
+                jj,
+                kk,
+                ll,
+                mm,
+                nn
+              } from 'fizz';
+              import a from 'foo';
+
+              import b from 'dirA/bar';
+
+              import index from './';
+
+              import type { AA,
+                BB, CC } from 'abc';
+              import type { Z } from 'fizz';
+              import type {
+                A,
+                B
+              } from 'foo';
+
+              import type { C2 } from 'dirB/Bar';
+              import type {
+                D2,
+                X2,
+                Y2
+              } from 'dirB/bar';
+              import type { E2 } from 'dirB/baz';
+
+              import type { C3 } from 'dirC/Bar';
+              import type {
+                D3,
+                X3,
+                Y3
+              } from 'dirC/bar';
+              import type { E3 } from 'dirC/baz';
+              import type { F3 } from 'dirC/caz';
+
+              import type { C1 } from 'dirA/Bar';
+              import type {
+                D1,
+                X1,
+                Y1
+              } from 'dirA/bar';
+              import type { E1 } from 'dirA/baz';
+
+              import type { F } from './index.js';
+
+              import type { G } from './aaa.js';
+              import type { H } from './bbb';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: { order: 'asc' },
+                groups: ['external', 'internal', 'index', 'type'],
+                pathGroups: [
+                  {
+                    pattern: 'dirA/**',
+                    group: 'internal',
+                    position: 'after',
+                  },
+                  {
+                    pattern: 'dirB/**',
+                    group: 'internal',
+                    position: 'before',
+                  },
+                  {
+                    pattern: 'dirC/**',
+                    group: 'internal',
+                  },
+                ],
+                'newlines-between': 'always-and-inside-groups',
+                'newlines-between-types': 'always-and-inside-groups',
+                pathGroupsExcludedImportTypes: [],
+                sortTypesGroup: true,
+                consolidateIslands: 'never',
+              },
+            ],
+            errors: [
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 22,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 23,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 24,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 28,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 38,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 46,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 53,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 54,
+              },
+
+            ],
+          }),
+
+          // Documentation failing example #1 for newlines-between
+          test({
+            code: `
+              import fs from 'fs';
+              import path from 'path';
+              import sibling from './foo';
+              import index from './';
+            `,
+            output: `
+              import fs from 'fs';
+              import path from 'path';
+
+              import sibling from './foo';
+
+              import index from './';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                'newlines-between': 'always',
+              },
+            ],
+            errors: [
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 3,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 4,
+              },
+            ],
+          }),
+          // Documentation failing example #2 for newlines-between
+          test({
+            code: `
+              import fs from 'fs';
+
+              import path from 'path';
+              import sibling from './foo';
+              import index from './';
+            `,
+            output: `
+              import fs from 'fs';
+
+              import path from 'path';
+
+              import sibling from './foo';
+
+              import index from './';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                'newlines-between': 'always-and-inside-groups',
+              },
+            ],
+            errors: [
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 4,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 5,
+              },
+            ],
+          }),
+          // Documentation failing example #3 for newlines-between
+          test({
+            code: `
+              import fs from 'fs';
+              import path from 'path';
+
+              import sibling from './foo';
+
+              import index from './';
+            `,
+            output: `
+              import fs from 'fs';
+              import path from 'path';
+              import sibling from './foo';
+              import index from './';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                'newlines-between': 'never',
+              },
+            ],
+            errors: [
+              {
+                message: 'There should be no empty line between import groups',
+                line: 3,
+              },
+              {
+                message: 'There should be no empty line between import groups',
+                line: 5,
+              },
+            ],
+          }),
+          // Multiple errors
+          ...semver.satisfies(eslintPkg.version, '< 3.0.0') ? [] : [
+            // Documentation failing example #1 for alphabetize
+            test({
+              code: `
+                import React, { PureComponent } from 'react';
+                import aTypes from 'prop-types';
+                import { compose, apply } from 'xcompose';
+                import * as classnames from 'classnames';
+                import blist2 from 'blist';
+                import blist from 'BList';
+              `,
+              // The reason why this output does not match the success example after being fixed is because eslint will leave overlapping errors alone, so only one import gets reordered when fixes are applied
+              output: `
+                import aTypes from 'prop-types';
+                import React, { PureComponent } from 'react';
+                import { compose, apply } from 'xcompose';
+                import * as classnames from 'classnames';
+                import blist2 from 'blist';
+                import blist from 'BList';
+              `,
+              ...parserConfig,
+              options: [
+                {
+                  alphabetize: {
+                    order: 'asc',
+                    caseInsensitive: true,
+                  },
+                },
+              ],
+              errors: [
+                {
+                  message: '`prop-types` import should occur before import of `react`',
+                  line: 3,
+                },
+                {
+                  message: '`classnames` import should occur before import of `react`',
+                  line: 5,
+                },
+                {
+                  message: '`blist` import should occur before import of `react`',
+                  line: 6,
+                },
+                {
+                  message: '`BList` import should occur before import of `react`',
+                  line: 7,
+                },
+              ],
+            }),
+          ],
+          // Documentation failing example #1 for named
+          test({
+            code: `
+              import { compose, apply } from 'xcompose';
+            `,
+            output: `
+              import { apply, compose } from 'xcompose';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                named: true,
+                alphabetize: {
+                  order: 'asc',
+                },
+              },
+            ],
+            errors: [
+              {
+                message: '`apply` import should occur before import of `compose`',
+                line: 2,
+              },
+            ],
+          }),
+          // Documentation failing example #1 for warnOnUnassignedImports
+          test({
+            code: `
+              import fs from 'fs';
+              import './styles.css';
+              import path from 'path';
+            `,
+            // Should not be fixed (eslint@>=9 expects null)
+            output: semver.satisfies(eslintPkg.version, '< 9.0.0') ? `
+              import fs from 'fs';
+              import './styles.css';
+              import path from 'path';
+            ` : null,
+            ...parserConfig,
+            options: [
+              {
+                warnOnUnassignedImports: true,
+              },
+            ],
+            errors: [
+              {
+                message: '`path` import should occur before import of `./styles.css`',
+                line: 4,
+              },
+            ],
+          }),
+          // Documentation failing example #1 for sortTypesGroup
+          test({
+            code: `
+              import type A from "fs";
+              import type B from "path";
+              import type C from "../foo.js";
+              import type D from "./bar.js";
+              import type E from './';
+
+              import a from "fs";
+              import b from "path";
+              import c from "../foo.js";
+              import d from "./bar.js";
+              import e from "./";
+            `,
+            // This is the "correct" behavior, but it's the wrong outcome (expectedly)
+            output: semver.satisfies(eslintPkg.version, '< 3.0.0')
+            // eslint@2 apparently attempts to fix multiple errors in one pass,
+            // which results in different erroneous output
+              ? `
+              import type E from './';
+              import type A from "fs";
+              import type B from "path";
+              import type C from "../foo.js";
+              import type D from "./bar.js";
+
+              import a from "fs";
+              import b from "path";
+              import c from "../foo.js";
+              import d from "./bar.js";
+              import e from "./";
+            ` : `
+              import type C from "../foo.js";
+              import type A from "fs";
+              import type B from "path";
+              import type D from "./bar.js";
+              import type E from './';
+
+              import a from "fs";
+              import b from "path";
+              import c from "../foo.js";
+              import d from "./bar.js";
+              import e from "./";
+            `,
+            ...parserConfig,
+            options: [
+              {
+                groups: ['type', 'builtin', 'parent', 'sibling', 'index'],
+                alphabetize: { order: 'asc' },
+              },
+            ],
+            errors: [
+              {
+                message: '`../foo.js` type import should occur before type import of `fs`',
+                line: 4,
+              },
+              {
+                message: '`./bar.js` type import should occur before type import of `fs`',
+                line: 5,
+              },
+              {
+                message: '`./` type import should occur before type import of `fs`',
+                line: 6,
+              },
+            ],
+          }),
+          // Documentation failing example #1 for newlines-between-types
+          test({
+            code: `
+              import type A from "fs";
+              import type B from "path";
+              import type C from "../foo.js";
+              import type D from "./bar.js";
+              import type E from './';
+
+              import a from "fs";
+              import b from "path";
+
+              import c from "../foo.js";
+
+              import d from "./bar.js";
+
+              import e from "./";
+            `,
+            output: `
+              import type A from "fs";
+              import type B from "path";
+
+              import type C from "../foo.js";
+
+              import type D from "./bar.js";
+
+              import type E from './';
+
+              import a from "fs";
+              import b from "path";
+
+              import c from "../foo.js";
+
+              import d from "./bar.js";
+
+              import e from "./";
+            `,
+            ...parserConfig,
+            options: [
+              {
+                groups: ['type', 'builtin', 'parent', 'sibling', 'index'],
+                sortTypesGroup: true,
+                'newlines-between': 'always',
+              },
+            ],
+            errors: [
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 3,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 4,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 5,
+              },
+            ],
+          }),
+          // Documentation failing example #2 for newlines-between-types
+          test({
+            code: `
+              import type A from "fs";
+              import type B from "path";
+              import type C from "../foo.js";
+              import type D from "./bar.js";
+              import type E from './';
+
+              import a from "fs";
+              import b from "path";
+
+              import c from "../foo.js";
+
+              import d from "./bar.js";
+
+              import e from "./";
+            `,
+            output: `
+              import type A from "fs";
+              import type B from "path";
+              import type C from "../foo.js";
+              import type D from "./bar.js";
+              import type E from './';
+              import a from "fs";
+              import b from "path";
+
+              import c from "../foo.js";
+
+              import d from "./bar.js";
+
+              import e from "./";
+            `,
+            ...parserConfig,
+            options: [
+              {
+                groups: ['type', 'builtin', 'parent', 'sibling', 'index'],
+                sortTypesGroup: true,
+                'newlines-between': 'always',
+                'newlines-between-types': 'never',
+              },
+            ],
+            errors: [
+              {
+                message: 'There should be no empty line between import groups',
+                line: 6,
+              },
+            ],
+          }),
+          // Documentation failing example #1 for consolidateIslands
+          test({
+            code: `
+              var fs = require('fs');
+              var path = require('path');
+              var { util1, util2, util3 } = require('util');
+              var async = require('async');
+              var relParent1 = require('../foo');
+              var {
+                relParent21,
+                relParent22,
+                relParent23,
+                relParent24,
+              } = require('../');
+              var relParent3 = require('../bar');
+              var { sibling1,
+                sibling2, sibling3 } = require('./foo');
+              var sibling2 = require('./bar');
+              var sibling3 = require('./foobar');
+            `,
+            output: `
+              var fs = require('fs');
+              var path = require('path');
+              var { util1, util2, util3 } = require('util');
+
+              var async = require('async');
+
+              var relParent1 = require('../foo');
+
+              var {
+                relParent21,
+                relParent22,
+                relParent23,
+                relParent24,
+              } = require('../');
+
+              var relParent3 = require('../bar');
+
+              var { sibling1,
+                sibling2, sibling3 } = require('./foo');
+
+              var sibling2 = require('./bar');
+              var sibling3 = require('./foobar');
+            `,
+            ...parserConfig,
+            options: [
+              {
+                'newlines-between': 'always-and-inside-groups',
+                consolidateIslands: 'inside-groups',
+              },
+            ],
+            errors: [
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 4,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 5,
+              },
+              {
+                message:
+                  'There should be at least one empty line between this import and the multi-line import that follows it',
+                line: 6,
+              },
+              {
+                message:
+                  'There should be at least one empty line between this multi-line import and the import that follows it',
+                line: 12,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 13,
+              },
+              {
+                message:
+                  'There should be at least one empty line between this multi-line import and the import that follows it',
+                line: 15,
+              },
+            ],
+          }),
+          // Documentation failing example #2 for consolidateIslands
+          test({
+            code: `
+              import c from 'Bar';
+              import d from 'bar';
+              import {
+                aa,
+                bb,
+                cc,
+                dd,
+                ee,
+                ff,
+                gg
+              } from 'baz';
+              import {
+                hh,
+                ii,
+                jj,
+                kk,
+                ll,
+                mm,
+                nn
+              } from 'fizz';
+              import a from 'foo';
+              import b from 'dirA/bar';
+              import index from './';
+              import type { AA,
+                BB, CC } from 'abc';
+              import type { Z } from 'fizz';
+              import type {
+                A,
+                B
+              } from 'foo';
+              import type { C2 } from 'dirB/Bar';
+              import type {
+                D2,
+                X2,
+                Y2
+              } from 'dirB/bar';
+              import type { E2 } from 'dirB/baz';
+              import type { C3 } from 'dirC/Bar';
+              import type {
+                D3,
+                X3,
+                Y3
+              } from 'dirC/bar';
+              import type { E3 } from 'dirC/baz';
+              import type { F3 } from 'dirC/caz';
+              import type { C1 } from 'dirA/Bar';
+              import type {
+                D1,
+                X1,
+                Y1
+              } from 'dirA/bar';
+              import type { E1 } from 'dirA/baz';
+              import type { F } from './index.js';
+              import type { G } from './aaa.js';
+              import type { H } from './bbb';
+            `,
+            output: `
+              import c from 'Bar';
+              import d from 'bar';
+
+              import {
+                aa,
+                bb,
+                cc,
+                dd,
+                ee,
+                ff,
+                gg
+              } from 'baz';
+
+              import {
+                hh,
+                ii,
+                jj,
+                kk,
+                ll,
+                mm,
+                nn
+              } from 'fizz';
+
+              import a from 'foo';
+
+              import b from 'dirA/bar';
+
+              import index from './';
+
+              import type { AA,
+                BB, CC } from 'abc';
+
+              import type { Z } from 'fizz';
+
+              import type {
+                A,
+                B
+              } from 'foo';
+
+              import type { C2 } from 'dirB/Bar';
+
+              import type {
+                D2,
+                X2,
+                Y2
+              } from 'dirB/bar';
+
+              import type { E2 } from 'dirB/baz';
+              import type { C3 } from 'dirC/Bar';
+
+              import type {
+                D3,
+                X3,
+                Y3
+              } from 'dirC/bar';
+
+              import type { E3 } from 'dirC/baz';
+              import type { F3 } from 'dirC/caz';
+              import type { C1 } from 'dirA/Bar';
+
+              import type {
+                D1,
+                X1,
+                Y1
+              } from 'dirA/bar';
+
+              import type { E1 } from 'dirA/baz';
+              import type { F } from './index.js';
+              import type { G } from './aaa.js';
+              import type { H } from './bbb';
+            `,
+            ...parserConfig,
+            options: [
+              {
+                alphabetize: { order: 'asc' },
+                groups: ['external', 'internal', 'index', 'type'],
+                pathGroups: [
+                  {
+                    pattern: 'dirA/**',
+                    group: 'internal',
+                    position: 'after',
+                  },
+                  {
+                    pattern: 'dirB/**',
+                    group: 'internal',
+                    position: 'before',
+                  },
+                  {
+                    pattern: 'dirC/**',
+                    group: 'internal',
+                  },
+                ],
+                'newlines-between': 'always-and-inside-groups',
+                'newlines-between-types': 'never',
+                pathGroupsExcludedImportTypes: [],
+                sortTypesGroup: true,
+                consolidateIslands: 'inside-groups',
+              },
+            ],
+            errors: [
+              {
+                message:
+                  'There should be at least one empty line between this import and the multi-line import that follows it',
+                line: 3,
+              },
+              {
+                message:
+                  'There should be at least one empty line between this import and the multi-line import that follows it',
+                line: 4,
+              },
+              {
+                message:
+                  'There should be at least one empty line between this multi-line import and the import that follows it',
+                line: 13,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 22,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 23,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 24,
+              },
+              {
+                message:
+                  'There should be at least one empty line between this multi-line import and the import that follows it',
+                line: 25,
+              },
+              {
+                message:
+                  'There should be at least one empty line between this import and the multi-line import that follows it',
+                line: 27,
+              },
+              {
+                message: 'There should be at least one empty line between import groups',
+                line: 28,
+              },
+              {
+                message:
+                  'There should be at least one empty line between this import and the multi-line import that follows it',
+                line: 32,
+              },
+              {
+                message:
+                  'There should be at least one empty line between this multi-line import and the import that follows it',
+                line: 33,
+              },
+              {
+                message:
+                  'There should be at least one empty line between this import and the multi-line import that follows it',
+                line: 39,
+              },
+              {
+                message:
+                  'There should be at least one empty line between this multi-line import and the import that follows it',
+                line: 40,
+              },
+              {
+                message:
+                  'There should be at least one empty line between this import and the multi-line import that follows it',
+                line: 47,
+              },
+              {
+                message:
+                  'There should be at least one empty line between this multi-line import and the import that follows it',
+                line: 48,
               },
             ],
           }),


### PR DESCRIPTION
Depends on #3128

**This PR implements in `import/order`: a new option enabling the manipulation/consolidation of newlines around imports.**

A demo package containing this feature is temporarily available for easy testing:

```bash
npm install --save-dev eslint-plugin-import@npm:@-xun/eslint-plugin-import-experimental
```

## Collapse excess spacing for aesthetically pleasing imports

This is implemented via `consolidateIslands`. The proposed documentation corresponding to this new feature can be previewed [here](https://github.com/Xunnamius/eslint-plugin-import/blob/main/docs/rules/order.md#consolidateislands).

<details><summary>Example</summary>

Given this code (which could be the output of a previous `--fix` pass):

```typescript
var fs = require('fs');
var path = require('path');
var { util1, util2, util3 } = require('util');

var async = require('async');

// Ugly but technically valid

var relParent1 = require('../foo');
var {
  relParent21,
  relParent22,
  relParent23,
  relParent24,
} = require('../');
var relParent3 = require('../bar');

var { sibling1,
  sibling2, sibling3 } = require('./foo');
var sibling2 = require('./bar');
var sibling3 = require('./foobar');
```

And the following settings, the rule check will _pass_:

```jsonc
{
  "newlines-between": "always-and-inside-groups"
}
```

However, when given the following instead, the rule check will _fail_:

```diff
{
  "newlines-between": "always-and-inside-groups",
+ "consolidateIslands": "inside-groups"
}
```

With `--fix` yielding:

```typescript
var fs = require('fs');
var path = require('path');
var { util1, util2, util3 } = require('util');

var async = require('async');

// Pretty

var relParent1 = require('../foo');

var {
  relParent21,
  relParent22,
  relParent23,
  relParent24,
} = require('../');

var relParent3 = require('../bar');

var { sibling1,
  sibling2, sibling3 } = require('./foo');

var sibling2 = require('./bar');
var sibling3 = require('./foobar');
```

Note how the intragroup "islands" of grouped single-line imports, as well as multi-line imports, are surrounded by new lines.

</details>

Essentially, I was looking for a `newlines-between`-like setting somewhere between `"never"` and `"always-and-inside-groups"`. I want newlines separating `groups`/`pathGroups` imports from one another (like `"always-and-inside-groups"`), newlines separating imports that span multiple lines from other imports (this is the new thing), and any remaining newlines deleted or "consolidated" (like `"never"`). The example above demonstrates this use case.

Right now, this is achievable with `newlines-between` set to `"always-and-inside-groups"` if you add additional newlines around multi-line imports to every file by hand. The goal of `consolidateIslands` is to allow `eslint --fix` to take care of the tedium in a backward-compatible way.

There was a slight complication with `consolidateIslands` though: while testing across a few mid-sized repos, I discovered my naive implementation caused a conflict when enabled alongside `sortTypesAmongThemselves: true`, `newlines-between: "always-and-inside-groups"`, and `newlines-between-types: "never"`... and then only when a normal import was followed by a multi-line type-only import. This conflict makes sense, since `newlines-between-types: "never"` wants no newlines ever and demands no newline separate type-only imports from normal imports (since, currently, `newlines-between-types` governs that space), yet `consolidateIslands` demands a newline separate _all_ multi-line imports from other imports.

To solve this, the current implementation has `newlines-between-types` yield to `consolidateIslands` whenever they conflict. I've also added a test to catch any regressions around this edge case.