### PR TITLE
[New] add `requireResolve` option to check `require.resolve()` paths

### DIFF
--- a/docs/rules/no-absolute-path.md
+++ b/docs/rules/no-absolute-path.md
@@ -41,6 +41,7 @@ You may provide an options object providing true/false for any of
  - `esmodule`: defaults to `true`
  - `commonjs`: defaults to `true`
  - `amd`: defaults to `false`
+ - `requireResolve`: defaults to `false`
 
 If `{ amd: true }` is provided, dependency paths for AMD-style `define` and `require`
 calls will be resolved:

--- a/docs/rules/no-extraneous-dependencies.md
+++ b/docs/rules/no-extraneous-dependencies.md
@@ -40,6 +40,12 @@ There are 2 boolean options to opt into checking extra imports that are normally
 "import/no-extraneous-dependencies": ["error", {"includeInternal": true, "includeTypes": true}]
 ```
 
+The `requireResolve` boolean option (off by default) additionally checks the path argument of `require.resolve()` calls:
+
+```js
+"import/no-extraneous-dependencies": ["error", {"requireResolve": true}]
+```
+
 Also there is one more option called `packageDir`, this option is to specify the path to the folder containing package.json.
 
 If provided as a relative path string, will be computed relative to the current working directory at linter execution time. If this is not ideal (does not work with some editor integrations), consider using `__dirname` to provide a path relative to your configuration.

--- a/docs/rules/no-internal-modules.md
+++ b/docs/rules/no-internal-modules.md
@@ -11,6 +11,8 @@ This rule has two mutally exclusive options that are arrays of [minimatch/glob p
  - `allow` that include paths and import statements that can be imported with reaching.
  - `forbid` that exclude paths and import statements that can be imported with reaching.
 
+It also accepts a `requireResolve` boolean option (default `false`) that, when enabled, checks the path argument of `require.resolve()` calls.
+
 ### Examples
 
 Given the following folder structure:

--- a/docs/rules/no-self-import.md
+++ b/docs/rules/no-self-import.md
@@ -30,3 +30,13 @@ import bar from './bar';
 
 const bar = require('./bar');
 ```
+
+## Options
+
+### requireResolve
+
+When set to `true`, this rule also checks the path argument of `require.resolve()` calls. Defaults to `false`.
+
+```js
+"import/no-self-import": ["error", { "requireResolve": true }]
+```

--- a/docs/rules/no-unresolved.md
+++ b/docs/rules/no-unresolved.md
@@ -58,6 +58,17 @@ define(['./foo'], function (foo) { /*...*/ }) // reported if './foo' is not foun
 require(['./foo'], function (foo) { /*...*/ }) // reported if './foo' is not found
 ```
 
+If `{ requireResolve: true }` is provided, `require.resolve` calls are resolved, independently of `commonjs`:
+
+```js
+/*eslint import/no-unresolved: [2, { requireResolve: true }]*/
+const x = require.resolve('./foo') // reported if './foo' is not found
+
+require.resolve('./foo', { paths: [dir] }) // ignored (`paths` changes the resolution base)
+require.resolve(0) // ignored (non-string)
+require['resolve']('./foo') // ignored (computed access)
+```
+
 #### `ignore`
 
 This rule has its own ignore list, separate from [`import/ignore`]. This is because you may want to know whether a module can be located, regardless of whether it can be parsed for exports: `node_modules`, CoffeeScript files, etc. are all good to resolve properly, but will not be parsed if configured as such via [`import/ignore`].

--- a/docs/rules/no-useless-path-segments.md
+++ b/docs/rules/no-useless-path-segments.md
@@ -83,3 +83,7 @@ Note: `noUselessIndex` only avoids ambiguous imports for `.js` files if you have
 ### commonjs
 
 When set to `true`, this rule checks CommonJS imports. Default to `false`.
+
+### requireResolve
+
+When set to `true`, this rule checks the path argument of `require.resolve()` calls. Defaults to `false`.

--- a/docs/rules/no-webpack-loader-syntax.md
+++ b/docs/rules/no-webpack-loader-syntax.md
@@ -34,6 +34,16 @@ var myModule = require('my-module');
 var theme = require('./theme.css');
 ```
 
