### PR TITLE
[Fix] no-unresolved: handle template literal requires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`no-unused-modules`]: honor the flat config's global `ignores` in the `listFilesWithNodeFs` fallback, restoring parity with the file set ESLint lints ([#3230], thanks [@ljharb])
 - [`no-deprecated`], [`namespace`]: route `declaredScope` through the `getScope` compat shim instead of the removed `context.getScope()` (ESLint 9+) ([#3230], thanks [@ljharb])
 - [`newline-after-import`]: ignore comments between consecutive imports when `considerComments` is enabled ([#2673], thanks [@raisulchowdhury])
+- [`no-unresolved`], [`no-useless-path-segments`]: handle template literal requires ([#3276], thanks [@pratyushsinghal7])
 
 ### Changed
 - [Refactor] [`order`]: extract the ESLint 10 token/comment compatibility shims into a reusable `getTokenOrComment` util ([#3230], thanks [@captaindonald])
@@ -1211,6 +1212,7 @@ for info on changes for earlier releases.
 
 [#3284]: https://github.com/import-js/eslint-plugin-import/pull/3284
 [#3283]: https://github.com/import-js/eslint-plugin-import/pull/3283
+[#3276]: https://github.com/import-js/eslint-plugin-import/pull/3276
 [#3262]: https://github.com/import-js/eslint-plugin-import/pull/3262
 [#3250]: https://github.com/import-js/eslint-plugin-import/pull/3250
 [#3230]: https://github.com/import-js/eslint-plugin-import/pull/3230
@@ -2072,6 +2074,7 @@ for info on changes for earlier releases.
 [@Pessimistress]: https://github.com/Pessimistress
 [@phryneas]: https://github.com/phryneas
 [@pmcelhaney]: https://github.com/pmcelhaney
+[@pratyushsinghal7]: https://github.com/pratyushsinghal7
 [@preco21]: https://github.com/preco21
 [@pri1311]: https://github.com/pri1311
 [@ProdigySim]: https://github.com/ProdigySim

--- a/tests/src/rules/no-unresolved.js
+++ b/tests/src/rules/no-unresolved.js
@@ -69,6 +69,23 @@ function runResolverTests(resolver) {
         options: [{ commonjs: true }],
       }),
       rest({
+        code: 'require(`./bar`)',
+        options: [{ commonjs: true }],
+        parserOptions: { ecmaVersion: 6 },
+      }),
+      // the cooked (not raw) template value is what must be resolved
+      rest({
+        code: 'require(`./\\u0062ar`)',
+        options: [{ commonjs: true }],
+        parserOptions: { ecmaVersion: 6 },
+      }),
+      // templates with expressions must remain ignored, even when the leading quasi does not resolve
+      rest({
+        code: 'const x = "bar"; require(`./does-not-exist-${x}`)',
+        options: [{ commonjs: true }],
+        parserOptions: { ecmaVersion: 6 },
+      }),
+      rest({
         code: 'require("./does-not-exist")',
         options: [{ commonjs: false }],
       }),
@@ -227,6 +244,17 @@ function runResolverTests(resolver) {
           {
             message: "Unable to resolve path to module './baz'.",
             type: 'Literal',
+          },
+        ],
+      }),
+      rest({
+        code: 'require(`./baz`)',
+        options: [{ commonjs: true }],
+        parserOptions: { ecmaVersion: 6 },
+        errors: [
+          {
+            message: "Unable to resolve path to module './baz'.",
+            type: 'TemplateLiteral',
           },
         ],
       }),

--- a/tests/src/rules/no-useless-path-segments.js
+++ b/tests/src/rules/no-useless-path-segments.js
@@ -44,6 +44,14 @@ function runResolverTests(resolver) {
         options: [{ commonjs: true }],
         errors: ['Useless path segments for "./../files/malformed.js", should be "../files/malformed.js"'],
       }),
+      // template literal requires are visited too, and the fix normalizes the quoting
+      test({
+        code: 'require(`./../files/malformed.js`)',
+        output: 'require("../files/malformed.js")',
+        options: [{ commonjs: true }],
+        parserOptions: { ecmaVersion: 6 },
+        errors: ['Useless path segments for "./../files/malformed.js", should be "../files/malformed.js"'],
+      }),
       test({
         code: 'require("./../files/malformed")',
         output: 'require("../files/malformed")',

--- a/utils/CHANGELOG.md
+++ b/utils/CHANGELOG.md
@@ -5,6 +5,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Fixed
+ - `moduleVisitor`: visit `require` calls whose argument is a no-substitution template literal ([#3276], thanks [@pratyushsinghal7])
+
 ## v2.14.0 - 2026-07-02
 
 ### Added
@@ -199,6 +202,7 @@ Yanked due to critical issue with cache key resulting from #839.
 ### Fixed
 - `unambiguous.test()` regex is now properly in multiline mode
 
+[#3276]: https://github.com/import-js/eslint-plugin-import/pull/3276
 [#3240]: https://github.com/import-js/eslint-plugin-import/pull/3240
 [#3124]: https://github.com/import-js/eslint-plugin-import/pull/3124
 [#3072]: https://github.com/import-js/eslint-plugin-import/pull/3072
@@ -259,6 +263,7 @@ Yanked due to critical issue with cache key resulting from #839.
 [@Mysak0CZ]: https://github.com/Mysak0CZ
 [@nicolo-ribaudo]: https://github.com/nicolo-ribaudo
 [@pmcelhaney]: https://github.com/pmcelhaney
+[@pratyushsinghal7]: https://github.com/pratyushsinghal7
 [@sergei-startsev]: https://github.com/sergei-startsev
 [@silverwind]: https://github.com/silverwind
 [@sompylasar]: https://github.com/sompylasar

--- a/utils/moduleVisitor.js
+++ b/utils/moduleVisitor.js
@@ -21,7 +21,7 @@ exports.default = function visitModules(visitor, options) {
 
   const ignoreRegExps = ignore == null ? [] : ignore.map((p) => new RegExp(p));
 
-  /** @type {(source: undefined | null | import('estree').Literal, importer: Parameters<typeof visitor>[1], moduleSystem?: 'import' | 'require') => void} */
+  /** @type {(source: undefined | null | import('estree').Literal | (import('estree').TemplateLiteral & { value: string }), importer: Parameters<typeof visitor>[1], moduleSystem?: 'import' | 'require') => void} */
   function checkSourceValue(source, importer, moduleSystem) {
     if (source == null) { return; } //?
 
@@ -71,10 +71,17 @@ exports.default = function visitModules(visitor, options) {
     if (call.arguments.length !== 1) { return; }
 
     const modulePath = call.arguments[0];
-    if (modulePath.type !== 'Literal') { return; }
-    if (typeof modulePath.value !== 'string') { return; }
+    if (modulePath.type === 'Literal') {
+      if (typeof modulePath.value !== 'string') { return; }
+      checkSourceValue(modulePath, call, 'require');
+      return;
+    }
+    if (modulePath.type !== 'TemplateLiteral') { return; }
+    if (modulePath.expressions.length !== 0 || modulePath.quasis.length !== 1) { return; }
 
-    checkSourceValue(modulePath, call, 'require');
+    const value = modulePath.quasis[0].value.cooked;
+    if (typeof value !== 'string') { return; }
+    checkSourceValue(Object.assign({}, modulePath, { value }), call, 'require');
   }
 
   /** @type {(call: Call) => void} */


### PR DESCRIPTION
## What changed

Treat no-substitution template literals passed to CommonJS `require()` as static module paths in `moduleVisitor`.

The template's cooked string value is exposed on a shallow source-node copy, so existing resolution logic and visitor-based rules can consume it without mutating the parser AST. Template literals containing expressions remain dynamic and are ignored.

Regression coverage verifies that:

- ``require(`./bar`)`` resolves successfully.
- ``require(`./baz`)`` reports `import/no-unresolved`.
- Both the node and webpack resolver test configurations exercise the cases.

Fixes #1575.

## Validation

- `BABEL_ENV=test ./node_modules/.bin/mocha --require babel-register tests/src/rules/no-unresolved.js --reporter dot` — 157 passing
- `npm test` — full tests, ESLint, generated documentation checks, and Markdown lint passed