### PR TITLE
[New] consistent-type-specifier-style: support TypeScript named exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`consistent-type-specifier-style`]: add `prefer-top-level-if-only-type-imports` option ([#3210], thanks [@aldeed])
 - [`no-deprecated`]: detect `@deprecated` on decorated TypeScript exports ([#3094], thanks [@raisulchowdhury])
 - export a top-level `meta` object, matching the declared types, and strengthen the type tests ([#3169], thanks [@ljharb])
+- [`consistent-type-specifier-style`]: support named TypeScript type exports ([#3044], thanks [@musjj] and [@ColumbusLabs])
 
 ### Fixed
 - [`no-duplicates`]: fix `prefer-inline` autofix producing invalid syntax when an identifier named `from` is imported ([#3236], thanks [@DukeDeSouth] [@Quantaly])
@@ -1260,6 +1261,7 @@ for info on changes for earlier releases.
 [#3062]: https://github.com/import-js/eslint-plugin-import/pull/3062
 [#3052]: https://github.com/import-js/eslint-plugin-import/pull/3052
 [#3043]: https://github.com/import-js/eslint-plugin-import/pull/3043
+[#3044]: https://github.com/import-js/eslint-plugin-import/issues/3044
 [#3036]: https://github.com/import-js/eslint-plugin-import/pull/3036
 [#3033]: https://github.com/import-js/eslint-plugin-import/pull/3033
 [#3032]: https://github.com/import-js/eslint-plugin-import/pull/3032
@@ -1905,6 +1907,7 @@ for info on changes for earlier releases.
 [@chrislloyd]: https://github.com/chrislloyd
 [@christianvuerings]: https://github.com/christianvuerings
 [@christophercurrie]: https://github.com/christophercurrie
+[@ColumbusLabs]: https://github.com/ColumbusLabs
 [@cristobal]: https://github.com/cristobal
 [@DamienCassou]: https://github.com/DamienCassou
 [@danielkcz]: https://github.com/danielkcz
@@ -2060,6 +2063,7 @@ for info on changes for earlier releases.
 [@mrmckeb]: https://github.com/mrmckeb
 [@msvab]: https://github.com/msvab
 [@mulztob]: https://github.com/mulztob
+[@musjj]: https://github.com/musjj
 [@mx-bernhard]: https://github.com/mx-bernhard
 [@Nfinished]: https://github.com/Nfinished
 [@nickofthyme]: https://github.com/nickofthyme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - support eslint v10 ([#3230], thanks [@rasmi])
 - [`no-deprecated`]: detect `@deprecated` on default-exported identifier declarations ([#3247], thanks [@mixelburg] [@etyrrell22])
 - [`consistent-type-specifier-style`]: add `prefer-top-level-if-only-type-imports` option ([#3210], thanks [@aldeed])
+- [`consistent-type-specifier-style`]: support named TypeScript type exports ([#3044], thanks [@musjj] and [@ColumbusLabs])
 
 ### Fixed
 - [`no-duplicates`]: fix `prefer-inline` autofix producing invalid syntax when an identifier named `from` is imported ([#3236], thanks [@DukeDeSouth] [@Quantaly])
@@ -1246,6 +1247,7 @@ for info on changes for earlier releases.
 [#3062]: https://github.com/import-js/eslint-plugin-import/pull/3062
 [#3052]: https://github.com/import-js/eslint-plugin-import/pull/3052
 [#3043]: https://github.com/import-js/eslint-plugin-import/pull/3043
+[#3044]: https://github.com/import-js/eslint-plugin-import/issues/3044
 [#3036]: https://github.com/import-js/eslint-plugin-import/pull/3036
 [#3033]: https://github.com/import-js/eslint-plugin-import/pull/3033
 [#3032]: https://github.com/import-js/eslint-plugin-import/pull/3032
@@ -1890,6 +1892,7 @@ for info on changes for earlier releases.
 [@chrislloyd]: https://github.com/chrislloyd
 [@christianvuerings]: https://github.com/christianvuerings
 [@christophercurrie]: https://github.com/christophercurrie
+[@ColumbusLabs]: https://github.com/ColumbusLabs
 [@cristobal]: https://github.com/cristobal
 [@DamienCassou]: https://github.com/DamienCassou
 [@danielkcz]: https://github.com/danielkcz
@@ -2044,6 +2047,7 @@ for info on changes for earlier releases.
 [@mrmckeb]: https://github.com/mrmckeb
 [@msvab]: https://github.com/msvab
 [@mulztob]: https://github.com/mulztob
+[@musjj]: https://github.com/musjj
 [@mx-bernhard]: https://github.com/mx-bernhard
 [@Nfinished]: https://github.com/Nfinished
 [@nickofthyme]: https://github.com/nickofthyme

--- a/README.md
+++ b/README.md
@@ -71,26 +71,26 @@ This plugin intends to support linting of ES2015+ (ES6+) import/export syntax, a
 
 ### Style guide
 
-| Name                                                                             | Description                                                                | 💼 | ⚠️    | 🚫 | 🔧 | 💡 | ❌  |
-| :------------------------------------------------------------------------------- | :------------------------------------------------------------------------- | :- | :---- | :- | :- | :- | :- |
-| [consistent-type-specifier-style](docs/rules/consistent-type-specifier-style.md) | Enforce or ban the use of inline type-only markers for named imports.      |    |       |    | 🔧 |    |    |
-| [dynamic-import-chunkname](docs/rules/dynamic-import-chunkname.md)               | Enforce a leading comment with the webpackChunkName for dynamic imports.   |    |       |    |    | 💡 |    |
-| [exports-last](docs/rules/exports-last.md)                                       | Ensure all exports appear after other statements.                          |    |       |    |    |    |    |
-| [extensions](docs/rules/extensions.md)                                           | Ensure consistent use of file extension within the import path.            |    |       |    |    |    |    |
-| [first](docs/rules/first.md)                                                     | Ensure all imports appear before other statements.                         |    |       |    | 🔧 |    |    |
-| [group-exports](docs/rules/group-exports.md)                                     | Prefer named exports to be grouped together in a single export declaration |    |       |    |    |    |    |
-| [imports-first](docs/rules/imports-first.md)                                     | Replaced by `import/first`.                                                |    |       |    | 🔧 |    | ❌  |
-| [max-dependencies](docs/rules/max-dependencies.md)                               | Enforce the maximum number of dependencies a module can have.              |    |       |    |    |    |    |
-| [newline-after-import](docs/rules/newline-after-import.md)                       | Enforce a newline after import statements.                                 |    |       |    | 🔧 |    |    |
-| [no-anonymous-default-export](docs/rules/no-anonymous-default-export.md)         | Forbid anonymous values as default exports.                                |    |       |    |    |    |    |
-| [no-default-export](docs/rules/no-default-export.md)                             | Forbid default exports.                                                    |    |       |    |    |    |    |
-| [no-duplicates](docs/rules/no-duplicates.md)                                     | Forbid repeated import of the same module in multiple places.              |    | ☑️ 🚸 |    | 🔧 |    |    |
-| [no-named-default](docs/rules/no-named-default.md)                               | Forbid named default exports.                                              |    |       |    |    |    |    |
-| [no-named-export](docs/rules/no-named-export.md)                                 | Forbid named exports.                                                      |    |       |    |    |    |    |
-| [no-namespace](docs/rules/no-namespace.md)                                       | Forbid namespace (a.k.a. "wildcard" `*`) imports.                          |    |       |    | 🔧 |    |    |
-| [no-unassigned-import](docs/rules/no-unassigned-import.md)                       | Forbid unassigned imports                                                  |    |       |    |    |    |    |
-| [order](docs/rules/order.md)                                                     | Enforce a convention in module import order.                               |    |       |    | 🔧 |    |    |
-| [prefer-default-export](docs/rules/prefer-default-export.md)                     | Prefer a default export if module exports a single name or multiple names. |    |       |    |    |    |    |
+| Name                                                                             | Description                                                                       | 💼 | ⚠️    | 🚫 | 🔧 | 💡 | ❌  |
+| :------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------- | :- | :---- | :- | :- | :- | :- |
+| [consistent-type-specifier-style](docs/rules/consistent-type-specifier-style.md) | Enforce or ban the use of inline type-only markers for named imports and exports. |    |       |    | 🔧 |    |    |
+| [dynamic-import-chunkname](docs/rules/dynamic-import-chunkname.md)               | Enforce a leading comment with the webpackChunkName for dynamic imports.          |    |       |    |    | 💡 |    |
+| [exports-last](docs/rules/exports-last.md)                                       | Ensure all exports appear after other statements.                                 |    |       |    |    |    |    |
+| [extensions](docs/rules/extensions.md)                                           | Ensure consistent use of file extension within the import path.                   |    |       |    |    |    |    |
+| [first](docs/rules/first.md)                                                     | Ensure all imports appear before other statements.                                |    |       |    | 🔧 |    |    |
+| [group-exports](docs/rules/group-exports.md)                                     | Prefer named exports to be grouped together in a single export declaration        |    |       |    |    |    |    |
+| [imports-first](docs/rules/imports-first.md)                                     | Replaced by `import/first`.                                                       |    |       |    | 🔧 |    | ❌  |
+| [max-dependencies](docs/rules/max-dependencies.md)                               | Enforce the maximum number of dependencies a module can have.                     |    |       |    |    |    |    |
+| [newline-after-import](docs/rules/newline-after-import.md)                       | Enforce a newline after import statements.                                        |    |       |    | 🔧 |    |    |
+| [no-anonymous-default-export](docs/rules/no-anonymous-default-export.md)         | Forbid anonymous values as default exports.                                       |    |       |    |    |    |    |
+| [no-default-export](docs/rules/no-default-export.md)                             | Forbid default exports.                                                           |    |       |    |    |    |    |
+| [no-duplicates](docs/rules/no-duplicates.md)                                     | Forbid repeated import of the same module in multiple places.                     |    | ☑️ 🚸 |    | 🔧 |    |    |
+| [no-named-default](docs/rules/no-named-default.md)                               | Forbid named default exports.                                                     |    |       |    |    |    |    |
+| [no-named-export](docs/rules/no-named-export.md)                                 | Forbid named exports.                                                             |    |       |    |    |    |    |
+| [no-namespace](docs/rules/no-namespace.md)                                       | Forbid namespace (a.k.a. "wildcard" `*`) imports.                                 |    |       |    | 🔧 |    |    |
+| [no-unassigned-import](docs/rules/no-unassigned-import.md)                       | Forbid unassigned imports                                                         |    |       |    |    |    |    |
+| [order](docs/rules/order.md)                                                     | Enforce a convention in module import order.                                      |    |       |    | 🔧 |    |    |
+| [prefer-default-export](docs/rules/prefer-default-export.md)                     | Prefer a default export if module exports a single name or multiple names.        |    |       |    |    |    |    |
 
 <!-- end auto-generated rules list -->
 

--- a/docs/rules/consistent-type-specifier-style.md
+++ b/docs/rules/consistent-type-specifier-style.md
@@ -4,32 +4,35 @@
 
 <!-- end auto-generated rule header -->
 
-In both Flow and TypeScript you can mark an import as a type-only import by adding a "kind" marker to the import. Both languages support two positions for marker.
+In both Flow and TypeScript you can mark an import as a type-only import by adding a "kind" marker to the import. TypeScript supports the same markers on named exports. Both languages support two positions for import markers, while inline export markers are TypeScript-only.
 
-**At the top-level** which marks all names in the import as type-only and applies to named, default, and namespace (for TypeScript) specifiers:
+**At the top-level** which marks all names in the import or export as type-only and applies to named, default, and namespace (for TypeScript) import specifiers:
 
 ```ts
 import type Foo from 'Foo';
 import type {Bar} from 'Bar';
+export type {Bar};
 // ts only
 import type * as Bam from 'Bam';
 // flow only
 import typeof Baz from 'Baz';
 ```
 
-**Inline** with to the named import, which marks just the specific name in the import as type-only. An inline specifier is only valid for named specifiers, and not for default or namespace specifiers:
+**Inline** with the named import or export, which marks just the specific name as type-only. An inline specifier is only valid for named specifiers, and not for default or namespace import specifiers:
 
 ```ts
 import {type Foo} from 'Foo';
+// ts only
+export {type Foo};
 // flow only
 import {typeof Bar} from 'Bar';
 ```
 
 ## Rule Details
 
-This rule either enforces or bans the use of inline type-only markers for named imports.
+This rule either enforces or bans the use of inline type-only markers for named imports and TypeScript exports. Flow type exports are ignored because Flow does not support inline type export specifiers.
 
-This rule includes a fixer that will automatically convert your specifiers to the correct form - however the fixer will not respect your preferences around de-duplicating imports. If this is important to you, consider using the [`import/no-duplicates`] rule.
+This rule includes a fixer that will automatically convert your specifiers to the correct form - however the fixer will not respect your preferences around de-duplicating imports or exports. Export fixes are omitted for import attributes or assertions, and when splitting a mixed export would make ownership of a leading comment ambiguous. If de-duplicating imports is important to you, consider using the [`import/no-duplicates`] rule.
 
 [`import/no-duplicates`]: ./no-duplicates.md
 
@@ -37,9 +40,9 @@ This rule includes a fixer that will automatically convert your specifiers to th
 
 The rule accepts a single string option which may be one of:
 
- - `'prefer-inline'` - enforces that named type-only specifiers are only ever written with an inline marker; and never as part of a top-level, type-only import.
- - `'prefer-top-level'` - enforces that named type-only specifiers are only ever written as part of a top-level, type-only import; and never with an inline marker.
- - `'prefer-top-level-if-only-type-imports'` - enforces that named type-only specifiers must use a top-level, type-only import when all named imports are types; if some are values, then inline markers are allowed. This is useful when you generally prefer inline but you are using TypeScript `verbatimModuleSyntax` and want all-type imports omitted by bundlers.
+ - `'prefer-inline'` - enforces that named type-only specifiers are only ever written with an inline marker; and never as part of a top-level, type-only import or export.
+ - `'prefer-top-level'` - enforces that named type-only specifiers are only ever written as part of a top-level, type-only import or export; and never with an inline marker.
+ - `'prefer-top-level-if-only-type-imports'` - enforces that named type-only specifiers must use a top-level, type-only import or export when all named specifiers are types; if some are values, then inline markers are allowed. This is useful when you generally prefer inline but you are using TypeScript `verbatimModuleSyntax` and want all-type imports omitted by bundlers.
 
 By default the rule will use the `prefer-inline` option.
 
@@ -52,6 +55,7 @@ By default the rule will use the `prefer-inline` option.
 ```ts
 import {type Foo} from 'Foo';
 import Foo, {type Bar} from 'Foo';
+export {type Foo};
 // flow only
 import {typeof Foo} from 'Foo';
 ```
@@ -61,6 +65,7 @@ import {typeof Foo} from 'Foo';
 ```ts
 import type {Foo} from 'Foo';
 import type Foo, {Bar} from 'Foo';
+export type {Foo};
 // flow only
 import typeof {Foo} from 'Foo';
 ```
@@ -72,6 +77,7 @@ import typeof {Foo} from 'Foo';
 ```ts
 import {type Foo} from 'Foo';
 import {type Foo,type Bar} from 'Foo';
+export {type Foo,type Bar};
 // flow only
 import {typeof Foo} from 'Foo';
 ```
@@ -82,6 +88,8 @@ import {typeof Foo} from 'Foo';
 import type {Foo} from 'Foo';
 import { type Foo, someValue } from 'Foo';
 import type Foo, {Bar} from 'Foo';
+export type {Foo};
+export { type Foo, someValue };
 // flow only
 import typeof {Foo} from 'Foo';
 ```
@@ -93,6 +101,7 @@ import typeof {Foo} from 'Foo';
 ```ts
 import type {Foo} from 'Foo';
 import type Foo, {Bar} from 'Foo';
+export type {Foo};
 // flow only
 import typeof {Foo} from 'Foo';
 ```
@@ -102,6 +111,7 @@ import typeof {Foo} from 'Foo';
 ```ts
 import {type Foo} from 'Foo';
 import Foo, {type Bar} from 'Foo';
+export {type Foo};
 // flow only
 import {typeof Foo} from 'Foo';
 ```
@@ -110,4 +120,4 @@ import {typeof Foo} from 'Foo';
 
 If you aren't using Flow or TypeScript 4.5+, then this rule does not apply and need not be used.
 
-If you don't care about, and don't want to standardize how named specifiers are imported then you should not use this rule.
+If you don't care about, and don't want to standardize how named specifiers are imported or exported then you should not use this rule.

--- a/src/rules/consistent-type-specifier-style.js
+++ b/src/rules/consistent-type-specifier-style.js
@@ -10,7 +10,7 @@ function isComma(token) {
  * @param {import('eslint').Rule.Fix[]} fixes
  * @param {import('eslint').Rule.RuleFixer} fixer
  * @param {import('eslint').SourceCode.SourceCode} sourceCode
- * @param {(ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier)[]} specifiers
+ * @param {(ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ExportSpecifier)[]} specifiers
  * */
 function removeSpecifiers(fixes, fixer, sourceCode, specifiers) {
   for (const specifier of specifiers) {
@@ -21,6 +21,34 @@ function removeSpecifiers(fixes, fixer, sourceCode, specifiers) {
     }
     fixes.push(fixer.remove(specifier));
   }
+}
+
+/**
+ * @param {import('eslint').Rule.RuleFixer} fixer
+ * @param {import('eslint').SourceCode.SourceCode} sourceCode
+ * @param {import('eslint').AST.Token} kindToken
+ */
+function removeKindToken(fixer, sourceCode, kindToken) {
+  const trailingCharacter = sourceCode.text[kindToken.range[1]];
+  const end = trailingCharacter && (/\s/).test(trailingCharacter)
+    ? kindToken.range[1] + 1
+    : kindToken.range[1];
+  return fixer.removeRange([kindToken.range[0], end]);
+}
+
+/**
+ * Leading comments may describe the type specifier being extracted. Splitting
+ * the export cannot safely determine whether to move or retain those comments.
+ * @param {import('eslint').SourceCode.SourceCode} sourceCode
+ * @param {ExportSpecifier[]} specifiers
+ */
+function hasLeadingComments(sourceCode, specifiers) {
+  // `getCommentsBefore` was added in ESLint 4. Avoid an unsafe fix when the
+  // installed ESLint cannot provide the comment ownership information.
+  if (typeof sourceCode.getCommentsBefore !== 'function') {
+    return true;
+  }
+  return specifiers.some((specifier) => sourceCode.getCommentsBefore(specifier).length > 0);
 }
 
 /** @type {(node: import('estree').Node, sourceCode: import('eslint').SourceCode.SourceCode, specifiers: (ImportSpecifier | ImportNamespaceSpecifier)[], kind: 'type' | 'typeof') => string} */
@@ -45,13 +73,47 @@ function getImportText(
   return `import ${kind} {${names.join(', ')}} from ${sourceString};`;
 }
 
+/** @type {(node: import('estree').ExportNamedDeclaration, sourceCode: import('eslint').SourceCode.SourceCode, specifiers: ExportSpecifier[]) => string} */
+function getExportText(
+  node,
+  sourceCode,
+  specifiers,
+) {
+  const names = specifiers.map((specifier) => {
+    const kindToken = sourceCode.getFirstToken(specifier);
+    return sourceCode.text.slice(kindToken.range[1], specifier.range[1]).replace(/^\s+/, '');
+  });
+  const closingBrace = sourceCode.getTokenAfter(
+    node.specifiers[node.specifiers.length - 1],
+    (token) => token.type === 'Punctuator' && token.value === '}',
+  );
+  const suffix = sourceCode.text.slice(closingBrace.range[1], node.range[1]);
+  return `export type {${names.join(', ')}}${suffix}`;
+}
+
+/**
+ * Flow supports top-level type exports but not inline type export specifiers.
+ * TypeScript-ESTree identifies its export specifiers with an `exportKind`.
+ * @param {import('estree').ExportNamedDeclaration} node
+ */
+function isTypeScriptExport(node) {
+  return node.specifiers.length > 0
+    && node.specifiers.every((specifier) => specifier.exportKind === 'type' || specifier.exportKind === 'value');
+}
+
+/** @param {import('estree').ExportNamedDeclaration} node */
+function hasExportAttributes(node) {
+  return node.assertions && node.assertions.length > 0
+    || node.attributes && node.attributes.length > 0;
+}
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
       category: 'Style guide',
-      description: 'Enforce or ban the use of inline type-only markers for named imports.',
+      description: 'Enforce or ban the use of inline type-only markers for named imports and exports.',
       url: docsUrl('consistent-type-specifier-style'),
     },
     fixable: 'code',
@@ -106,6 +168,28 @@ module.exports = {
               return [].concat(
                 kindToken ? fixer.remove(kindToken) : [],
                 node.specifiers.map((specifier) => fixer.insertTextBefore(specifier, `${node.importKind} `)),
+              );
+            },
+          });
+        },
+        ExportNamedDeclaration(node) {
+          if (!isTypeScriptExport(node) || node.exportKind !== 'type') {
+            return;
+          }
+
+          context.report({
+            node,
+            message: 'Prefer using inline type specifiers instead of a top-level type-only export.',
+            fix(fixer) {
+              if (hasExportAttributes(node)) {
+                return null;
+              }
+
+              const kindToken = sourceCode.getFirstToken(node, { skip: 1 });
+
+              return [].concat(
+                kindToken ? removeKindToken(fixer, sourceCode, kindToken) : [],
+                node.specifiers.map((specifier) => fixer.insertTextBefore(specifier, 'type ')),
               );
             },
           });
@@ -233,6 +317,84 @@ module.exports = {
                 return fixes.concat(
                   // insert the new imports after the old declaration
                   fixer.insertTextAfter(node, `\n${newImports}`),
+                );
+              },
+            });
+          });
+        }
+      },
+      /** @param {import('estree').ExportNamedDeclaration} node */
+      ExportNamedDeclaration(node) {
+        if (
+          !isTypeScriptExport(node)
+          // already top-level is valid
+          || node.exportKind === 'type'
+        ) {
+          return;
+        }
+
+        /** @type {ExportSpecifier[]} */
+        const typeSpecifiers = [];
+        /** @type {ExportSpecifier[]} */
+        const valueSpecifiers = [];
+        for (const specifier of node.specifiers) {
+          if (specifier.exportKind === 'type') {
+            typeSpecifiers.push(specifier);
+          } else {
+            valueSpecifiers.push(specifier);
+          }
+        }
+
+        if (typeSpecifiers.length === 0) {
+          return;
+        }
+
+        const typeExport = getExportText(node, sourceCode, typeSpecifiers);
+
+        if (typeSpecifiers.length === node.specifiers.length) {
+          const messageSuffix = preference === 'prefer-top-level-if-only-type-imports' ? ' when there are only type exports' : '';
+          context.report({
+            node,
+            message: `Prefer using a top-level type-only export instead of inline type specifiers${messageSuffix}.`,
+            fix(fixer) {
+              if (hasExportAttributes(node)) {
+                return null;
+              }
+
+              const exportToken = sourceCode.getFirstToken(node);
+              return [].concat(
+                fixer.insertTextAfter(exportToken, ' type'),
+                typeSpecifiers.map((specifier) => {
+                  const kindToken = sourceCode.getFirstToken(specifier);
+                  return removeKindToken(fixer, sourceCode, kindToken);
+                }),
+              );
+            },
+          });
+        } else if (preference !== 'prefer-top-level-if-only-type-imports') {
+          typeSpecifiers.forEach((specifier) => {
+            context.report({
+              node: specifier,
+              message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+              fix(fixer) {
+                if (hasExportAttributes(node) || hasLeadingComments(sourceCode, typeSpecifiers)) {
+                  return null;
+                }
+
+                /** @type {import('eslint').Rule.Fix[]} */
+                const fixes = [];
+
+                removeSpecifiers(fixes, fixer, sourceCode, typeSpecifiers);
+
+                // Remove the trailing comma after the last value export so the
+                // original declaration does not retain an empty final slot.
+                const maybeComma = sourceCode.getTokenAfter(valueSpecifiers[valueSpecifiers.length - 1]);
+                if (isComma(maybeComma)) {
+                  fixes.push(fixer.remove(maybeComma));
+                }
+
+                return fixes.concat(
+                  fixer.insertTextAfter(node, `\n${typeExport}`),
                 );
               },
             });

--- a/src/rules/consistent-type-specifier-style.js
+++ b/src/rules/consistent-type-specifier-style.js
@@ -10,7 +10,7 @@ function isComma(token) {
  * @param {import('eslint').Rule.Fix[]} fixes
  * @param {import('eslint').Rule.RuleFixer} fixer
  * @param {import('eslint').SourceCode.SourceCode} sourceCode
- * @param {(ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier)[]} specifiers
+ * @param {(ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ExportSpecifier)[]} specifiers
  * */
 function removeSpecifiers(fixes, fixer, sourceCode, specifiers) {
   for (const specifier of specifiers) {
@@ -21,6 +21,38 @@ function removeSpecifiers(fixes, fixer, sourceCode, specifiers) {
     }
     fixes.push(fixer.remove(specifier));
   }
+}
+
+/**
+ * @param {import('eslint').Rule.RuleFixer} fixer
+ * @param {import('eslint').SourceCode.SourceCode} sourceCode
+ * @param {import('eslint').AST.Token} kindToken
+ */
+function removeKindToken(fixer, sourceCode, kindToken) {
+  const trailingCharacter = sourceCode.text[kindToken.range[1]];
+  const end = trailingCharacter && (/\s/).test(trailingCharacter)
+    ? kindToken.range[1] + 1
+    : kindToken.range[1];
+  return fixer.removeRange([kindToken.range[0], end]);
+}
+
+/**
+ * Comments may describe the type specifier being extracted. Splitting the
+ * export cannot safely determine whether to move or retain those comments.
+ * @param {import('eslint').SourceCode.SourceCode} sourceCode
+ * @param {ExportSpecifier[]} specifiers
+ */
+function hasSpecifierComments(sourceCode, specifiers) {
+  // `getCommentsBefore` was added in ESLint 4. Avoid an unsafe fix when the
+  // installed ESLint cannot provide the comment ownership information.
+  if (
+    typeof sourceCode.getCommentsBefore !== 'function'
+    || typeof sourceCode.getCommentsAfter !== 'function'
+  ) {
+    return true;
+  }
+  return specifiers.some((specifier) => sourceCode.getCommentsBefore(specifier).length > 0
+    || sourceCode.getCommentsAfter(specifier).length > 0);
 }
 
 /** @type {(node: import('estree').Node, sourceCode: import('eslint').SourceCode.SourceCode, specifiers: (ImportSpecifier | ImportNamespaceSpecifier)[], kind: 'type' | 'typeof') => string} */
@@ -45,13 +77,47 @@ function getImportText(
   return `import ${kind} {${names.join(', ')}} from ${sourceString};`;
 }
 
+/** @type {(node: import('estree').ExportNamedDeclaration, sourceCode: import('eslint').SourceCode.SourceCode, specifiers: ExportSpecifier[]) => string} */
+function getExportText(
+  node,
+  sourceCode,
+  specifiers,
+) {
+  const names = specifiers.map((specifier) => {
+    const kindToken = sourceCode.getFirstToken(specifier);
+    return sourceCode.text.slice(kindToken.range[1], specifier.range[1]).replace(/^\s+/, '');
+  });
+  const closingBrace = sourceCode.getTokenAfter(
+    node.specifiers[node.specifiers.length - 1],
+    (token) => token.type === 'Punctuator' && token.value === '}',
+  );
+  const suffix = sourceCode.text.slice(closingBrace.range[1], node.range[1]);
+  return `export type {${names.join(', ')}}${suffix}`;
+}
+
+/**
+ * Flow supports top-level type exports but not inline type export specifiers.
+ * TypeScript-ESTree identifies its export specifiers with an `exportKind`.
+ * @param {import('estree').ExportNamedDeclaration} node
+ */
+function isTypeScriptExport(node) {
+  return node.specifiers.length > 0
+    && node.specifiers.every((specifier) => specifier.exportKind === 'type' || specifier.exportKind === 'value');
+}
+
+/** @param {import('estree').ExportNamedDeclaration} node */
+function hasExportAttributes(node) {
+  return node.assertions && node.assertions.length > 0
+    || node.attributes && node.attributes.length > 0;
+}
+
 /** @type {import('eslint').Rule.RuleModule} */
 module.exports = {
   meta: {
     type: 'suggestion',
     docs: {
       category: 'Style guide',
-      description: 'Enforce or ban the use of inline type-only markers for named imports.',
+      description: 'Enforce or ban the use of inline type-only markers for named imports and exports.',
       url: docsUrl('consistent-type-specifier-style'),
     },
     fixable: 'code',
@@ -70,7 +136,7 @@ module.exports = {
 
   create(context) {
     const sourceCode = getSourceCode(context);
-    const preference = context.options[0];
+    const preference = context.options[0] || 'prefer-inline';
 
     if (preference === 'prefer-inline') {
       return {
@@ -106,6 +172,28 @@ module.exports = {
               return [].concat(
                 kindToken ? fixer.remove(kindToken) : [],
                 node.specifiers.map((specifier) => fixer.insertTextBefore(specifier, `${node.importKind} `)),
+              );
+            },
+          });
+        },
+        ExportNamedDeclaration(node) {
+          if (!isTypeScriptExport(node) || node.exportKind !== 'type') {
+            return;
+          }
+
+          context.report({
+            node,
+            message: 'Prefer using inline type specifiers instead of a top-level type-only export.',
+            fix(fixer) {
+              if (hasExportAttributes(node)) {
+                return null;
+              }
+
+              const kindToken = sourceCode.getFirstToken(node, { skip: 1 });
+
+              return [].concat(
+                kindToken ? removeKindToken(fixer, sourceCode, kindToken) : [],
+                node.specifiers.map((specifier) => fixer.insertTextBefore(specifier, 'type ')),
               );
             },
           });
@@ -233,6 +321,84 @@ module.exports = {
                 return fixes.concat(
                   // insert the new imports after the old declaration
                   fixer.insertTextAfter(node, `\n${newImports}`),
+                );
+              },
+            });
+          });
+        }
+      },
+      /** @param {import('estree').ExportNamedDeclaration} node */
+      ExportNamedDeclaration(node) {
+        if (
+          !isTypeScriptExport(node)
+          // already top-level is valid
+          || node.exportKind === 'type'
+        ) {
+          return;
+        }
+
+        /** @type {ExportSpecifier[]} */
+        const typeSpecifiers = [];
+        /** @type {ExportSpecifier[]} */
+        const valueSpecifiers = [];
+        for (const specifier of node.specifiers) {
+          if (specifier.exportKind === 'type') {
+            typeSpecifiers.push(specifier);
+          } else {
+            valueSpecifiers.push(specifier);
+          }
+        }
+
+        if (typeSpecifiers.length === 0) {
+          return;
+        }
+
+        const typeExport = getExportText(node, sourceCode, typeSpecifiers);
+
+        if (typeSpecifiers.length === node.specifiers.length) {
+          const messageSuffix = preference === 'prefer-top-level-if-only-type-imports' ? ' when there are only type exports' : '';
+          context.report({
+            node,
+            message: `Prefer using a top-level type-only export instead of inline type specifiers${messageSuffix}.`,
+            fix(fixer) {
+              if (hasExportAttributes(node)) {
+                return null;
+              }
+
+              const exportToken = sourceCode.getFirstToken(node);
+              return [].concat(
+                fixer.insertTextAfter(exportToken, ' type'),
+                typeSpecifiers.map((specifier) => {
+                  const kindToken = sourceCode.getFirstToken(specifier);
+                  return removeKindToken(fixer, sourceCode, kindToken);
+                }),
+              );
+            },
+          });
+        } else if (preference !== 'prefer-top-level-if-only-type-imports') {
+          typeSpecifiers.forEach((specifier) => {
+            context.report({
+              node: specifier,
+              message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+              fix(fixer) {
+                if (hasExportAttributes(node) || hasSpecifierComments(sourceCode, typeSpecifiers)) {
+                  return null;
+                }
+
+                /** @type {import('eslint').Rule.Fix[]} */
+                const fixes = [];
+
+                removeSpecifiers(fixes, fixer, sourceCode, typeSpecifiers);
+
+                // Remove the trailing comma after the last value export so the
+                // original declaration does not retain an empty final slot.
+                const maybeComma = sourceCode.getTokenAfter(valueSpecifiers[valueSpecifiers.length - 1]);
+                if (isComma(maybeComma)) {
+                  fixes.push(fixer.remove(maybeComma));
+                }
+
+                return fixes.concat(
+                  fixer.insertTextAfter(node, `\n${typeExport}`),
                 );
               },
             });

--- a/tests/src/rules/consistent-type-specifier-style.js
+++ b/tests/src/rules/consistent-type-specifier-style.js
@@ -321,8 +321,193 @@ const TS_ONLY = {
     // always valid
     //
     test({ code: "import type * as Foo from 'Foo';" }),
+    {
+      code: 'export { Foo };',
+      options: ['prefer-top-level'],
+    },
+    {
+      code: 'export { Foo };',
+      options: ['prefer-inline'],
+    },
+    {
+      code: 'export const Foo = 1;',
+      options: ['prefer-top-level'],
+    },
+    {
+      code: 'export type Foo = string;',
+      options: ['prefer-inline'],
+    },
+    {
+      code: 'export interface Foo {}',
+      options: ['prefer-top-level'],
+    },
+
+    //
+    // prefer-top-level
+    //
+    {
+      code: 'export type { Foo };',
+      options: ['prefer-top-level'],
+    },
+    {
+      code: "export type { Foo as Bar } from 'Foo';",
+      options: ['prefer-top-level'],
+    },
+
+    //
+    // prefer-top-level-if-only-type-imports
+    //
+    {
+      code: 'export { Foo, type Bar };',
+      options: ['prefer-top-level-if-only-type-imports'],
+    },
+    {
+      code: "export { Foo, type Bar } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    },
+
+    //
+    // prefer-inline
+    //
+    {
+      code: 'export { type Foo };',
+      options: ['prefer-inline'],
+    },
+    {
+      code: "export { type Foo as Bar } from 'Foo';",
+      options: ['prefer-inline'],
+    },
   ],
-  invalid: [],
+  invalid: [
+    //
+    // prefer-top-level
+    //
+    {
+      code: 'export { type Foo };',
+      output: 'export type { Foo };',
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+    {
+      code: "export { type Foo as Bar } from 'Foo';",
+      output: "export type { Foo as Bar } from 'Foo';",
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+    {
+      code: 'export { type Foo, type Bar };',
+      output: 'export type { Foo, Bar };',
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+    {
+      code: "export { type Foo /* keep */ } from 'Foo';",
+      output: "export type { Foo /* keep */ } from 'Foo';",
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+    {
+      code: 'export { Foo, type Bar };',
+      output: 'export { Foo  };\nexport type {Bar};',
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportSpecifier',
+      }],
+    },
+    {
+      code: "export { type Foo, Bar as Baz } from 'Foo';",
+      output: "export {  Bar as Baz } from 'Foo';\nexport type {Foo} from 'Foo';",
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportSpecifier',
+      }],
+    },
+    {
+      code: "export { Foo, type Bar /* keep */ } from 'Foo'",
+      output: "export { Foo  /* keep */ } from 'Foo'\nexport type {Bar} from 'Foo'",
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportSpecifier',
+      }],
+    },
+    {
+      code: "export { Foo, /* Bar docs */ type Bar } from 'Foo';",
+      output: null,
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportSpecifier',
+      }],
+    },
+    {
+      code: 'export {\n  Foo,\n  // Bar docs\n  type Bar,\n};',
+      output: null,
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportSpecifier',
+      }],
+    },
+
+    //
+    // prefer-top-level-if-only-type-imports
+    //
+    {
+      code: 'export { type Foo, type Bar };',
+      output: 'export type { Foo, Bar };',
+      options: ['prefer-top-level-if-only-type-imports'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers when there are only type exports.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+
+    //
+    // prefer-inline
+    //
+    {
+      code: 'export type { Foo };',
+      output: 'export { type Foo };',
+      options: ['prefer-inline'],
+      errors: [{
+        message: 'Prefer using inline type specifiers instead of a top-level type-only export.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+    {
+      code: "export type { Foo as Bar } from 'Foo';",
+      output: "export { type Foo as Bar } from 'Foo';",
+      options: ['prefer-inline'],
+      errors: [{
+        message: 'Prefer using inline type specifiers instead of a top-level type-only export.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+    {
+      code: "export type { Foo /* keep */ } from 'Foo'",
+      output: "export { type Foo /* keep */ } from 'Foo'",
+      options: ['prefer-inline'],
+      errors: [{
+        message: 'Prefer using inline type specifiers instead of a top-level type-only export.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+  ],
 };
 
 const FLOW_ONLY = {
@@ -376,6 +561,10 @@ const FLOW_ONLY = {
     },
     {
       code: "import { type Foo, type Bar, typeof Baz, typeof Bam } from 'Foo';",
+      options: ['prefer-inline'],
+    },
+    {
+      code: 'export type { Foo };',
       options: ['prefer-inline'],
     },
   ],

--- a/tests/src/rules/consistent-type-specifier-style.js
+++ b/tests/src/rules/consistent-type-specifier-style.js
@@ -167,6 +167,17 @@ const COMMON_TESTS = {
   ],
   invalid: [
     //
+    // default (prefer-inline)
+    //
+    {
+      code: "import type { Foo } from 'Foo';",
+      output: "import  { type Foo } from 'Foo';",
+      errors: [{
+        message: 'Prefer using inline type specifiers instead of a top-level type-only import.',
+        type: 'ImportDeclaration',
+      }],
+    },
+    //
     // prefer-top-level
     //
     {
@@ -321,8 +332,205 @@ const TS_ONLY = {
     // always valid
     //
     test({ code: "import type * as Foo from 'Foo';" }),
+    {
+      code: 'export { Foo };',
+      options: ['prefer-top-level'],
+    },
+    {
+      code: 'export { Foo };',
+      options: ['prefer-inline'],
+    },
+    {
+      code: 'export const Foo = 1;',
+      options: ['prefer-top-level'],
+    },
+    {
+      code: 'export type Foo = string;',
+      options: ['prefer-inline'],
+    },
+    {
+      code: 'export interface Foo {}',
+      options: ['prefer-top-level'],
+    },
+
+    //
+    // prefer-top-level
+    //
+    {
+      code: 'export type { Foo };',
+      options: ['prefer-top-level'],
+    },
+    {
+      code: "export type { Foo as Bar } from 'Foo';",
+      options: ['prefer-top-level'],
+    },
+
+    //
+    // prefer-top-level-if-only-type-imports
+    //
+    {
+      code: 'export { Foo, type Bar };',
+      options: ['prefer-top-level-if-only-type-imports'],
+    },
+    {
+      code: "export { Foo, type Bar } from 'Foo';",
+      options: ['prefer-top-level-if-only-type-imports'],
+    },
+
+    //
+    // prefer-inline
+    //
+    {
+      code: 'export { type Foo };',
+      options: ['prefer-inline'],
+    },
+    {
+      code: "export { type Foo as Bar } from 'Foo';",
+      options: ['prefer-inline'],
+    },
   ],
-  invalid: [],
+  invalid: [
+    //
+    // default (prefer-inline)
+    //
+    {
+      code: 'export type { Foo };',
+      output: 'export { type Foo };',
+      errors: [{
+        message: 'Prefer using inline type specifiers instead of a top-level type-only export.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+
+    //
+    // prefer-top-level
+    //
+    {
+      code: 'export { type Foo };',
+      output: 'export type { Foo };',
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+    {
+      code: "export { type Foo as Bar } from 'Foo';",
+      output: "export type { Foo as Bar } from 'Foo';",
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+    {
+      code: 'export { type Foo, type Bar };',
+      output: 'export type { Foo, Bar };',
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+    {
+      code: "export { type Foo /* keep */ } from 'Foo';",
+      output: "export type { Foo /* keep */ } from 'Foo';",
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+    {
+      code: 'export { Foo, type Bar };',
+      output: 'export { Foo  };\nexport type {Bar};',
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportSpecifier',
+      }],
+    },
+    {
+      code: "export { type Foo, Bar as Baz } from 'Foo';",
+      output: "export {  Bar as Baz } from 'Foo';\nexport type {Foo} from 'Foo';",
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportSpecifier',
+      }],
+    },
+    {
+      code: "export { Foo, type Bar /* keep */ } from 'Foo'",
+      output: null,
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportSpecifier',
+      }],
+    },
+    {
+      code: "export { Foo, /* Bar docs */ type Bar } from 'Foo';",
+      output: null,
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportSpecifier',
+      }],
+    },
+    {
+      code: 'export {\n  Foo,\n  // Bar docs\n  type Bar,\n};',
+      output: null,
+      options: ['prefer-top-level'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers.',
+        type: 'ExportSpecifier',
+      }],
+    },
+
+    //
+    // prefer-top-level-if-only-type-imports
+    //
+    {
+      code: 'export { type Foo, type Bar };',
+      output: 'export type { Foo, Bar };',
+      options: ['prefer-top-level-if-only-type-imports'],
+      errors: [{
+        message: 'Prefer using a top-level type-only export instead of inline type specifiers when there are only type exports.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+
+    //
+    // prefer-inline
+    //
+    {
+      code: 'export type { Foo };',
+      output: 'export { type Foo };',
+      options: ['prefer-inline'],
+      errors: [{
+        message: 'Prefer using inline type specifiers instead of a top-level type-only export.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+    {
+      code: "export type { Foo as Bar } from 'Foo';",
+      output: "export { type Foo as Bar } from 'Foo';",
+      options: ['prefer-inline'],
+      errors: [{
+        message: 'Prefer using inline type specifiers instead of a top-level type-only export.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+    {
+      code: "export type { Foo /* keep */ } from 'Foo'",
+      output: "export { type Foo /* keep */ } from 'Foo'",
+      options: ['prefer-inline'],
+      errors: [{
+        message: 'Prefer using inline type specifiers instead of a top-level type-only export.',
+        type: 'ExportNamedDeclaration',
+      }],
+    },
+  ],
 };
 
 const FLOW_ONLY = {
@@ -376,6 +584,10 @@ const FLOW_ONLY = {
     },
     {
       code: "import { type Foo, type Bar, typeof Baz, typeof Bam } from 'Foo';",
+      options: ['prefer-inline'],
+    },
+    {
+      code: 'export type { Foo };',
       options: ['prefer-inline'],
     },
   ],


### PR DESCRIPTION
Closes #3044.

## Summary
- apply all consistent-type-specifier-style preferences to TypeScript named exports
- support local exports, re-exports, aliases, mixed value/type exports, comments, and semicolonless syntax
- keep Flow exports out of scope and conservatively omit fixes for export attributes/assertions or ambiguous leading comments
- update rule docs, generated README metadata, and changelog attribution

## Validation
- focused rule suite: 151 passing
- full npm test: 3,145 passing, 2 pending
- npm run test-types with TypeScript 7.0.2
- ESLint, build, generated-doc check, Markdown lint, and git diff --check