### PR TITLE
fix: no-unused-modules correctly handles `export { X as default }` syntax

### DIFF
--- a/src/rules/no-unused-modules.js
+++ b/src/rules/no-unused-modules.js
@@ -723,7 +723,11 @@ module.exports = {
           if (specifiers.length > 0) {
             specifiers.forEach((specifier) => {
               if (specifier.exported) {
-                newExportIdentifiers.add(specifier.exported.name || specifier.exported.value);
+                const exportedName = specifier.exported.name || specifier.exported.value;
+                // `export { X as default }` uses the string "default" as the exported name,
+                // but the exports map stores default exports under IMPORT_DEFAULT_SPECIFIER.
+                // Normalize here so that the map key lookup is consistent.
+                newExportIdentifiers.add(exportedName === DEFAULT ? IMPORT_DEFAULT_SPECIFIER : exportedName);
               }
             });
           }

--- a/tests/files/no-unused-modules/export-as-default/test-export.js
+++ b/tests/files/no-unused-modules/export-as-default/test-export.js
@@ -1,0 +1,2 @@
+function testHandler() {}
+export { testHandler as default };

--- a/tests/files/no-unused-modules/export-as-default/usage.js
+++ b/tests/files/no-unused-modules/export-as-default/usage.js
@@ -1,0 +1,1 @@
+import handler from './test-export';

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -742,6 +742,45 @@ describe('renameDefault', () => {
   });
 });
 
+describe('export { X as default } syntax (issue #3216)', () => {
+  const exportAsDefaultOptions = [{
+    unusedExports: true,
+    src: [testFilePath('./no-unused-modules/export-as-default/**/*.js')],
+  }];
+
+  // First lint: establishes the export/import maps via doPreparation
+  ruleTester.run('no-unused-modules', rule, {
+    valid: [
+      test({
+        options: exportAsDefaultOptions,
+        code: `import handler from '${testFilePath('./no-unused-modules/export-as-default/test-export.js')}'`,
+        filename: testFilePath('./no-unused-modules/export-as-default/usage.js'),
+      }),
+      test({
+        options: exportAsDefaultOptions,
+        code: 'function testHandler() {}\nexport { testHandler as default };',
+        filename: testFilePath('./no-unused-modules/export-as-default/test-export.js'),
+      }),
+    ],
+    invalid: [],
+  });
+
+  // Second lint of the same file with the same options (same prepareKey, so doPreparation
+  // is skipped). The bug caused updateExportUsage to corrupt the export map on the first
+  // lint, so checkUsage would fail to find the IMPORT_DEFAULT_SPECIFIER key on the second
+  // lint.
+  ruleTester.run('no-unused-modules', rule, {
+    valid: [
+      test({
+        options: exportAsDefaultOptions,
+        code: 'function testHandler() {}\nexport { testHandler as default };',
+        filename: testFilePath('./no-unused-modules/export-as-default/test-export.js'),
+      }),
+    ],
+    invalid: [],
+  });
+});
+
 describe('test behavior for new file', () => {
   before(() => {
     fs.writeFileSync(testFilePath('./no-unused-modules/file-added-0.js'), '', { encoding: 'utf8', flag: 'w' });


### PR DESCRIPTION
## Summary

Fixes #3216.

When a file uses `export { testHandler as default }` syntax (exporting a local binding as the default export), the `no-unused-modules` rule incorrectly flagged the default export as unused even when it was imported correctly via `import handler from './module'` in another file.

- **Root cause:** In `updateExportUsage`, when scanning `ExportNamedDeclaration` specifiers, the raw exported name `"default"` was added to `newExportIdentifiers`. However, the exports map uses `IMPORT_DEFAULT_SPECIFIER` (`"ImportDefaultSpecifier"`) as the key for default exports. This mismatch meant the existing `whereUsed` data (populated during `doPreparation`) was dropped from the map on the first lint pass, and the export was stored under the wrong key `"default"`. On the next lint of the same file, `checkUsage` looked up `IMPORT_DEFAULT_SPECIFIER` and found nothing, incorrectly reporting the export as unused.
- **Fix:** Normalize `"default"` → `IMPORT_DEFAULT_SPECIFIER` when building `newExportIdentifiers` in `updateExportUsage`, consistent with how `EXPORT_DEFAULT_DECLARATION` is already handled on the line above.

## Changes

- `src/rules/no-unused-modules.js`: Normalize `"default"` exported specifier name to `IMPORT_DEFAULT_SPECIFIER` in `updateExportUsage`.
- `tests/src/rules/no-unused-modules.js`: Add regression test that lints the file twice (second lint triggers the bug — `doPreparation` is skipped due to caching, exposing the corrupted export map).
- `tests/files/no-unused-modules/export-as-default/`: New fixture files (`test-export.js`, `usage.js`) for the test.

## Test plan

- [x] New test fails before the fix and passes after
- [x] Full `no-unused-modules` test suite passes: `BABEL_ENV=test node_modules/.bin/nyc node_modules/.bin/mocha tests/src/rules/no-unused-modules.js` → 157 passing, 1 pending, 0 failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)