+## Options
+
+### requireResolve
+
+When set to `true`, this rule also checks the path argument of `require.resolve()` calls. Defaults to `false`.
+
+```js
+"import/no-webpack-loader-syntax": ["error", { "requireResolve": true }]
+```
+
 ## When Not To Use It
 
 If you have a project that doesn't use Webpack you can safely disable this rule.

--- a/src/rules/no-cycle.js
+++ b/src/rules/no-cycle.js
@@ -76,6 +76,14 @@ module.exports = {
     const fileScc = options.disableScc ? {} : StronglyConnectedComponentsBuilder.get(myPath, context);
 
     function checkSourceValue(sourceNode, importer, moduleSystem) {
+      if (
+        importer.type === 'CallExpression'
+        && importer.callee.type === 'MemberExpression'
+        && importer.callee.object.name === 'require'
+        && importer.callee.property.name === 'resolve'
+      ) {
+        return; // require.resolve computes a path, not a load-time cycle edge
+      }
       if (ignoreModule(sourceNode.value, moduleSystem)) {
         return; // ignore external modules
       }

--- a/src/rules/no-extraneous-dependencies.js
+++ b/src/rules/no-extraneous-dependencies.js
@@ -289,6 +289,7 @@ module.exports = {
           packageDir: { type: ['string', 'array'] },
           includeInternal: { type: ['boolean'] },
           includeTypes: { type: ['boolean'] },
+          requireResolve: { type: ['boolean'] },
         },
         additionalProperties: false,
       },
@@ -311,7 +312,7 @@ module.exports = {
 
     return moduleVisitor((source, node, moduleSystem) => {
       reportIfMissing(context, deps, depsOptions, node, source.value, moduleSystem);
-    }, { commonjs: true });
+    }, { commonjs: true, requireResolve: !!options.requireResolve });
   },
 
   'Program:exit'() {

--- a/src/rules/no-internal-modules.js
+++ b/src/rules/no-internal-modules.js
@@ -26,6 +26,7 @@ module.exports = {
                   type: 'string',
                 },
               },
+              requireResolve: { type: 'boolean' },
             },
             additionalProperties: false,
           },
@@ -38,6 +39,7 @@ module.exports = {
                   type: 'string',
                 },
               },
+              requireResolve: { type: 'boolean' },
             },
             additionalProperties: false,
           },
@@ -138,7 +140,7 @@ module.exports = {
       (source, node, moduleSystem) => {
         checkImportForReaching(source.value, source, moduleSystem);
       },
-      { commonjs: true },
+      { commonjs: true, requireResolve: options.requireResolve },
     );
   },
 };

--- a/src/rules/no-self-import.js
+++ b/src/rules/no-self-import.js
@@ -31,11 +31,20 @@ module.exports = {
       url: docsUrl('no-self-import'),
     },
 
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          requireResolve: { type: 'boolean' },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
   create(context) {
+    const options = context.options[0] || {};
     return moduleVisitor((source, node, moduleSystem) => {
       isImportingSelf(context, node, source.value, moduleSystem);
-    }, { commonjs: true });
+    }, { commonjs: true, requireResolve: options.requireResolve });
   },
 };

--- a/src/rules/no-useless-path-segments.js
+++ b/src/rules/no-useless-path-segments.js
@@ -53,6 +53,7 @@ module.exports = {
         type: 'object',
         properties: {
           commonjs: { type: 'boolean' },
+          requireResolve: { type: 'boolean' },
           noUselessIndex: { type: 'boolean' },
         },
         additionalProperties: false,

--- a/src/rules/no-webpack-loader-syntax.js
+++ b/src/rules/no-webpack-loader-syntax.js
@@ -15,12 +15,21 @@ module.exports = {
       description: 'Forbid webpack loader syntax in imports.',
       url: docsUrl('no-webpack-loader-syntax'),
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          requireResolve: { type: 'boolean' },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
 
   create(context) {
+    const options = context.options[0] || {};
     return moduleVisitor((source, node) => {
       reportIfNonStandard(context, node, source.value);
-    }, { commonjs: true });
+    }, { commonjs: true, requireResolve: options.requireResolve });
   },
 };

--- a/tests/src/rules/no-absolute-path.js
+++ b/tests/src/rules/no-absolute-path.js
@@ -49,6 +49,13 @@ ruleTester.run('no-absolute-path', rule, {
       code: 'define(["./some/path"], function (f) { /* ... */ })',
       options: [{ amd: true }],
     }),
