### PR TITLE
[Deps] let user know `eslint-import-resolver-node` needs to be in root of node_modules (important when using `install-strategy=linked`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ## [Unreleased]
 
 ### Added
+- [Deps] let user know `eslint-import-resolver-node` needs to be in root of node_modules (important when using `install-strategy=linked`) ([#3266], thanks [@nikolawork])
 - support eslint v10 ([#3230], thanks [@rasmi])
 - [`no-deprecated`]: detect `@deprecated` on default-exported identifier declarations ([#3247], thanks [@mixelburg] [@etyrrell22])
 - [`consistent-type-specifier-style`]: add `prefer-top-level-if-only-type-imports` option ([#3210], thanks [@aldeed])

--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
     "typescript-eslint-parser": "^15 || ^20 || ^22"
   },
   "peerDependencies": {
-    "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9 || ^10"
+    "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9 || ^10",
+    "eslint-import-resolver-node": "^0.4.0"
   },
   "dependencies": {
     "@rtsao/scc": "^1.1.0",


### PR DESCRIPTION
Using `install-strategy=linked` only puts the packages from `dependencies` and `devDependencies` in the root of node_modules. This means that `eslint-import-resolver-node` is not in the root of node_modules which leads to the following error:

```
Resolve error: unable to load resolver "node"
```

This is fixed by adding `eslint-import-resolver-node` to your `package.json`. We signal this to the user by adding `eslint-import-resolver-node` to `peerDependencies`.

`install-strategy=linked` is stable since `npm@11.18.0`: https://docs.npmjs.com/cli/v11/using-npm/config#install-strategy

npm even recommends using it when developing. From the above link:

> We recommend that package authors use `--install-strategy=linked` during development to catch undeclared ("phantom") dependencies before publishing: the isolated layout only exposes a package's declared dependencies, so an `import` of a package that was never added to `package.json` can fail instead of resolving by accident and shipping broken. See [Catching undeclared ("phantom") dependencies](https://docs.npmjs.com/cli/v11/using-npm/developers#catching-undeclared-phantom-dependencies).

There is a closed (but unresolved) issue for this: #828