### PR TITLE
[resolvers] [webpack] [fix] use a valid `file:` spec for the webpack stub

### DIFF
--- a/resolvers/webpack/CHANGELOG.md
+++ b/resolvers/webpack/CHANGELOG.md
@@ -5,6 +5,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 - [tests] replace gist dep with local file dep
+- [fix] use a valid `file:` spec for the webpack stub ([#3279], thanks [@manzoorwanijk])
 - [deps] update `hasown`
 
 ## 0.13.11 - 2026-04-01
@@ -190,6 +191,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Added
  - `interpret` configs (such as `.babel.js`). Thanks to [@gausie] for the initial PR ([#164], ages ago! 😅) and [@jquense] for tests ([#278]).
 
+[#3279]: https://github.com/import-js/eslint-plugin-import/pull/3279
 [#3100]: https://github.com/import-js/eslint-plugin-import/pull/3100
 [#3029]: https://github.com/import-js/eslint-plugin-import/pull/3029
 [#2287]: https://github.com/import-js/eslint-plugin-import/pull/2287
@@ -249,6 +251,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 [@kesne]: https://github.com/kesne
 [@Kovensky]: https://github.com/Kovensky
 [@ljharb]: https://github.com/ljharb
+[@manzoorwanijk]: https://github.com/manzoorwanijk
 [@mattkrick]: https://github.com/mattkrick
 [@migueloller]: https://github.com/migueloller
 [@ogonkov]: https://github.com/ogonkov

--- a/resolvers/webpack/package.json
+++ b/resolvers/webpack/package.json
@@ -53,7 +53,7 @@
     "chai": "^3.5.0",
     "mocha": "^3.5.3",
     "nyc": "^11.9.0",
-    "webpack": "file://./webpack-stub"
+    "webpack": "file:./webpack-stub"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
Fixes the `Tests: eslint (old versions)` CI failures on main, introduced in 5f8ae098.

## Problem

5f8ae098 added `"webpack": "file://./webpack-stub"`. The `file://` prefix makes npm parse the rest as a URL, so `.` is read as the host and the path becomes `/webpack-stub` — outside the repo. npm creates a dangling symlink:

```
node_modules/webpack -> ../../../../../../../../webpack-stub
```

The initial `npm install` tolerates this, but the node ends up with an empty version string. The next npm command run by `tests/dep-time-travel.sh` then throws:

```
silly placeDep ROOT webpack@ OK for: eslint-import-resolver-webpack@0.13.11 want: file://./webpack-stub
TypeError: Invalid Version:
    at Object.gte (semver/functions/gte.js:2:30)
    at Node.canDedupe (@npmcli/arborist/lib/node.js:1035:32)
```

Only npm 7 throws here (npm 8+ does not), which is why exactly the Node 10–15 jobs failed. Since `dep-time-travel.sh` doesn't check exit codes, the failed `npm install --no-save eslint@N` went unnoticed and the suite ran against modern ESLint on old Node, surfacing later as an unrelated-looking `SyntaxError: Unexpected token .` on optional chaining.

## Fix

```diff
-    "webpack": "file://./webpack-stub"
+    "webpack": "file:./webpack-stub"
```

## Verification

Reproduced locally against a clean export of `HEAD` with npm 7.24.2 (the version used by the failing jobs) — identical `npm ERR! Invalid Version:`. With the fix:

- `node_modules/webpack -> ../resolvers/webpack/webpack-stub` — resolvable
- `npm uninstall --no-save @angular-eslint/template-parser` — passes
- `npm install --no-save eslint@4 --ignore-scripts` — passes, `eslint` resolves to `4.19.1`
- `npm uninstall --no-save @typescript-eslint/parser` — passes