+
+    // require.resolve not checked unless requireResolve is enabled
+    test({ code: 'var f = require.resolve("/some/path")' }),
+    test({
+      code: 'var f = require.resolve("./some/path")',
+      options: [{ requireResolve: true }],
+    }),
   ],
   invalid: [
     test({
@@ -87,6 +94,13 @@ ruleTester.run('no-absolute-path', rule, {
       filename: '/foo/bar/index.js',
       errors: [error],
       output: 'var f = require("..")',
+    }),
+    test({
+      code: 'var f = require.resolve("/foo/path")',
+      filename: '/foo/bar/index.js',
+      options: [{ requireResolve: true }],
+      errors: [error],
+      output: 'var f = require.resolve("../path")',
     }),
     test({
       code: 'var f = require("/foo/path")',

--- a/tests/src/rules/no-cycle.js
+++ b/tests/src/rules/no-cycle.js
@@ -66,6 +66,12 @@ const cases = {
       },
     }),
 
+    // require.resolve computes a path, so it is never a cycle edge
+    test({
+      code: 'var foo = require.resolve("./es6/depth-one")',
+      options: [{ requireResolve: true }],
+    }),
+
     flatMap(testDialects, (testDialect) => [
       test({
         code: `import { foo } from "./${testDialect}/depth-two"`,

--- a/tests/src/rules/no-extraneous-dependencies.js
+++ b/tests/src/rules/no-extraneous-dependencies.js
@@ -75,6 +75,14 @@ ruleTester.run('no-extraneous-dependencies', rule, {
       filename: path.join(process.cwd(), 'foo.spec.js'),
     }),
     test({ code: 'require(6)' }),
+
+    // requireResolve option
+    test({
+      code: 'require.resolve("lodash.cond")',
+      options: [{ requireResolve: true }],
+    }),
+    // off by default: require.resolve is not checked
+    test({ code: 'require.resolve("not-a-dependency")' }),
     test({
       code: 'import "doctrine"',
       options: [{ packageDir: path.join(__dirname, '../../../') }],
@@ -269,6 +277,13 @@ ruleTester.run('no-extraneous-dependencies', rule, {
     }),
     test({
       code: 'var foo = require("not-a-dependency")',
+      errors: [{
+        message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
+      }],
+    }),
+    test({
+      code: 'require.resolve("not-a-dependency")',
+      options: [{ requireResolve: true }],
       errors: [{
         message: '\'not-a-dependency\' should be listed in the project\'s dependencies. Run \'npm i -S not-a-dependency\' to add it',
       }],

--- a/tests/src/rules/no-internal-modules.js
+++ b/tests/src/rules/no-internal-modules.js
@@ -73,6 +73,11 @@ ruleTester.run('no-internal-modules', rule, {
         forbid: ['**/api/*'],
       }],
     }),
+    // require.resolve reaching is not checked unless requireResolve is enabled
+    test({
+      code: 'require.resolve("./app/index.js")',
+      filename: testFilePath('./internal-modules/plugins/plugin2/internal.js'),
+    }),
     test({
       code: 'import b from "app/a"',
       filename: testFilePath('./internal-modules/plugins/plugin2/internal.js'),
@@ -193,6 +198,16 @@ ruleTester.run('no-internal-modules', rule, {
         message: 'Reaching to "./app/index.js" is not allowed.',
         line: 1,
         column: 8,
+      }],
+    }),
+    test({
+      code: 'require.resolve("./app/index.js")',
+      filename: testFilePath('./internal-modules/plugins/plugin2/internal.js'),
+      options: [{ requireResolve: true }],
+      errors: [{
+        message: 'Reaching to "./app/index.js" is not allowed.',
+        line: 1,
+        column: 17,
       }],
     }),
     test({

--- a/tests/src/rules/no-self-import.js
+++ b/tests/src/rules/no-self-import.js
@@ -79,10 +79,21 @@ ruleTester.run('no-self-import', rule, {
       code: 'var bar = require("./bar")',
       filename: '<text>',
     }),
+    // require.resolve to self is not reported unless requireResolve is enabled
+    test({
+      code: 'var bar = require.resolve("./no-self-import")',
+      filename: testFilePath('./no-self-import.js'),
+    }),
   ],
   invalid: [
     test({
       code: 'import bar from "./no-self-import"',
+      errors: [error],
+      filename: testFilePath('./no-self-import.js'),
+    }),
+    test({
+      code: 'var bar = require.resolve("./no-self-import")',
+      options: [{ requireResolve: true }],
       errors: [error],
       filename: testFilePath('./no-self-import.js'),
     }),

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -142,6 +142,62 @@ function runResolverTests(resolver) {
         code: 'require(foo)',
         options: [{ commonjs: true }],
       }),
+
+      // requireResolve setting
+      rest({
+        code: 'require.resolve("./bar")',
+        options: [{ requireResolve: true }],
+      }),
+      rest({
+        code: 'var foo = require.resolve("./bar")',
+        options: [{ requireResolve: true }],
+      }),
+      // resolves independently of the commonjs option
+      rest({
+        code: 'require.resolve("./bar")',
+        options: [{ commonjs: false, requireResolve: true }],
+      }),
+      rest({
+        code: 'require.resolve("./bar")',
+        options: [{ esmodule: false, requireResolve: true }],
+      }),
+      // off by default
+      rest({ code: 'require.resolve("./does-not-exist")' }),
+      rest({
+        code: 'require.resolve("./does-not-exist")',
+        options: [{ requireResolve: false }],
+      }),
+      // require.resolve does not opt into plain require() checking
+      rest({
+        code: 'require("./does-not-exist")',
+        options: [{ requireResolve: true }],
+      }),
+      // ignored forms
+      rest({
+        code: 'require.resolve(0)',
+        options: [{ requireResolve: true }],
+      }),
+      // 2-arg form: `paths` overrides the resolution base, which resolvers cannot honor
+      rest({
+        code: 'require.resolve("./does-not-exist", { paths: [__dirname] })',
+        options: [{ requireResolve: true }],
+      }),
+      rest({
+        code: 'require.resolve(foo)',
+        options: [{ requireResolve: true }],
+      }),
+      rest({
+        code: 'require["resolve"]("./does-not-exist")',
+        options: [{ requireResolve: true }],
+      }),
+      rest({
+        code: 'foo.require.resolve("./does-not-exist")',
+        options: [{ requireResolve: true }],
+      }),
+      rest({
+        code: 'var x = require.resolve',
+        options: [{ requireResolve: true }],
+      }),
     ),
 
     invalid: [].concat(
@@ -290,6 +346,39 @@ function runResolverTests(resolver) {
           },
           {
             message: "Unable to resolve path to module './does-not-exist'.",
+            type: 'Literal',
+          },
+        ],
+      }),
+
+      // requireResolve setting
+      rest({
+        code: 'require.resolve("./baz")',
+        options: [{ requireResolve: true }],
+        errors: [
+          {
+            message: "Unable to resolve path to module './baz'.",
+            type: 'Literal',
+          },
+        ],
+      }),
+      rest({
+        code: 'var bar = require.resolve("./baz")',
+        options: [{ requireResolve: true }],
+        errors: [
+          {
+            message: "Unable to resolve path to module './baz'.",
+            type: 'Literal',
+          },
+        ],
+      }),
+      // resolves with commonjs/esmodule disabled
+      rest({
+        code: 'require.resolve("./baz")',
+        options: [{ commonjs: false, esmodule: false, requireResolve: true }],
+        errors: [
+          {
+            message: "Unable to resolve path to module './baz'.",
             type: 'Literal',
           },
         ],

--- a/tests/src/rules/no-useless-path-segments.js
+++ b/tests/src/rules/no-useless-path-segments.js
@@ -10,6 +10,9 @@ function runResolverTests(resolver) {
       // CommonJS modules with default options
       test({ code: 'require("./../files/malformed.js")' }),
 
+      // require.resolve not checked unless requireResolve is enabled
+      test({ code: 'require.resolve("./../files/malformed.js")' }),
+
       // ES modules with default options
       test({ code: 'import "./malformed.js"' }),
       test({ code: 'import "./test-module"' }),
@@ -93,6 +96,14 @@ function runResolverTests(resolver) {
         output: 'require("./deep/a")',
         options: [{ commonjs: true }],
         errors: ['Useless path segments for "./deep//a", should be "./deep/a"'],
+      }),
+
+      // require.resolve
+      test({
+        code: 'require.resolve("./../files/malformed.js")',
+        output: 'require.resolve("../files/malformed.js")',
+        options: [{ requireResolve: true }],
+        errors: ['Useless path segments for "./../files/malformed.js", should be "../files/malformed.js"'],
       }),
 
       // CommonJS modules + noUselessIndex

--- a/tests/src/rules/no-webpack-loader-syntax.js
+++ b/tests/src/rules/no-webpack-loader-syntax.js
@@ -21,6 +21,13 @@ ruleTester.run('no-webpack-loader-syntax', rule, {
     test({ code: 'var foo = require("foo")' }),
     test({ code: 'var foo = require("./")' }),
     test({ code: 'var foo = require("@scope/foo")' }),
+
+    // require.resolve not checked unless requireResolve is enabled
+    test({ code: 'var foo = require.resolve("babel!lodash")' }),
+    test({
+      code: 'var foo = require.resolve("./foo.css")',
+      options: [{ requireResolve: true }],
+    }),
   ],
   invalid: [
     test({
@@ -69,6 +76,13 @@ ruleTester.run('no-webpack-loader-syntax', rule, {
       code: 'var data = require("json!@scope/my-package/data.json")',
       errors: [
         { message: `Unexpected '!' in 'json!@scope/my-package/data.json'. ${message}` },
+      ],
+    }),
+    test({
+      code: 'var foo = require.resolve("style!css!./foo.css")',
+      options: [{ requireResolve: true }],
+      errors: [
+        { message: `Unexpected '!' in 'style!css!./foo.css'. ${message}` },
       ],
     }),
   ],

--- a/utils/moduleVisitor.d.ts
+++ b/utils/moduleVisitor.d.ts
@@ -8,6 +8,7 @@ type Options = {
     amd?: boolean;
     commonjs?: boolean;
     esmodule?: boolean;
+    requireResolve?: boolean;
     ignore?: string[];
 };
 

--- a/utils/moduleVisitor.js
+++ b/utils/moduleVisitor.js
@@ -16,6 +16,7 @@ exports.default = function visitModules(visitor, options) {
   const ignore = options && options.ignore;
   const amd = !!(options && options.amd);
   const commonjs = !!(options && options.commonjs);
+  const requireResolve = !!(options && options.requireResolve);
   // if esmodule is not explicitly disabled, it is assumed to be enabled
   const esmodule = !!Object.assign({ esmodule: true }, options).esmodule;
 
@@ -84,6 +85,23 @@ exports.default = function visitModules(visitor, options) {
     checkSourceValue(Object.assign({}, modulePath, { value }), call, 'require');
   }
 
+  // for CommonJS `require.resolve` calls
+  /** @type {(call: Call) => void} */
+  function checkRequireResolve(call) {
+    if (call.callee.type !== 'MemberExpression') { return; }
+    if (call.callee.computed) { return; }
+    if (call.callee.object.type !== 'Identifier' || call.callee.object.name !== 'require') { return; }
+    if (call.callee.property.type !== 'Identifier' || call.callee.property.name !== 'resolve') { return; }
+    // skip the 2-arg form: `paths` overrides the resolution base, which resolvers cannot honor
+    if (call.arguments.length !== 1) { return; }
+
+    const modulePath = call.arguments[0];
+    if (modulePath.type !== 'Literal') { return; }
+    if (typeof modulePath.value !== 'string') { return; }
+
+    checkSourceValue(modulePath, call, 'require');
+  }
+
   /** @type {(call: Call) => void} */
   function checkAMD(call) {
     if (call.callee.type !== 'Identifier') { return; }
@@ -120,12 +138,13 @@ exports.default = function visitModules(visitor, options) {
     });
   }
 
-  if (commonjs || amd) {
+  if (commonjs || amd || requireResolve) {
     const currentCallExpression = visitors.CallExpression;
     visitors.CallExpression = /** @type {(call: Call) => void} */ function (call) {
       if (currentCallExpression) { currentCallExpression(call); }
       if (commonjs) { checkCommon(call); }
       if (amd) { checkAMD(call); }
+      if (requireResolve) { checkRequireResolve(call); }
     };
   }
 
@@ -144,6 +163,7 @@ function makeOptionsSchema(additionalProperties) {
       commonjs: { type: 'boolean' },
       amd: { type: 'boolean' },
       esmodule: { type: 'boolean' },
+      requireResolve: { type: 'boolean' },
       ignore: {
         type: 'array',
         minItems: 1,


### PR DESCRIPTION
Closes #585. Supersedes #1217.

## Motivation

While working on a [PR in Gutenberg](https://github.com/WordPress/gutenberg/pull/79703#issuecomment-4846406458) (which powers the WordPress block editor), I noticed that `require.resolve()` calls are not considered by these rules. Looking for existing discussion I found #585, so this PR implements it.

## Summary

`require.resolve()` resolves a module path the same way `require()` does, but until now the resolution rules ignored it. This PR adds an opt-in **`requireResolve`** boolean option (default `false`) to the shared `moduleVisitor`. When enabled, the first string-literal argument of a `require.resolve("<path>")` call is visited as a `require` module path, so the rules that resolve specifiers can check it too.

```js
/*eslint import/no-unresolved: [2, { requireResolve: true }]*/
const x = require.resolve('./foo'); // reported if './foo' is not found
require.resolve('./foo', { paths: [dir] }); // ignored (`paths` changes the resolution base)

require.resolve(0); // ignored (non-string)
require['resolve']('./foo'); // ignored (computed access)
```

## Relation to #1217

This supersedes the earlier #1217, which also added a `requireResolve` option but stalled in review. The main differences here: the option is a plain boolean independent of `commonjs` (instead of the `boolean | { commonjs }` `oneOf`), the 2-arg `{ paths }` form is ignored since resolvers cannot honor a custom resolution base, `no-cycle` explicitly ignores `require.resolve`, and the option is wired into several additional resolution rules — all with tests and docs.

## Why opt-in (off by default)

This mirrors the conclusion of the earlier attempts (#1216 / #1217): emitting new warnings on existing code is a breaking change, and `require.resolve` is sometimes used to resolve non-module assets (e.g. build-generated files) that a resolver can't find. The option therefore defaults to `false` and is independent of `commonjs`.

> Note on `require.resolve(0)`: like `require()` and `import()`, the visitor only forwards static string paths, so non-string / dynamic arguments are skipped rather than reported. (In the #1217 review @ljharb noted a warning there could be useful; that is arguably a separate "invalid argument type" concern and is intentionally left out of scope here.)

## Affected rules

The change lives in `moduleVisitor`, so every resolution rule can opt in:

- **Enabled via the shared options schema** (no rule change needed): [`no-unresolved`], [`no-absolute-path`], [`no-relative-packages`], [`no-relative-parent-imports`].
- **[`no-cycle`]**: explicitly **ignores** `require.resolve` — it computes a path without loading the module, so it cannot form a runtime cycle. This prevents false cycle reports when the option is enabled elsewhere.
- **Explicitly wired** (these have their own schema and/or hardcode the visitor options): [`no-extraneous-dependencies`], [`no-self-import`], [`no-webpack-loader-syntax`], [`no-useless-path-segments`], [`no-internal-modules`].

Deliberately **not** wired: `max-dependencies` (a resolved path is not a load-time dependency edge), `extensions` (`require.resolve` is often used specifically to resolve paths _with_ an extension), and `no-nodejs-modules` (marginal value).

## Behaviour / edge cases

- The 2-arg `require.resolve(path, { paths })` form is ignored: `paths` overrides the resolution base, which resolvers cannot honor, so checking the first argument would produce false positives. (This deviates from the "check the first argument in every case" suggestion in the #1217 review, which predates the `paths` semantics being raised.)
- Only non-computed `require.resolve(...)` member calls match; `require['resolve'](...)`, `require[resolve](...)`, and `foo.require.resolve(...)` are ignored.
- Non-string / dynamic first arguments are ignored.
- The visitor reports with `moduleSystem: 'require'`, so resolver `moduleSystem` configuration applies consistently with `require()`.

## Checklist

- [x] write tests — valid (off-by-default) and invalid (option-on) cases for every wired rule, across the existing parser matrix where applicable
- [x] implement feature
- [x] update docs (`docs/rules/*`)
- [x] make a note in the change log

## Testing

- `npm run tests-only` for the affected suites — all passing
- `eslint .`, `tsc --noEmit index.d.ts`, `npm run update:eslint-docs -- --check`, and `markdownlint` all clean

## AI tool disclosure

This change was prepared with AI assistance. The plan, implementation, tests, and docs were drafted with Claude Code, and the plan and final diff were independently reviewed with Codex. All output was reviewed by me before submission, and I take responsibility for the contents of this PR.

