### PR TITLE
[Docs] clarify that the `typescript` config (legacy and flat) does not set up the TypeScript resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [Tests] cover ESLint 10 `getTokenOrComment` and `listFilesToProcess` API fallbacks ([#3230], thanks [@captaindonald])
 - [Docs] `no-unused-modules`: Fix docs of `ignoreUnusedTypeExports` option ([#3233], thanks [@ej612])
 - [actions] update `codecov/codecov-action` to v7, for reliable tokenless coverage uploads from fork PRs ([#3262], thanks [@captaindonald])
+- [Docs] clarify that the `typescript` config (legacy and flat) does not set up the TypeScript resolver ([#3170], thanks [@KAMRONBEK])
 
 ## [2.32.0] - 2025-06-20
 
@@ -1220,6 +1221,7 @@ for info on changes for earlier releases.
 [#3191]: https://github.com/import-js/eslint-plugin-import/pull/3191
 [#3173]: https://github.com/import-js/eslint-plugin-import/pull/3173
 [#3172]: https://github.com/import-js/eslint-plugin-import/pull/3172
+[#3170]: https://github.com/import-js/eslint-plugin-import/issues/3170
 [#3167]: https://github.com/import-js/eslint-plugin-import/pull/3167
 [#3166]: https://github.com/import-js/eslint-plugin-import/pull/3166
 [#3152]: https://github.com/import-js/eslint-plugin-import/pull/3152
@@ -1980,6 +1982,7 @@ for info on changes for earlier releases.
 [@justinanastos]: https://github.com/justinanastos
 [@jwbth]: https://github.com/jwbth
 [@k15a]: https://github.com/k15a
+[@KAMRONBEK]: https://github.com/KAMRONBEK
 [@kentcdodds]: https://github.com/kentcdodds
 [@kevin940726]: https://github.com/kevin940726
 [@kgregory]: https://github.com/kgregory

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ export default [
 You may use the following snippet or assemble your own config using the granular settings described below it.
 
 Make sure you have installed [`@typescript-eslint/parser`] and [`eslint-import-resolver-typescript`] which are used in the following configuration.
+Note that the `plugin:import/typescript` config (and its flat counterpart, `importPlugin.flatConfigs.typescript`) only adds the TypeScript extensions and parser settings; it does not set up the TypeScript resolver, since [`eslint-import-resolver-typescript`] is a separate package that is not a dependency of this plugin. You must install it and enable it via the `import/resolver` setting yourself, as shown below.
 
 ```jsonc
 {
@@ -195,6 +196,8 @@ Make sure you have installed [`@typescript-eslint/parser`] and [`eslint-import-r
 
 If you are using the `config` method from [`typescript-eslint`](https://github.com/typescript-eslint/typescript-eslint), ensure that the `flatConfig` is included within the `extends` array.
 
+As explained above, `importPlugin.flatConfigs.typescript` does not enable the TypeScript resolver, so [`eslint-import-resolver-typescript`] must still be installed and configured via the `import/resolver` setting. Without it, imports resolved through `tsconfig.json` `paths` or a package's `exports` field (such as `typescript-eslint` itself) will fail `import/no-unresolved`.
+
 ```js
 import tseslint from 'typescript-eslint';
 import importPlugin from 'eslint-plugin-import';
@@ -206,6 +209,14 @@ export default tseslint.config(
   {
     files: ['**/*.{ts,tsx}'],
     extends: [importPlugin.flatConfigs.recommended, importPlugin.flatConfigs.typescript],
+    settings: {
+      'import/resolver': {
+        // You will also need to install and configure the TypeScript resolver
+        // See also https://github.com/import-js/eslint-import-resolver-typescript#configuration
+        typescript: true,
+        node: true,
+      },
+    },
     // other configs...
   }
 );

--- a/config/typescript.js
+++ b/config/typescript.js
@@ -2,6 +2,11 @@
  * This config:
  * 1) adds `.jsx`, `.ts`, `.cts`, `.mts`, and `.tsx` as an extension
  * 2) enables JSX/TSX parsing
+ *
+ * It does NOT set up the TypeScript resolver: `eslint-import-resolver-typescript`
+ * is not a dependency of this plugin, so it must be installed and enabled
+ * separately, via the `import/resolver` setting.
+ * See https://github.com/import-js/eslint-import-resolver-typescript#configuration
  */
 
 // Omit `.d.ts` because 1) TypeScript compilation already confirms that


### PR DESCRIPTION
## Problem

Users extending `importPlugin.flatConfigs.typescript` (or `plugin:import/typescript`) assume TypeScript-aware resolution works out of the box, then hit `Unable to resolve path to module 'typescript-eslint'` (`import/no-unresolved`) or `Resolve error: typescript with invalid interface loaded as resolver`. The README's flat-config example (`### Config - Flat with config() in typescript-eslint`) — the snippet the issue author copied — never mentions the resolver at all.

## Root cause

The `typescript` config only adds the TS extensions and parser settings; its `import/resolver` setting is just `node`. It does not enable the TypeScript resolver, because `eslint-import-resolver-typescript` is a separate package that is not a dependency of this plugin (shipping `typescript: true` in the shared config would break every user who doesn't have it installed — the "invalid interface loaded as resolver" error). Per the maintainer answers in the thread, the resolver must be installed manually and enabled via the `import/resolver` setting; imports resolved through `tsconfig.json` `paths` or a package's `exports` field (like `typescript-eslint` itself, since this plugin doesn't support `exports` yet) fail without it.

## Fix (docs only)

- **README `## TypeScript`**: state explicitly that `plugin:import/typescript` / `flatConfigs.typescript` does not set up the TypeScript resolver, and that `eslint-import-resolver-typescript` must be installed and enabled via `import/resolver`.
- **README `### Config - Flat with config() in typescript-eslint`**: add the same note and extend the minimal working example with the missing `settings: { 'import/resolver': { typescript: true, node: true } }` block (mirroring the legacy jsonc example above it, including its install/configure comment).
- **`config/typescript.js`** (backs both `configs.typescript` and `flatConfigs.typescript` via `src/index.js`): extend the header comment with the same clarification and a link to the resolver's configuration docs.
- **CHANGELOG.md**: entry under Unreleased → Changed, following the existing `[Docs]` format.

## Tests

Docs-only; no unit tests. `markdownlint "**/*.md"` (repo config) and `eslint config/typescript.js` (repo .eslintrc) both pass.

Fixes #3170
