### PR TITLE
[Fix] `newline-after-import`: preserve comments between imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`no-unused-modules`]: normalize path separators so `listFilesWithNodeFs` glob matching works on Windows ([#3230], thanks [@ljharb])
 - [`no-unused-modules`]: honor the flat config's global `ignores` in the `listFilesWithNodeFs` fallback, restoring parity with the file set ESLint lints ([#3230], thanks [@ljharb])
 - [`no-deprecated`], [`namespace`]: route `declaredScope` through the `getScope` compat shim instead of the removed `context.getScope()` (ESLint 9+) ([#3230], thanks [@ljharb])
+- [`newline-after-import`]: ignore comments between consecutive imports when `considerComments` is enabled ([#2673], thanks [@raisulchowdhury])
 
 ### Changed
 - [Refactor] [`order`]: extract the ESLint 10 token/comment compatibility shims into a reusable `getTokenOrComment` util ([#3230], thanks [@captaindonald])
@@ -1284,6 +1285,7 @@ for info on changes for earlier releases.
 [#2748]: https://github.com/import-js/eslint-plugin-import/pull/2748
 [#2735]: https://github.com/import-js/eslint-plugin-import/pull/2735
 [#2699]: https://github.com/import-js/eslint-plugin-import/pull/2699
+[#2673]: https://github.com/import-js/eslint-plugin-import/issues/2673
 [#2664]: https://github.com/import-js/eslint-plugin-import/pull/2664
 [#2640]: https://github.com/import-js/eslint-plugin-import/pull/2640
 [#2613]: https://github.com/import-js/eslint-plugin-import/pull/2613

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -179,9 +179,17 @@ module.exports = {
         return;
       }
 
+      if (nextNode && nextNode.type === 'ImportDeclaration') {
+        return;
+      }
+
+      if (nextNode && nextNode.type === 'TSImportEqualsDeclaration' && !nextNode.isExport) {
+        return;
+      }
+
       if (nextComment && typeof nextComment !== 'undefined') {
         commentAfterImport(node, nextComment, 'import');
-      } else if (nextNode && nextNode.type !== 'ImportDeclaration' && (nextNode.type !== 'TSImportEqualsDeclaration' || nextNode.isExport)) {
+      } else if (nextNode) {
         checkForNewLine(node, nextNode, 'import');
       }
     }

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -117,6 +117,11 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
+      code: `import foo from 'foo';\n// Bar.\n// Baz.\nimport qux from 'qux';\n\nconst quux = 'quux';`,
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+      options: [{ considerComments: true }],
+    },
+    {
       code: `import path from 'path';import foo from 'foo';\n`,
       parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
@@ -285,6 +290,12 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
         parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
       },
       {
+        code: `import { ExecaReturnValue } from 'execa';\n// intermediate comment\nimport execa = require('execa');\n\nconst foo = 1;`,
+        parser,
+        parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+        options: [{ considerComments: true }],
+      },
+      {
         code: `
           import execa = require('execa');
           import { ExecaReturnValue } from 'execa';
@@ -411,6 +422,14 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
   ),
 
   invalid: [].concat(
+    // an `export import` following a TS import-equals must still require a newline
+    flatMap(getTSParsers(), (parser) => [{
+      code: `import { ns } from 'namespace';\nimport Bar = ns.baz.foo.Bar;\nexport import Foo = ns.baz.bar.Foo;\n`,
+      output: `import { ns } from 'namespace';\nimport Bar = ns.baz.foo.Bar;\n\nexport import Foo = ns.baz.bar.Foo;\n`,
+      parser,
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+      errors: [{ line: 2, message: IMPORT_ERROR_MESSAGE }],
+    }]),
     {
       code: `
         import { A, B, C, D } from


### PR DESCRIPTION
## Summary

When `newline-after-import` runs with `considerComments`, comments between two
imports are part of the import group and should not trigger a blank-line error.
The rule now checks the following import declaration before evaluating the
intervening comment, with a regression test for consecutive imports.

Fixes #2673.

## Validation

- full test suite: 3,121 passing, 2 pending
- lint and Markdown checks
- `git diff --check`

## AI assistance

AI assistance was used for investigation and drafting. I reviewed the rule,
test contract, and complete diff, then independently ran the full validation.
