### PR TITLE
[Docs] show bare plugin flat config usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - [Docs] `no-unused-modules`: Fix docs of `ignoreUnusedTypeExports` option ([#3233], thanks [@ej612])
 - [actions] update `codecov/codecov-action` to v7, for reliable tokenless coverage uploads from fork PRs ([#3262], thanks [@captaindonald])
 - [Docs] clarify flat config file scoping ([#3283], thanks [@raisulchowdhury])
+- [Docs] show bare plugin flat config usage ([#3284], thanks [@raisulchowdhury])
 
 ## [2.32.0] - 2025-06-20
 
@@ -1208,6 +1209,7 @@ for info on changes for earlier releases.
 
 [`memo-parser`]: ./memo-parser/README.md
 
+[#3284]: https://github.com/import-js/eslint-plugin-import/pull/3284
 [#3283]: https://github.com/import-js/eslint-plugin-import/pull/3283
 [#3262]: https://github.com/import-js/eslint-plugin-import/pull/3262
 [#3250]: https://github.com/import-js/eslint-plugin-import/pull/3250

--- a/README.md
+++ b/README.md
@@ -163,6 +163,24 @@ export default [
 ];
 ```
 
+ - Configuring rules without a preset:
+
+```js
+import importPlugin from 'eslint-plugin-import';
+
+export default [
+  {
+    files: ['**/*.{js,mjs,cjs,jsx,mjsx}'],
+    plugins: {
+      import: importPlugin,
+    },
+    rules: {
+      'import/no-cycle': 'warn',
+    },
+  },
+];
+```
+
 ## TypeScript
 
 You may use the following snippet or assemble your own config using the granular settings described below it.
@@ -190,6 +208,34 @@ Make sure you have installed [`@typescript-eslint/parser`] and [`eslint-import-r
 
 [`@typescript-eslint/parser`]: https://github.com/typescript-eslint/typescript-eslint/tree/HEAD/packages/parser
 [`eslint-import-resolver-typescript`]: https://github.com/import-js/eslint-import-resolver-typescript
+
+### Config - Flat
+
+```js
+import importPlugin from 'eslint-plugin-import';
+import tsParser from '@typescript-eslint/parser';
+
+export default [
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+    },
+    plugins: {
+      import: importPlugin,
+    },
+    settings: {
+      'import/resolver': {
+        typescript: true,
+        node: true,
+      },
+    },
+    rules: {
+      'import/no-unresolved': 'error',
+    },
+  },
+];
+```
 
 ### Config - Flat with `config()` in `typescript-eslint`
 


### PR DESCRIPTION
## Summary

- document how to register eslint-plugin-import directly in flat config and enable a selected rule without a preset
- add a TypeScript flat-config example with the TypeScript parser and resolver settings

Fixes #3083.

## Validation

- npx --yes markdownlint-cli@0.35 README.md
- git diff --check

## AI assistance

This PR was prepared with AI assistance. The changes are limited to the README, and the examples and diff were reviewed against the existing flat-config guidance in this repository.