### PR TITLE
extensions: treat relative package roots as packages for ignorePackages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`consistent-type-specifier-style`]: add `prefer-top-level-if-only-type-imports` option ([#3210], thanks [@aldeed])
 
 ### Fixed
+- Fixed `extensions` false positives for relative package-root imports when `ignorePackages` is enabled. ([#2844], thanks [@benasher44])
 - [`no-duplicates`]: fix `prefer-inline` autofix producing invalid syntax when an identifier named `from` is imported ([#3236], thanks [@DukeDeSouth] [@Quantaly])
 - [`no-duplicates`]: avoid false positives for TypeScript namespace and default type imports that cannot be merged ([#3195], thanks [@sjh9714] [@robyoder])
 - ExportMap: resolve export * as ns re-exports under modern parsers ([#3250], thanks [@rasmi] [@JounQin] [@butterybread])
@@ -1260,6 +1261,7 @@ for info on changes for earlier releases.
 [#2854]: https://github.com/import-js/eslint-plugin-import/pull/2854
 [#2851]: https://github.com/import-js/eslint-plugin-import/pull/2851
 [#2850]: https://github.com/import-js/eslint-plugin-import/pull/2850
+[#2844]: https://github.com/import-js/eslint-plugin-import/issues/2844
 [#2842]: https://github.com/import-js/eslint-plugin-import/pull/2842
 [#2835]: https://github.com/import-js/eslint-plugin-import/pull/2835
 [#2832]: https://github.com/import-js/eslint-plugin-import/pull/2832

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -2,7 +2,9 @@ import path from 'path';
 
 import minimatch from 'minimatch';
 import resolve from 'eslint-module-utils/resolve';
+import { getPhysicalFilename } from 'eslint-module-utils/contextCompat';
 import { isBuiltIn, isExternalModule, isScoped } from '../core/importType';
+import { getFilePackagePath } from '../core/packagePath';
 import moduleVisitor from 'eslint-module-utils/moduleVisitor';
 import docsUrl from '../docsUrl';
 
@@ -87,6 +89,28 @@ function buildProperties(context) {
   }
 
   return result;
+}
+
+/**
+ * A relative specifier that resolves to a directory which is itself a package
+ * root (it has its own `package.json`) imports that package, not a file in the
+ * current one, so `ignorePackages` should not require an extension for it.
+ * https://github.com/import-js/eslint-plugin-import/issues/2844
+ */
+function isRelativeToPackage(importPath, context) {
+  if (!(/^[.]{1,2}([\\/]|$)/).test(importPath)) {
+    return false;
+  }
+  const physicalFilename = getPhysicalFilename(context);
+  if (!physicalFilename || physicalFilename === '<text>') {
+    return false;
+  }
+  const targetPath = path.resolve(path.dirname(physicalFilename), importPath);
+  try {
+    return getFilePackagePath(targetPath) === targetPath;
+  } catch (e) {
+    return false;
+  }
 }
 
 module.exports = {
@@ -213,7 +237,8 @@ module.exports = {
         importPath,
         resolve(importPath, context, moduleSystem),
         context,
-      ) || isScoped(importPath);
+      ) || isScoped(importPath)
+        || isRelativeToPackage(importPath, context);
 
       if (!extension || !importPath.endsWith(`.${extension}`)) {
         // ignore type-only imports and exports

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -97,7 +97,7 @@ function buildProperties(context) {
  * current one, so `ignorePackages` should not require an extension for it.
  * https://github.com/import-js/eslint-plugin-import/issues/2844
  */
-function isRelativeToPackage(importPath, context) {
+function isRelativeToPackage(importPath, context, packagePathCache) {
   if (!(/^[.]{1,2}([\\/]|$)/).test(importPath)) {
     return false;
   }
@@ -106,11 +106,17 @@ function isRelativeToPackage(importPath, context) {
     return false;
   }
   const targetPath = path.resolve(path.dirname(physicalFilename), importPath);
-  try {
-    return getFilePackagePath(targetPath) === targetPath;
-  } catch (e) {
-    return false;
+  if (packagePathCache.has(targetPath)) {
+    return packagePathCache.get(targetPath);
   }
+  let isPackageRoot = false;
+  try {
+    isPackageRoot = getFilePackagePath(targetPath) === targetPath;
+  } catch (e) {
+    isPackageRoot = false;
+  }
+  packagePathCache.set(targetPath, isPackageRoot);
+  return isPackageRoot;
 }
 
 module.exports = {
@@ -162,6 +168,7 @@ module.exports = {
   create(context) {
 
     const props = buildProperties(context);
+    const packagePathCache = new Map();
 
     function getModifier(extension) {
       return props.pattern[extension] || props.defaultConfig;
@@ -238,7 +245,7 @@ module.exports = {
         resolve(importPath, context, moduleSystem),
         context,
       ) || isScoped(importPath)
-        || isRelativeToPackage(importPath, context);
+        || props.ignorePackages && isRelativeToPackage(importPath, context, packagePathCache);
 
       if (!extension || !importPath.endsWith(`.${extension}`)) {
         // ignore type-only imports and exports

--- a/src/rules/extensions.js
+++ b/src/rules/extensions.js
@@ -97,7 +97,7 @@ function buildProperties(context) {
  * current one, so `ignorePackages` should not require an extension for it.
  * https://github.com/import-js/eslint-plugin-import/issues/2844
  */
-function isRelativeToPackage(importPath, context, packagePathCache) {
+const isRelativeToPackage = (importPath, context, packagePathCache) => {
   if (!(/^[.]{1,2}([\\/]|$)/).test(importPath)) {
     return false;
   }
@@ -117,7 +117,7 @@ function isRelativeToPackage(importPath, context, packagePathCache) {
   }
   packagePathCache.set(targetPath, isPackageRoot);
   return isPackageRoot;
-}
+};
 
 module.exports = {
   meta: {

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -636,6 +636,34 @@ ruleTester.run('extensions', rule, {
         },
       ],
     }),
+
+    // without a resolvable filename (e.g. a `<text>` buffer) we can't tell
+    // whether a relative import points at a package root, so `ignorePackages`
+    // still requires the extension (#2844)
+    test({
+      code: 'import foo from "./foo"',
+      filename: '<text>',
+      options: ['ignorePackages'],
+      errors: [
+        {
+          message: 'Missing file extension for "./foo"',
+          line: 1,
+        },
+      ],
+    }),
+    // when a relative import resolves above any package.json, looking up its
+    // package root throws; treat it as not-a-package instead of crashing (#2844)
+    test({
+      code: 'import * as test from "."',
+      filename: '/x.js',
+      options: ['ignorePackages'],
+      errors: [
+        {
+          message: 'Missing file extension for "."',
+          line: 1,
+        },
+      ],
+    }),
   ],
 });
 

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -155,6 +155,19 @@ ruleTester.run('extensions', rule, {
       ].join('\n'),
       options: ['always'],
     }),
+
+    // a relative import that resolves to a directory with its own package.json
+    // is a package, so `ignorePackages` should not require an extension (#2844)
+    test({
+      code: 'import * as test from "."',
+      filename: testFilePath('./internal-modules/test.js'),
+      options: ['ignorePackages'],
+    }),
+    test({
+      code: 'import * as test from ".."',
+      filename: testFilePath('./internal-modules/plugins/plugin.js'),
+      options: ['ignorePackages'],
+    }),
   ],
 
   invalid: [
@@ -620,35 +633,6 @@ ruleTester.run('extensions', rule, {
         {
           message: 'Unexpected use of file extension "js" for "@test-scope/some-module/index.js"',
           line: 3,
-        },
-      ],
-    }),
-
-    // TODO: properly ignore packages resolved via relative imports
-    test({
-      code: [
-        'import * as test from "."',
-      ].join('\n'),
-      filename: testFilePath('./internal-modules/test.js'),
-      options: ['ignorePackages'],
-      errors: [
-        {
-          message: 'Missing file extension for "."',
-          line: 1,
-        },
-      ],
-    }),
-    // TODO: properly ignore packages resolved via relative imports
-    test({
-      code: [
-        'import * as test from ".."',
-      ].join('\n'),
-      filename: testFilePath('./internal-modules/plugins/plugin.js'),
-      options: ['ignorePackages'],
-      errors: [
-        {
-          message: 'Missing file extension for ".."',
-          line: 1,
         },
       ],
     }),

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -159,12 +159,16 @@ ruleTester.run('extensions', rule, {
     // a relative import that resolves to a directory with its own package.json
     // is a package, so `ignorePackages` should not require an extension (#2844)
     test({
-      code: 'import * as test from "."',
+      code: [
+        'import * as test from "."',
+      ].join('\n'),
       filename: testFilePath('./internal-modules/test.js'),
       options: ['ignorePackages'],
     }),
     test({
-      code: 'import * as test from ".."',
+      code: [
+        'import * as test from ".."',
+      ].join('\n'),
       filename: testFilePath('./internal-modules/plugins/plugin.js'),
       options: ['ignorePackages'],
     }),
@@ -423,6 +427,34 @@ ruleTester.run('extensions', rule, {
       ],
     }),
 
+    // without a resolvable filename (e.g. a `<text>` buffer) we can't tell
+    // whether a relative import points at a package root, so `ignorePackages`
+    // still requires the extension (#2844)
+    test({
+      code: 'import foo from "./foo"',
+      filename: '<text>',
+      options: ['ignorePackages'],
+      errors: [
+        {
+          message: 'Missing file extension for "./foo"',
+          line: 1,
+        },
+      ],
+    }),
+    // when a relative import resolves above any package.json, looking up its
+    // package root throws; treat it as not-a-package instead of crashing (#2844)
+    test({
+      code: 'import * as test from "."',
+      filename: '/x.js',
+      options: ['ignorePackages'],
+      errors: [
+        {
+          message: 'Missing file extension for "."',
+          line: 1,
+        },
+      ],
+    }),
+
     test({
       code: `
         import foo from './foo.js'
@@ -637,33 +669,6 @@ ruleTester.run('extensions', rule, {
       ],
     }),
 
-    // without a resolvable filename (e.g. a `<text>` buffer) we can't tell
-    // whether a relative import points at a package root, so `ignorePackages`
-    // still requires the extension (#2844)
-    test({
-      code: 'import foo from "./foo"',
-      filename: '<text>',
-      options: ['ignorePackages'],
-      errors: [
-        {
-          message: 'Missing file extension for "./foo"',
-          line: 1,
-        },
-      ],
-    }),
-    // when a relative import resolves above any package.json, looking up its
-    // package root throws; treat it as not-a-package instead of crashing (#2844)
-    test({
-      code: 'import * as test from "."',
-      filename: '/x.js',
-      options: ['ignorePackages'],
-      errors: [
-        {
-          message: 'Missing file extension for "."',
-          line: 1,
-        },
-      ],
-    }),
   ],
 });
 

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -669,7 +669,33 @@ ruleTester.run('extensions', rule, {
         },
       ],
     }),
-
+    // relative package roots still need extensions unless packages are ignored
+    test({
+      code: [
+        'import * as test from "."',
+      ].join('\n'),
+      filename: testFilePath('./internal-modules/test.js'),
+      options: ['always'],
+      errors: [
+        {
+          message: 'Missing file extension for "."',
+          line: 1,
+        },
+      ],
+    }),
+    test({
+      code: [
+        'import * as test from ".."',
+      ].join('\n'),
+      filename: testFilePath('./internal-modules/plugins/plugin.js'),
+      options: ['always'],
+      errors: [
+        {
+          message: 'Missing file extension for ".."',
+          line: 1,
+        },
+      ],
+    }),
   ],
 });
 

--- a/tests/src/rules/extensions.js
+++ b/tests/src/rules/extensions.js
@@ -161,6 +161,7 @@ ruleTester.run('extensions', rule, {
     test({
       code: [
         'import * as test from "."',
+        'import * as testAgain from "."',
       ].join('\n'),
       filename: testFilePath('./internal-modules/test.js'),
       options: ['ignorePackages'],


### PR DESCRIPTION
Problem I saw:
`import/extensions` could still report `.` or `..` as missing an extension even when `ignorePackages` was enabled.
Those relative imports can point at a directory that is itself a package root, but the rule only gave package treatment to external or scoped imports. Thanks @benasher44 for filing the follow-up from #2778.

What I changed:
I added a narrow package-root check for relative `.` and `..` imports.
When one of those specifiers resolves to a package root, it now follows the same `ignorePackages` behavior as package imports. I kept the scope to `ignorePackages` and did not broaden the ambiguous `always` plus relative-import case.

How I checked it:
I moved the existing TODO cases into valid first and got the expected red run: 69 passing, 2 failing.
After the fix, the `extensions` rule suite passed with 71 passing and 0 failing. The full repo suite also passed with 3029 passing, 0 failing, and 1 pending. Lint passed on the changed files, and pre-push hygiene is clean.

Closes #2844
