### PR TITLE
[New] `order`: add `named.orderByLocalName` option to sort aliased specifiers by local name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - support eslint v10 ([#3230], thanks [@rasmi])
 - [`no-deprecated`]: detect `@deprecated` on default-exported identifier declarations ([#3247], thanks [@mixelburg] [@etyrrell22])
 - [`consistent-type-specifier-style`]: add `prefer-top-level-if-only-type-imports` option ([#3210], thanks [@aldeed])
+- [`order`]: add `named.sortBy` option to sort named imports/exports by their alias instead of their name ([#3181], thanks [@KAMRONBEK])
 
 ### Fixed
 - [`no-duplicates`]: fix `prefer-inline` autofix producing invalid syntax when an identifier named `from` is imported ([#3236], thanks [@DukeDeSouth] [@Quantaly])
@@ -1218,6 +1219,7 @@ for info on changes for earlier releases.
 [#3208]: https://github.com/import-js/eslint-plugin-import/issues/3208
 [#3195]: https://github.com/import-js/eslint-plugin-import/issues/3195
 [#3191]: https://github.com/import-js/eslint-plugin-import/pull/3191
+[#3181]: https://github.com/import-js/eslint-plugin-import/issues/3181
 [#3173]: https://github.com/import-js/eslint-plugin-import/pull/3173
 [#3172]: https://github.com/import-js/eslint-plugin-import/pull/3172
 [#3167]: https://github.com/import-js/eslint-plugin-import/pull/3167
@@ -1980,6 +1982,7 @@ for info on changes for earlier releases.
 [@justinanastos]: https://github.com/justinanastos
 [@jwbth]: https://github.com/jwbth
 [@k15a]: https://github.com/k15a
+[@KAMRONBEK]: https://github.com/KAMRONBEK
 [@kentcdodds]: https://github.com/kentcdodds
 [@kevin940726]: https://github.com/kevin940726
 [@kgregory]: https://github.com/kgregory

--- a/docs/rules/order.md
+++ b/docs/rules/order.md
@@ -422,7 +422,7 @@ import { compose, apply } from 'xcompose';
 
 ### `named`
 
-Valid values: `boolean | { enabled: boolean, import?: boolean, export?: boolean, require?: boolean, cjsExports?: boolean, types?: "mixed" | "types-first" | "types-last" }` \
+Valid values: `boolean | { enabled: boolean, import?: boolean, export?: boolean, require?: boolean, cjsExports?: boolean, sortBy?: "name" | "alias", types?: "mixed" | "types-first" | "types-last" }` \
 Default: `false`
 
 Enforce ordering of names within imports and exports.
@@ -467,6 +467,25 @@ Further, the `named.types` option allows you to specify the order of [import ide
  - `types-first`: forces type-only identifiers to occur first
  - `types-last`: forces type-only identifiers to occur last
  - `mixed`: sorts all identifiers in alphabetical order
+
+The `named.sortBy` option allows you to specify which name aliased identifiers are sorted by, e.g. `import { originalName as aliasName } from 'specifier';`.
+
+`named.sortBy` accepts the following values:
+
+ - `name` (default): sorts aliased identifiers by their original name (the name to the left of `as`)
+ - `alias`: sorts aliased identifiers by their alias (the name to the right of `as`, i.e. the local name of an aliased import, or the exported name of an aliased export)
+
+For example, with `{ "named": { "enabled": true, "sortBy": "alias" }, "alphabetize": { "order": "asc" } }`, this will pass the rule check:
+
+```ts
+import { b, a as c } from 'specifier';
+```
+
+While this will fail the rule check:
+
+```ts
+import { a as c, b } from 'specifier';
+```
 
 #### Example
 

--- a/src/rules/order.js
+++ b/src/rules/order.js
@@ -937,6 +937,13 @@ module.exports = {
                 export: { type: 'boolean' },
                 require: { type: 'boolean' },
                 cjsExports: { type: 'boolean' },
+                sortBy: {
+                  type: 'string',
+                  enum: [
+                    'name',
+                    'alias',
+                  ],
+                },
                 types: {
                   type: 'string',
                   enum: [
@@ -1055,6 +1062,7 @@ module.exports = {
 
     const named = {
       types: 'mixed',
+      sortBy: 'name',
       ...typeof options.named === 'object' ? {
         ...options.named,
         import: 'import' in options.named ? options.named.import : options.named.enabled,
@@ -1117,12 +1125,17 @@ module.exports = {
           (namedImport) => {
             const kind = namedImport.kind || 'value';
             const rank = namedGroups.findIndex((entry) => [].concat(entry).indexOf(kind) > -1);
+            const sortByAlias = named.sortBy === 'alias';
 
             return {
-              displayName: namedImport.value,
+              displayName: sortByAlias && namedImport.alias
+                ? `${namedImport.value} as ${namedImport.alias}`
+                : namedImport.value,
               rank: rank === -1 ? namedGroups.length : rank,
               ...namedImport,
-              value: `${namedImport.value}:${namedImport.alias || ''}`,
+              value: sortByAlias
+                ? `${namedImport.alias || namedImport.value}:${namedImport.value}`
+                : `${namedImport.value}:${namedImport.alias || ''}`,
             };
           });
 

--- a/tests/src/rules/order.js
+++ b/tests/src/rules/order.js
@@ -1303,6 +1303,47 @@ ruleTester.run('order', rule, {
         alphabetize: { order: 'asc' },
       }],
     }),
+    // sortBy: 'alias' sorts aliased names by their alias instead of their name
+    test({
+      code: `
+        import { b, a as c } from "./Z";
+      `,
+      options: [{
+        named: {
+          enabled: true,
+          sortBy: 'alias',
+        },
+        alphabetize: { order: 'asc' },
+      }],
+    }),
+    test({
+      code: `
+        import { B, Z } from "./Z";
+        export { Z as A, B };
+        const { x: a, b } = require("./Z");
+        module.exports = { b: B, a: Z };
+      `,
+      options: [{
+        named: {
+          enabled: true,
+          sortBy: 'alias',
+        },
+        alphabetize: { order: 'asc' },
+      }],
+    }),
+    // sortBy: 'name' is the default behavior
+    test({
+      code: `
+        import { a as c, b } from "./Z";
+      `,
+      options: [{
+        named: {
+          enabled: true,
+          sortBy: 'name',
+        },
+        alphabetize: { order: 'asc' },
+      }],
+    }),
   ],
   invalid: [
     // builtin before external module (require)
@@ -2951,6 +2992,86 @@ ruleTester.run('order', rule, {
       }],
       errors: [{
         message: '`A.C` export should occur after export of `A.B`',
+      }],
+    }),
+    // sortBy: 'alias' sorts aliased names by their alias instead of their name
+    test({
+      code: `
+        import { c as z, b } from "./Z";
+      `,
+      output: `
+        import { b, c as z } from "./Z";
+      `,
+      options: [{
+        named: {
+          enabled: true,
+          sortBy: 'alias',
+        },
+        alphabetize: { order: 'asc' },
+      }],
+      errors: [{
+        message: '`b` import should occur before import of `c as z`',
+      }],
+    }),
+    test({
+      code: `
+        import { b, z } from "./Z";
+        export { b, z as a };
+        const { b: y, a: x } = require("./Z");
+      `,
+      output: `
+        import { b, z } from "./Z";
+        export { z as a, b };
+        const { a: x, b: y } = require("./Z");
+      `,
+      options: [{
+        named: {
+          enabled: true,
+          sortBy: 'alias',
+        },
+        alphabetize: { order: 'asc' },
+      }],
+      errors: [{
+        message: '`z as a` export should occur before export of `b`',
+      }, {
+        message: '`a as x` import should occur before import of `b as y`',
+      }],
+    }),
+    test({
+      code: `
+        module.exports = { a: C, b: B };
+      `,
+      output: `
+        module.exports = { b: B, a: C };
+      `,
+      options: [{
+        named: {
+          enabled: true,
+          sortBy: 'alias',
+        },
+        alphabetize: { order: 'asc' },
+      }],
+      errors: [{
+        message: '`b as B` export should occur before export of `a as C`',
+      }],
+    }),
+    // sortBy: 'name' is the default behavior
+    test({
+      code: `
+        import { b, a as c } from "./Z";
+      `,
+      output: `
+        import { a as c, b } from "./Z";
+      `,
+      options: [{
+        named: {
+          enabled: true,
+          sortBy: 'name',
+        },
+        alphabetize: { order: 'asc' },
+      }],
+      errors: [{
+        message: '`a` import should occur before import of `b`',
       }],
     }),
     // multi-line named specifiers & trailing commas


### PR DESCRIPTION
**Problem**

With `named: true` and `alphabetize: { order: 'asc' }`, `import { b, a as c } from 'lib';` is reported because named ordering always sorts by the original (imported/exported) name — here `a` — with no way to order by the local alias `c`. #3181 asks for an option to sort by the alias instead; ljharb: "That seems like a reasonable option to add." (labels: help wanted, semver-minor).

**Implementation**

New `named.sortBy` option following the existing `named` option-object shape (like `named.types`):

- `'name'` (default — current behavior): sort aliased specifiers by their original name (the name to the left of `as`).
- `'alias'`: sort aliased specifiers by their alias (the name to the right of `as` — the local name of an aliased import / destructured require, or the exported name of an aliased export / CJS export), falling back to the name when not aliased.

Changes in `src/rules/order.js`:

- schema: `sortBy: { type: 'string', enum: ['name', 'alias'] }` on the `named` object form;
- `create()`: `sortBy: 'name'` default merged into the normalized `named` options;
- `makeNamedOrderReport()`: in alias mode the composite sort key becomes `` `${alias || name}:${name}` `` (mirroring the existing `` `${name}:${alias}` `` scheme, so duplicate keys stay distinct), and the report `displayName` becomes `name as alias` so messages are unambiguous, e.g. ``'`b` import should occur before import of `c as z`'``.

The autofix needs no changes — it already swaps whole specifier texts, so reordering follows the new ranks.

**Docs**

`docs/rules/order.md` `named` section: updated the Valid values line and added a `named.sortBy` value list with a pass/fail example, matching the existing `named.types` doc format.

**Tests**

7 new cases in `tests/src/rules/order.js`, following the surrounding `named` test style:

- valid: the exact example from the issue (`import { b, a as c }` with `sortBy: 'alias'`); a combined aliased `export { Z as A, B }` + destructured `require` + `module.exports = { b: B, a: Z }` case; explicit `sortBy: 'name'` keeping current behavior;
- invalid (with autofix `output` and messages): aliased imports, aliased exports + destructured require in one test, `module.exports` object exports, and explicit `sortBy: 'name'` on the issue's example.

All 326 tests in the file pass; the 7 new tests fail without the implementation (verified by temporarily reverting `src/rules/order.js`). Default behavior is unchanged (the full pre-existing suite passes untouched), so this is semver-minor.

Fixes #3181.
