### PR TITLE
[meta] Update flatConfig example to include typescript config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [Docs] [`extensions`], [`order`]: improve documentation ([#3106], thanks [@Xunnamius])
 - [Docs] add flat config guide for using `tseslint.config()` ([#3125], thanks [@lnuvy])
 - [Docs] add missing comma ([#3122], thanks [@RyanGst])
+- [readme] Update flatConfig example to include typescript config ([#3138], thanks [@intellix])
 
 ## [2.31.0] - 2024-10-03
 
@@ -1167,6 +1168,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3138]: https://github.com/import-js/eslint-plugin-import/pull/3138
 [#3125]: https://github.com/import-js/eslint-plugin-import/pull/3125
 [#3122]: https://github.com/import-js/eslint-plugin-import/pull/3122
 [#3116]: https://github.com/import-js/eslint-plugin-import/pull/3116
@@ -1873,6 +1875,7 @@ for info on changes for earlier releases.
 [@hulkish]: https://github.com/hulkish
 [@hyperupcall]: https://github.com/hyperupcall
 [@Hypnosphi]: https://github.com/Hypnosphi
+[@intellix]: https://github.com/intellix
 [@isiahmeadows]: https://github.com/isiahmeadows
 [@IvanGoncharov]: https://github.com/IvanGoncharov
 [@ivo-stefchev]: https://github.com/ivo-stefchev

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ export default tseslint.config(
   // other configs...
   {
     files: ['**/*.{ts,tsx}'],
-    extends: [importPlugin.flatConfigs.recommended],
+    extends: [importPlugin.flatConfigs.recommended, importPlugin.flatConfigs.typescript],
     // other configs...
   }
 );


### PR DESCRIPTION
Was having an issue for a few hours trying to get import/no-unresolved not picking up relative imports that don't include the extension like so:
```ts
import { add } from './utils';
```

After asking inside Discord, kkapp helped me by pointing out that I may need to configure the resolver to look for "ts" extensions. After adding it I went on a crusade to figure out how I had managed to miss that when migrating to flat configs.

The example given for non-flat configs tells you to include the typescript config, but the flatConfig variant does not, so for an out-of-the-box experience when migrating, it can cause a headache.