### PR TITLE
[Fix] configs: added missing name attribute for eslint config inspector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Fixed
 - [`no-unused-modules`]: provide more meaningful error message when no .eslintrc is present ([#3116], thanks [@michaelfaith])
+- configs: added missing name attribute for eslint config inspector ([#3151], thanks [@NishargShah])
 
 ### Changed
 - [Docs] [`extensions`], [`order`]: improve documentation ([#3106], thanks [@Xunnamius])
@@ -1169,6 +1170,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3151]: https://github.com/import-js/eslint-plugin-import/pull/3151
 [#3138]: https://github.com/import-js/eslint-plugin-import/pull/3138
 [#3125]: https://github.com/import-js/eslint-plugin-import/pull/3125
 [#3122]: https://github.com/import-js/eslint-plugin-import/pull/3122
@@ -1965,6 +1967,7 @@ for info on changes for earlier releases.
 [@Nfinished]: https://github.com/Nfinished
 [@nickofthyme]: https://github.com/nickofthyme
 [@nicolashenry]: https://github.com/nicolashenry
+[@NishargShah]: https://github.com/NishargShah
 [@noelebrun]: https://github.com/noelebrun
 [@ntdb]: https://github.com/ntdb
 [@nwalters512]: https://github.com/nwalters512

--- a/src/index.js
+++ b/src/index.js
@@ -96,8 +96,8 @@ export const flatConfigs = {
   warnings: createFlatConfig(require('../config/flat/warnings'), 'warnings'),
 
   // useful stuff for folks using various environments
-  react: require('../config/flat/react'),
-  'react-native': configs['react-native'],
-  electron: configs.electron,
-  typescript: configs.typescript,
+  react: createFlatConfig(require('../config/flat/react'), 'react'),
+  'react-native': createFlatConfig(configs['react-native'], 'react-native'),
+  electron: createFlatConfig(configs.electron, 'electron'),
+  typescript: createFlatConfig(configs.typescript, 'typescript'),
 };


### PR DESCRIPTION
I am working on the eslint config inspector for my big flat config and I saw many anonymous configs where one of them is related to `import` so I added names in the flat configs