### PR TITLE
[Fix] correct `flatConfigs` types so flat-config usage type-checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`no-deprecated`], [`namespace`]: route `declaredScope` through the `getScope` compat shim instead of the removed `context.getScope()` (ESLint 9+) ([#3230], thanks [@ljharb])
 - [`newline-after-import`]: ignore comments between consecutive imports when `considerComments` is enabled ([#2673], thanks [@raisulchowdhury])
 - [`no-unresolved`], [`no-useless-path-segments`]: handle template literal requires ([#3276], thanks [@pratyushsinghal7])
+- [types] remove `stage-0` from the `flatConfigs` types, since it does not exist at runtime, and add type tests for the plugin's exports ([#3169], thanks [@KAMRONBEK])
 
 ### Changed
 - [Refactor] [`order`]: extract the ESLint 10 token/comment compatibility shims into a reusable `getTokenOrComment` util ([#3230], thanks [@captaindonald])
@@ -1228,6 +1229,7 @@ for info on changes for earlier releases.
 [#3191]: https://github.com/import-js/eslint-plugin-import/pull/3191
 [#3173]: https://github.com/import-js/eslint-plugin-import/pull/3173
 [#3172]: https://github.com/import-js/eslint-plugin-import/pull/3172
+[#3169]: https://github.com/import-js/eslint-plugin-import/issues/3169
 [#3167]: https://github.com/import-js/eslint-plugin-import/pull/3167
 [#3166]: https://github.com/import-js/eslint-plugin-import/pull/3166
 [#3152]: https://github.com/import-js/eslint-plugin-import/pull/3152
@@ -1990,6 +1992,7 @@ for info on changes for earlier releases.
 [@justinanastos]: https://github.com/justinanastos
 [@jwbth]: https://github.com/jwbth
 [@k15a]: https://github.com/k15a
+[@KAMRONBEK]: https://github.com/KAMRONBEK
 [@kentcdodds]: https://github.com/kentcdodds
 [@kevin940726]: https://github.com/kevin940726
 [@kgregory]: https://github.com/kgregory

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,6 @@ declare const plugin: ESLint.Plugin & {
     'recommended': Linter.FlatConfig;
     'errors': Linter.FlatConfig;
     'warnings': Linter.FlatConfig;
-    'stage-0': Linter.FlatConfig;
     'react': Linter.FlatConfig;
     'react-native': Linter.FlatConfig;
     'electron': Linter.FlatConfig;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test-example:legacy": "cd examples/legacy && npm install && npm run lint",
     "test-example:flat": "cd examples/flat && npm install && npm run lint",
     "test-example:v9": "cd examples/v9 && npm install && npm run lint",
-    "test-types": "npx --package typescript@latest tsc --noEmit index.d.ts",
+    "test-types": "npx --package typescript@latest tsc --noEmit index.d.ts && npx --package typescript@latest tsc -p tests/types",
     "prepublishOnly": "safe-publish-latest && npm run build",
     "prepublish": "not-in-publish || npm run prepublishOnly",
     "preupdate:eslint-docs": "npm run build",

--- a/tests/types/index.test-d.ts
+++ b/tests/types/index.test-d.ts
@@ -1,0 +1,44 @@
+// Type tests for the root `index.d.ts` (see #3169).
+// Compiled by `npm run test-types` via `tests/types/tsconfig.json`;
+// never executed at runtime.
+
+import importPlugin from 'eslint-plugin-import';
+import { ESLint, Linter, Rule } from 'eslint';
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+// the plugin object itself is a usable, fully-typed ESLint plugin
+const plugin: ESLint.Plugin = importPlugin;
+
+// `flatConfigs` and its entries must not be optional or `any` (#3169)
+const flatConfigsNotAny: IsAny<typeof importPlugin.flatConfigs> = false;
+const recommendedNotAny: IsAny<typeof importPlugin.flatConfigs.recommended> = false;
+
+// the README flat-config examples: every flat config is a defined `Linter.FlatConfig`
+const flatConfigs: Linter.FlatConfig[] = [
+  importPlugin.flatConfigs.recommended,
+  importPlugin.flatConfigs.errors,
+  importPlugin.flatConfigs.warnings,
+  importPlugin.flatConfigs.react,
+  importPlugin.flatConfigs['react-native'],
+  importPlugin.flatConfigs.electron,
+  importPlugin.flatConfigs.typescript,
+];
+
+// @ts-expect-error `stage-0` only exists in the legacy `configs`, not in `flatConfigs`
+importPlugin.flatConfigs['stage-0'];
+
+// the legacy configs are eslintrc-style configs, including `stage-0`
+const legacyConfigs: Linter.LegacyConfig[] = [
+  importPlugin.configs.recommended,
+  importPlugin.configs.errors,
+  importPlugin.configs.warnings,
+  importPlugin.configs['stage-0'],
+  importPlugin.configs.react,
+  importPlugin.configs['react-native'],
+  importPlugin.configs.electron,
+  importPlugin.configs.typescript,
+];
+
+// every rule is a fully-typed rule module
+const orderRule: Rule.RuleModule = importPlugin.rules.order;

--- a/tests/types/tsconfig.json
+++ b/tests/types/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "types": [],
+    "paths": {
+      "eslint-plugin-import": ["../../index.d.ts"]
+    }
+  },
+  "files": ["index.test-d.ts"]
+}


### PR DESCRIPTION
**Problem**

#3169 reports that following the README's TypeScript flat-config example yields `'importPlugin.flatConfigs' is possibly 'undefined'` and `any`-typed configs.

**Root cause / investigation**

The issue was filed 2025-03-22, when the latest release was v2.31.0 — which shipped **no types at all** (the `index.d.ts` added in #3097 first shipped in v2.32.0). That explains the reported errors and the reporter's `declare module 'eslint-plugin-import'` workaround (an ambient override only takes effect when the package ships no declarations).

I verified the shipped 2.32.0 `index.d.ts` against the current ecosystem: both README flat-config examples (`export default [...]` and `tseslint.config(...)`), plus `defineConfig(...)` and `plugins: { import: importPlugin }` usage, type-check cleanly with `tsc --strict` (`skipLibCheck: false`) against eslint 9.39.5 and 10.7.0, TypeScript 5.9.3 and 7.0.2, so the originally-reported errors are already resolved on `main`.

One genuine mismatch remains: `index.d.ts` declares `flatConfigs['stage-0']`, but the runtime `flatConfigs` object in `src/index.js` has no `stage-0` key (it exists only in the legacy `configs`). TypeScript reports a defined `Linter.FlatConfig` for a value that is `undefined` at runtime, so spreading it into a config crashes despite a clean type-check.

**Fix**

- Remove `'stage-0'` from the `flatConfigs` declaration in `index.d.ts` (legacy `configs['stage-0']` is kept — it exists at runtime).
- Add a type-test suite at `tests/types/` (compiled by `npm run test-types` alongside the existing bare `index.d.ts` check) asserting: `flatConfigs`/`configs` and every entry are non-optional and not `any`; every flat config is assignable to `Linter.FlatConfig` and every legacy config to `Linter.LegacyConfig`; the plugin object is assignable to `ESLint.Plugin`; and `flatConfigs['stage-0']` stays a type error (`@ts-expect-error`).

**Tests**

`tsc -p tests/types` passes with the fix and fails (TS2578 unused `@ts-expect-error`) with the `stage-0` removal reverted — verified under both TypeScript 5.9.3 and 7.0.2 (the latter matching CI's `typescript@latest`). The tests/types tsconfig avoids options removed in TS 7 (`baseUrl`, `moduleResolution: node10`), so `test-types` keeps working as CI's `typescript@latest` advances.

**Independence from #3213**

#3213 changes runtime exports in `src/index.js` (default-export identity / `meta`) and does not touch `index.d.ts`; its new package test explicitly expects `stage-0` to be absent from flat configs, consistent with this change. The two merge cleanly in either order.

Fixes #3169.
