### PR TITLE
[Fix] `newline-after-import`: skip comment checks between imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [`newline-after-import`]: ignore comments between consecutive imports when `considerComments` is enabled ([#2673], thanks [@raisulchowdhury])
 - [`no-unresolved`], [`no-useless-path-segments`]: handle template literal requires ([#3276], thanks [@pratyushsinghal7])
 - [types] remove `stage-0` from the `flatConfigs` types, since it does not exist at runtime, and add type tests for the plugin's exports ([#3169], thanks [@KAMRONBEK])
+- [`newline-after-import`]: skip comment checks between imports ([#3282], thanks [@raisulchowdhury])
 
 ### Changed
 - [Refactor] [`order`]: extract the ESLint 10 token/comment compatibility shims into a reusable `getTokenOrComment` util ([#3230], thanks [@captaindonald])
@@ -1214,6 +1215,7 @@ for info on changes for earlier releases.
 
 [#3284]: https://github.com/import-js/eslint-plugin-import/pull/3284
 [#3283]: https://github.com/import-js/eslint-plugin-import/pull/3283
+[#3282]: https://github.com/import-js/eslint-plugin-import/pull/3282
 [#3276]: https://github.com/import-js/eslint-plugin-import/pull/3276
 [#3262]: https://github.com/import-js/eslint-plugin-import/pull/3262
 [#3250]: https://github.com/import-js/eslint-plugin-import/pull/3250

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -179,9 +179,16 @@ module.exports = {
         return;
       }
 
+      if (nextNode && (
+        nextNode.type === 'ImportDeclaration'
+        || nextNode.type === 'TSImportEqualsDeclaration' && !nextNode.isExport
+      )) {
+        return;
+      }
+
       if (nextComment && typeof nextComment !== 'undefined') {
         commentAfterImport(node, nextComment, 'import');
-      } else if (nextNode && nextNode.type !== 'ImportDeclaration' && (nextNode.type !== 'TSImportEqualsDeclaration' || nextNode.isExport)) {
+      } else if (nextNode) {
         checkForNewLine(node, nextNode, 'import');
       }
     }

--- a/src/rules/newline-after-import.js
+++ b/src/rules/newline-after-import.js
@@ -179,7 +179,12 @@ module.exports = {
         return;
       }
 
-      if (nextNode && nextNode.type === 'ImportDeclaration') {
+      if (
+        nextNode && (
+          nextNode.type === 'ImportDeclaration'
+          || nextNode.type === 'TSImportEqualsDeclaration' && !nextNode.isExport
+        )
+      ) {
         return;
       }
 

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -122,6 +122,11 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       options: [{ considerComments: true }],
     },
     {
+      code: `import './index.scss';\n\n// other imports\nimport { ErrorBoundary } from 'react-error-boundary';`,
+      options: [{ count: 2, exactCount: true, considerComments: true }],
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+    },
+    {
       code: `import path from 'path';import foo from 'foo';\n`,
       parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },

--- a/tests/src/rules/newline-after-import.js
+++ b/tests/src/rules/newline-after-import.js
@@ -117,6 +117,11 @@ ruleTester.run('newline-after-import', require('rules/newline-after-import'), {
       parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },
     {
+      code: `import './index.scss';\n\n// other imports\nimport { ErrorBoundary } from 'react-error-boundary';`,
+      options: [{ count: 2, exactCount: true, considerComments: true }],
+      parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
+    },
+    {
       code: `import path from 'path';import foo from 'foo';\n`,
       parserOptions: { ecmaVersion: 2015, sourceType: 'module' },
     },


### PR DESCRIPTION
## Summary

- Treat the next top-level import as part of the import group before evaluating comments.
- Prevent `newline-after-import` from reporting a blank-line error for comments between imports.
- Add the reported `considerComments` regression case.

Fixes #2913.

## Validation

- `npm run mocha -- tests/src/rules/newline-after-import.js` (`97` passing)
- `npm test` (`3121` passing, `2` pending)
- `git diff --check`

Assisted-by: OpenAI Codex. The contributor reviewed the implementation and validation before publication.
