### PR TITLE
[Docs] clarify flat config file scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [Tests] cover ESLint 10 `getTokenOrComment` and `listFilesToProcess` API fallbacks ([#3230], thanks [@captaindonald])
 - [Docs] `no-unused-modules`: Fix docs of `ignoreUnusedTypeExports` option ([#3233], thanks [@ej612])
 - [actions] update `codecov/codecov-action` to v7, for reliable tokenless coverage uploads from fork PRs ([#3262], thanks [@captaindonald])
+- [Docs] clarify flat config file scoping ([#3283], thanks [@raisulchowdhury])
 
 ## [2.32.0] - 2025-06-20
 
@@ -1207,6 +1208,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3283]: https://github.com/import-js/eslint-plugin-import/pull/3283
 [#3262]: https://github.com/import-js/eslint-plugin-import/pull/3262
 [#3250]: https://github.com/import-js/eslint-plugin-import/pull/3250
 [#3230]: https://github.com/import-js/eslint-plugin-import/pull/3230

--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ export default tseslint.config(
 );
 ```
 
+`importPlugin.flatConfigs.recommended` does not specify a `files` pattern. Scope it to JavaScript and TypeScript files in projects that also lint other file types. For Angular projects, use the Angular-specific parser and apply the import plugin configuration only to the files it can parse, rather than to Angular HTML templates.
+
 ## Resolvers
 
 With the advent of module bundlers and the current state of modules and module


### PR DESCRIPTION
## Summary

- Clarify that `flatConfigs.recommended` does not set a `files` pattern.
- Explain how to scope the import config in projects that lint multiple file types, including Angular templates.

Fixes #3099

## Validation

- `markdownlint README.md`
- `git diff --check`

This follows the maintainer guidance in #3099 and documents the existing configuration behavior without changing the exported config. AI assistance was used for implementation and review; the final diff and validation were checked before publication.