### PR TITLE
[Fix] load the default `node` resolver under an isolated `node_modules` layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - export a top-level `meta` object, matching the declared types, and strengthen the type tests ([#3169], thanks [@ljharb])
 
 ### Fixed
+- load the default `node` resolver under an isolated `node_modules` layout, where `eslint-module-utils` cannot see our dependencies ([#3269], thanks [@manzoorwanijk])
 - [`no-duplicates`]: fix `prefer-inline` autofix producing invalid syntax when an identifier named `from` is imported ([#3236], thanks [@DukeDeSouth] [@Quantaly])
 - [`no-duplicates`]: avoid false positives for TypeScript namespace and default type imports that cannot be merged ([#3195], thanks [@sjh9714] [@robyoder])
 - ExportMap: resolve export * as ns re-exports under modern parsers ([#3250], thanks [@rasmi] [@JounQin] [@butterybread])
@@ -1214,6 +1215,7 @@ for info on changes for earlier releases.
 [`memo-parser`]: ./memo-parser/README.md
 
 [#3284]: https://github.com/import-js/eslint-plugin-import/pull/3284
+[#3269]: https://github.com/import-js/eslint-plugin-import/pull/3269
 [#3283]: https://github.com/import-js/eslint-plugin-import/pull/3283
 [#3282]: https://github.com/import-js/eslint-plugin-import/pull/3282
 [#3276]: https://github.com/import-js/eslint-plugin-import/pull/3276
@@ -2035,6 +2037,7 @@ for info on changes for earlier releases.
 [@malykhinvi]: https://github.com/malykhinvi
 [@manovotny]: https://github.com/manovotny
 [@manuth]: https://github.com/manuth
+[@manzoorwanijk]: https://github.com/manzoorwanijk
 [@marcusdarmstrong]: https://github.com/marcusdarmstrong
 [@mastilver]: https://github.com/mastilver
 [@mathieudutour]: https://github.com/mathieudutour

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,14 @@
+import { registerResolverRequire } from 'eslint-module-utils/resolve';
+
 import { name, version } from '../package.json';
+
+/**
+ * Lend our `require` to `eslint-module-utils`, which can not see our
+ * `eslint-import-resolver-node` under an isolated `node_modules` layout.
+ */
+if (typeof registerResolverRequire === 'function') { // older versions lack this API
+  registerResolverRequire(require);
+}
 
 export const rules = {
   'no-unresolved': require('./rules/no-unresolved'),

--- a/tests/src/core/resolve.js
+++ b/tests/src/core/resolve.js
@@ -184,6 +184,17 @@ describe('resolve', function () {
       expect(registered.requested).to.have.lengthOf(0);
     });
 
+    it('registers each `require` once, and ignores anything else', function () {
+      const registered = fakeRequire({});
+      registerResolverRequire(registered);
+      registerResolverRequire(registered);
+      registerResolverRequire(null);
+      registerResolverRequire('not a require');
+
+      expect(reportsFor({ 'import/resolver': 'nope-not-here' }).resolved).to.equal(undefined);
+      expect(registered.requested).to.eql(['eslint-import-resolver-nope-not-here', 'nope-not-here']);
+    });
+
     it('surfaces a load exception from a registered resolver', function () {
       registerResolverRequire(fakeRequire({
         'eslint-import-resolver-throws-on-load'() { throw new SyntaxError('TEST SYNTAX ERROR'); },

--- a/tests/src/core/resolve.js
+++ b/tests/src/core/resolve.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import eslintPkg from 'eslint/package.json';
 import semver from 'semver';
 
-import resolve, { CASE_SENSITIVE_FS, fileExistsWithCaseSync } from 'eslint-module-utils/resolve';
+import resolve, { CASE_SENSITIVE_FS, fileExistsWithCaseSync, registerResolverRequire } from 'eslint-module-utils/resolve';
 
 import * as path from 'path';
 import * as fs from 'fs';
@@ -119,6 +119,80 @@ describe('resolve', function () {
       '../files/foo',
       { ...testContext, getFilename() { return utils.getFilename('foo.js'); } },
     )).to.equal(utils.testFilePath('./bar.jsx'));
+  });
+
+  describe('registerResolverRequire', function () {
+    const resolverName = 'not-reachable-from-the-source-file';
+
+    function reportsFor(settings) {
+      const testContext = utils.testContext(settings);
+      const testContextReports = [];
+      testContext.report = function (reportInfo) {
+        testContextReports.push(reportInfo);
+      };
+      const resolved = resolve(
+        '../files/foo',
+        { ...testContext, getFilename() { return utils.getFilename('foo.js'); } },
+      );
+      return { reports: testContextReports, resolved };
+    }
+
+    /** a `require` that only knows `targets`, recording every request it is asked to resolve */
+    function fakeRequire(targets) {
+      const requested = [];
+      function fake(request) { return targets[request](); }
+      fake.resolve = function (request) {
+        requested.push(request);
+        if (!(request in targets)) { throw new Error(`Cannot find module '${request}'`); }
+        return request;
+      };
+      fake.requested = requested;
+      return fake;
+    }
+
+    it('loads a resolver that is unreachable from the source file', function () {
+      const before = reportsFor({ 'import/resolver': { [resolverName]: {} } });
+      expect(before.resolved).to.equal(undefined);
+      expect(before.reports[0].message).to.equal(`Resolve error: unable to load resolver "${resolverName}".`);
+
+      registerResolverRequire(fakeRequire({
+        [`eslint-import-resolver-${resolverName}`]() { return require('../../files/node_modules/eslint-import-resolver-foo'); },
+      }));
+
+      const after = reportsFor({ 'import/resolver': { [resolverName]: {} } });
+      expect(after.reports).to.have.lengthOf(0);
+      expect(after.resolved).to.equal(utils.testFilePath('./bar.jsx'));
+    });
+
+    it('still prefers a resolver found from the source file', function () {
+      const registered = fakeRequire({});
+      registerResolverRequire(registered);
+
+      const { reports, resolved } = reportsFor({ 'import/resolver': { foo: {} } });
+      expect(reports).to.have.lengthOf(0);
+      expect(resolved).to.equal(utils.testFilePath('./bar.jsx'));
+      expect(registered.requested).to.have.lengthOf(0);
+    });
+
+    it('never consults registered requires for relative or absolute resolver names', function () {
+      const registered = fakeRequire({});
+      registerResolverRequire(registered);
+
+      ['./no-such-resolver', path.join(__dirname, 'no-such-resolver')].forEach(function (name) {
+        expect(reportsFor({ 'import/resolver': name }).resolved).to.equal(undefined);
+      });
+      expect(registered.requested).to.have.lengthOf(0);
+    });
+
+    it('surfaces a load exception from a registered resolver', function () {
+      registerResolverRequire(fakeRequire({
+        'eslint-import-resolver-throws-on-load'() { throw new SyntaxError('TEST SYNTAX ERROR'); },
+      }));
+
+      const { reports, resolved } = reportsFor({ 'import/resolver': 'throws-on-load' });
+      expect(resolved).to.equal(undefined);
+      expect(replaceErrorStackForTest(reports[0].message)).to.equal('Resolve error: SyntaxError: TEST SYNTAX ERROR\n<stack-was-here>');
+    });
   });
 
   it('reports invalid import/resolver config', function () {

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -5,6 +5,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Added
+ - `resolve`: add `registerResolverRequire`, so a consuming plugin can lend its own `require` for loading resolvers it depends on ([#3269], thanks [@manzoorwanijk])
+
 ### Fixed
  - `moduleVisitor`: visit `require` calls whose argument is a no-substitution template literal ([#3276], thanks [@pratyushsinghal7])
 
@@ -203,6 +206,7 @@ Yanked due to critical issue with cache key resulting from #839.
 - `unambiguous.test()` regex is now properly in multiline mode
 
 [#3276]: https://github.com/import-js/eslint-plugin-import/pull/3276
+[#3269]: https://github.com/import-js/eslint-plugin-import/pull/3269
 [#3240]: https://github.com/import-js/eslint-plugin-import/pull/3240
 [#3124]: https://github.com/import-js/eslint-plugin-import/pull/3124
 [#3072]: https://github.com/import-js/eslint-plugin-import/pull/3072
@@ -258,6 +262,7 @@ Yanked due to critical issue with cache key resulting from #839.
 [@ljharb]: https://github.com/ljharb
 [@manuth]: https://github.com/manuth
 [@maxkomarychev]: https://github.com/maxkomarychev
+[@manzoorwanijk]: https://github.com/manzoorwanijk
 [@mgwalker]: https://github.com/mgwalker
 [@michaelfaith]: https://github.com/michaelfaith
 [@Mysak0CZ]: https://github.com/Mysak0CZ

--- a/utils/resolve.d.ts
+++ b/utils/resolve.d.ts
@@ -28,5 +28,6 @@ declare function fileExistsWithCaseSync(
 
 declare function relative(modulePath: string, sourceFile: string, settings: ESLintSettings, moduleSystem?: ModuleSystem): ResolvedResult['path'];
 
+declare function registerResolverRequire(requireFn: NodeJS.Require): void;
 
-export { fileExistsWithCaseSync, relative };
+export { fileExistsWithCaseSync, registerResolverRequire, relative };

--- a/utils/resolve.js
+++ b/utils/resolve.js
@@ -95,12 +95,53 @@ function getBaseDir(sourceFile) {
   return pkgDir(sourceFile) || process.cwd();
 }
 
+/** @type {NodeJS.Require[]} */
+const resolverRequires = [];
+
+/**
+ * Registers a `require` from a package that declares resolvers among its own dependencies,
+ * for isolated `node_modules` layouts, where this package can not see them.
+ * @type {import('./resolve').registerResolverRequire}
+ */
+exports.registerResolverRequire = function registerResolverRequire(requireFn) {
+  if (typeof requireFn === 'function' && resolverRequires.indexOf(requireFn) === -1) {
+    resolverRequires.push(requireFn);
+  }
+};
+
+/** @type {(target: string) => undefined | ReturnType<typeof require>} */
+function requireFromRegistered(target) {
+  for (let i = 0; i < resolverRequires.length; i++) {
+    const requireFn = resolverRequires[i];
+    let resolved;
+    try {
+      resolved = requireFn.resolve(target);
+    } catch (e) {
+      continue; // this `require` can not see `target`
+    }
+    return requireFn(resolved); // load errors propagate, as they do above
+  }
+
+  return undefined;
+}
+
+/** @type {(name: string) => undefined | ReturnType<typeof require>} */
+function tryRegisteredRequires(name) {
+  // these belong to the source file's package
+  if (name.charAt(0) === '.' || path.isAbsolute(name)) { return undefined; }
+
+  return requireFromRegistered(`eslint-import-resolver-${name}`)
+    || requireFromRegistered(name);
+}
+
 /** @type {(name: string, sourceFile: string) => import('./resolve').Resolver} */
 function requireResolver(name, sourceFile) {
   // Try to resolve package with conventional name
   const resolver = tryRequire(`eslint-import-resolver-${name}`, sourceFile)
     || tryRequire(name, sourceFile)
-    || tryRequire(path.resolve(getBaseDir(sourceFile), name));
+    || tryRequire(path.resolve(getBaseDir(sourceFile), name))
+    // last, so that a resolver reachable from the source file always wins
+    || tryRegisteredRequires(name);
 
   if (!resolver) {
     const err = new Error(`unable to load resolver "${name}".`);


### PR DESCRIPTION
Fixes #3268.

Under an isolated `node_modules` layout (`npm install --install-strategy=linked`), a stock config fails with `Resolve error: unable to load resolver "node"`, and every import - core modules included - is then reported unresolved.

`eslint-import-resolver-node` is our dependency, but it is `require`d from `eslint-module-utils`, which does not declare it. A hoisted layout hides that, since every package can see every other; an isolated one does not. pnpm and yarn paper over it via Yarn's [compat DB](https://github.com/yarnpkg/berry/blob/0a230c14e71247576f6b51fa811ae08edb6608aa/packages/yarnpkg-extensions/sources/index.ts#L745), which injects optional peer deps citing #2283 - npm has no such thing, so it surfaces there.

## Approach

`eslint-module-utils/resolve` gains `registerResolverRequire`; we lend it our own `require`, so the resolver is loaded from the package that actually depends on it. Passing a `require` rather than a path anchors the lookup at this package whatever the layout, so it does not rely on the compat DB continuing to cover for us - if that entry ever goes away, pnpm and yarn are already handled.

No peer dependencies involved, per #2283. `eslint-module-utils` stays generic - it learns no consumer's name.

## Backwards compatibility

Registered requires are consulted only after every existing lookup has failed, so resolution is bit-for-bit unchanged wherever it already succeeds; only previously-failing cases can start resolving. Relative and absolute names skip them entirely, as those belong to the source file's package. Load errors propagate rather than being swallowed, matching the existing lookups.

Two notes:

- The call is guarded with `typeof registerResolverRequire === 'function'`, since `eslint-module-utils` is released separately and our declared range still admits versions that predate this API. It can go once the range is bumped.
- Needs an `eslint-module-utils` release plus the usual `[Drps]` bump before it takes effect for consumers.

## Verification

Against a real `--install-strategy=linked` repro, lint goes from the error above to clean, with `eslint-module-utils` still genuinely unable to see the resolver (`MODULE_NOT_FOUND`) - and a bogus import is still reported, so the resolver is doing real work. Also verified where the plugin is a transitive dep of a shared config, which the app itself does not declare. Under yarn PnP the compat DB means the bug does not arise; checked that this changes nothing there.

Five tests added, each confirmed to fail without its fix. Full suite green.

Out of scope: a third-party resolver declared only by a shared config (not by the app or by us) is still unreachable under an isolated layout - nothing in the chain can see it.
