### PR TITLE
Match default export of plugin and `plugin` object of flat configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## [Unreleased]
 
+### Fixed
+- ensure plugin exports are equal to the `plugin` object on flat configs ([#3213], thanks [@soren121])
+
 ## [2.32.0] - 2025-06-20
 
 ### Added
@@ -1181,6 +1184,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3213]: https://github.com/import-js/eslint-plugin-import/pull/3213
 [#3191]: https://github.com/import-js/eslint-plugin-import/pull/3191
 [#3173]: https://github.com/import-js/eslint-plugin-import/pull/3173
 [#3172]: https://github.com/import-js/eslint-plugin-import/pull/3172
@@ -2042,6 +2046,7 @@ for info on changes for earlier releases.
 [@skyrpex]: https://github.com/skyrpex
 [@snewcomer]: https://github.com/snewcomer
 [@sompylasar]: https://github.com/sompylasar
+[@soren121]: https://github.com/soren121
 [@soryy708]: https://github.com/soryy708
 [@sosukesuzuki]: https://github.com/sosukesuzuki
 [@spalger]: https://github.com/spalger

--- a/src/index.js
+++ b/src/index.js
@@ -73,9 +73,13 @@ export const configs = {
   typescript: require('../config/typescript'),
 };
 
+export const meta = { name, version };
+
 // Base Plugin Object
 const importPlugin = {
-  meta: { name, version },
+  meta,
+  configs,
+  flatConfigs: {},
   rules,
 };
 
@@ -86,7 +90,7 @@ const createFlatConfig = (baseConfig, configName) => ({
   plugins: { import: importPlugin },
 });
 
-export const flatConfigs = {
+export const flatConfigs = importPlugin.flatConfigs = {
   recommended: createFlatConfig(
     require('../config/flat/recommended'),
     'recommended',
@@ -101,3 +105,5 @@ export const flatConfigs = {
   electron: createFlatConfig(configs.electron, 'electron'),
   typescript: createFlatConfig(configs.typescript, 'typescript'),
 };
+
+module.exports = importPlugin;

--- a/tests/src/package.js
+++ b/tests/src/package.js
@@ -20,7 +20,6 @@ describe('package', function () {
   });
 
   it('has every rule', function (done) {
-
     fs.readdir(
       path.join(pkg, 'rules')
       , function (err, files) {
@@ -34,7 +33,7 @@ describe('package', function () {
       });
   });
 
-  it('exports all configs', function (done) {
+  it('exports all legacy configs', function (done) {
     fs.readdir(path.join(process.cwd(), 'config'), function (err, files) {
       if (err) { done(err); return; }
       files.filter(isJSFile).forEach((file) => {
@@ -43,6 +42,34 @@ describe('package', function () {
       });
       done();
     });
+  });
+
+  it('exports all flat configs', function (done) {
+    fs.readdir(path.join(process.cwd(), 'config'), function (err, files) {
+      if (err) { done(err); return; }
+      files.filter(isJSFile).forEach((file) => {
+        if (file[0] === '.') { return; }
+
+        const basename = path.basename(file, '.js');
+        // stage-0 is not included in flat configs
+        if (basename === 'stage-0') { return; }
+
+        expect(module.flatConfigs).to.have.property(basename);
+      });
+      done();
+    });
+  });
+
+  it('exports plugin meta object', function () {
+    expect(module.meta).to.be.an('object').that.has.all.keys('name', 'version');
+    expect(module.meta.name).to.equal('eslint-plugin-import');
+    expect(module.meta.version).to.be.a('string');
+  });
+
+  it('ensures the plugin object in the flat configs is identical to the module', function () {
+    for (const configFile in module.flatConfigs) {
+      expect(module.flatConfigs[configFile].plugins.import).to.equal(module);
+    }
   });
 
   function getRulePath(ruleName) {


### PR DESCRIPTION
Fixes #3212 

The plugin's default export is not equal by reference to the `plugin` object defined on flat configs. This can cause issues for ESLint's plugin normalization in some scenarios. This PR changes the default export to equal the `plugin` object.

I've added tests for this change, and I also added missing tests for the flat config exports.