### PR TITLE
[Fix] `no-deprecated`: detect `@deprecated` on decorated TypeScript exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 - support eslint v10 ([#3230], thanks [@rasmi])
 - [`no-deprecated`]: detect `@deprecated` on default-exported identifier declarations ([#3247], thanks [@mixelburg] [@etyrrell22])
 - [`consistent-type-specifier-style`]: add `prefer-top-level-if-only-type-imports` option ([#3210], thanks [@aldeed])
+- [`no-deprecated`]: detect `@deprecated` on decorated TypeScript exports ([#3094], thanks [@raisulchowdhury])
 
 ### Fixed
 - [`no-duplicates`]: fix `prefer-inline` autofix producing invalid syntax when an identifier named `from` is imported ([#3236], thanks [@DukeDeSouth] [@Quantaly])
@@ -1235,6 +1236,7 @@ for info on changes for earlier releases.
 [#3105]: https://github.com/import-js/eslint-plugin-import/pull/3105
 [#3104]: https://github.com/import-js/eslint-plugin-import/pull/3104
 [#3097]: https://github.com/import-js/eslint-plugin-import/pull/3097
+[#3094]: https://github.com/import-js/eslint-plugin-import/issues/3094
 [#3079]: https://github.com/import-js/eslint-plugin-import/issues/3079
 [#3073]: https://github.com/import-js/eslint-plugin-import/pull/3073
 [#3072]: https://github.com/import-js/eslint-plugin-import/pull/3072
@@ -2069,6 +2071,7 @@ for info on changes for earlier releases.
 [@ProdigySim]: https://github.com/ProdigySim
 [@pzhine]: https://github.com/pzhine
 [@Quantaly]: https://github.com/Quantaly
+[@raisulchowdhury]: https://github.com/raisulchowdhury
 [@ramasilveyra]: https://github.com/ramasilveyra
 [@randallreedjr]: https://github.com/randallreedjr
 [@rasmi]: https://github.com/rasmi

--- a/src/exportMap/visitor.js
+++ b/src/exportMap/visitor.js
@@ -49,7 +49,11 @@ export default class ImportExportVisitorBuilder {
   build(astNode) {
     return {
       ExportDefaultDeclaration() {
-        const exportMeta = captureDoc(this.source, this.docStyleParsers, astNode);
+        // A decorated export's doc may sit above the first decorator, outside the export node's range.
+        // The export node is checked first, so a doc between decorator and `export` still wins;
+        // later decorators are ignored, since a doc between decorators does not document the export.
+        const decorators = astNode.declaration.decorators || [];
+        const exportMeta = captureDoc(this.source, this.docStyleParsers, astNode, ...decorators.slice(0, 1));
         if (astNode.declaration.type === 'Identifier') {
           this.namespace.add(exportMeta, astNode.declaration);
           // If the export has no JSDoc, look for it on the referenced declaration
@@ -98,6 +102,10 @@ export default class ImportExportVisitorBuilder {
         captureDependencyWithSpecifiers(astNode, this.remotePathResolver, this.exportMap, this.context, this.thunkFor);
         // capture declaration
         if (astNode.declaration != null) {
+          // A decorated export's doc may sit above the first decorator, outside the export node's range.
+          // The export node is checked first, so a doc between decorator and `export` still wins;
+          // later decorators are ignored, since a doc between decorators does not document the export.
+          const decorators = astNode.declaration.decorators || [];
           switch (astNode.declaration.type) {
             case 'FunctionDeclaration':
             case 'ClassDeclaration':
@@ -110,7 +118,10 @@ export default class ImportExportVisitorBuilder {
             case 'TSInterfaceDeclaration':
             case 'TSAbstractClassDeclaration':
             case 'TSModuleDeclaration':
-              this.exportMap.namespace.set(astNode.declaration.id.name, captureDoc(this.source, this.docStyleParsers, astNode));
+              this.exportMap.namespace.set(
+                astNode.declaration.id.name,
+                captureDoc(this.source, this.docStyleParsers, astNode, ...decorators.slice(0, 1)),
+              );
               break;
             case 'VariableDeclaration':
               astNode.declaration.declarations.forEach((d) => {

--- a/tests/files/ts-deprecated.ts
+++ b/tests/files/ts-deprecated.ts
@@ -6,3 +6,33 @@
 export function foo() {
   return 'bar'
 }
+
+function decorate() {
+  return () => {};
+}
+
+/**
+ * @deprecated don't use this class!
+ */
+@decorate()
+export class DeprecatedClass {}
+
+/**
+ * @deprecated don't use this default class!
+ */
+@decorate()
+export default class DeprecatedDefaultClass {}
+
+// this comment must stay above the decorator, to cover a doc between decorator and export
+@decorate()
+/**
+ * @deprecated don't use this between class!
+ */
+export class DeprecatedBetweenClass {}
+
+@decorate()
+/**
+ * @deprecated this doc is sandwiched between decorators, and documents nothing!
+ */
+@decorate()
+export class NotDeprecatedSandwichClass {}

--- a/tests/src/rules/no-deprecated.js
+++ b/tests/src/rules/no-deprecated.js
@@ -219,6 +219,10 @@ describe('TypeScript', function () {
           code: 'import * as hasDeprecated from \'./ts-deprecated.ts\'',
           ...parserConfig,
         }),
+        test({
+          code: 'import { NotDeprecatedSandwichClass } from \'./ts-deprecated.ts\'',
+          ...parserConfig,
+        }),
       ],
       invalid: [
         test({
@@ -226,6 +230,27 @@ describe('TypeScript', function () {
           errors: [
             { type: 'ImportSpecifier', message: 'Deprecated: don\'t use this!' },
             { type: 'Identifier', message: 'Deprecated: don\'t use this!' },
+          ],
+          ...parserConfig,
+        }),
+        test({
+          code: 'import { DeprecatedClass } from \'./ts-deprecated.ts\'',
+          errors: [
+            { type: 'ImportSpecifier', message: 'Deprecated: don\'t use this class!' },
+          ],
+          ...parserConfig,
+        }),
+        test({
+          code: 'import DeprecatedDefaultClass from \'./ts-deprecated.ts\'',
+          errors: [
+            { type: 'ImportDefaultSpecifier', message: 'Deprecated: don\'t use this default class!' },
+          ],
+          ...parserConfig,
+        }),
+        test({
+          code: 'import { DeprecatedBetweenClass } from \'./ts-deprecated.ts\'',
+          errors: [
+            { type: 'ImportSpecifier', message: 'Deprecated: don\'t use this between class!' },
           ],
           ...parserConfig,
         }),


### PR DESCRIPTION
## Summary

- associate leading documentation before decorators with named and default exported declarations
- report deprecated decorated TypeScript classes through `import/no-deprecated`
- add focused regression fixtures and rule tests for named and default decorated exports

Fixes #3094.

## Validation

- targeted no-deprecated suite: 57 passing (`BABEL_ENV=test BABEL_DISABLE_CACHE=1 ./node_modules/.bin/mocha --require babel-register tests/src/rules/no-deprecated.js`)
- ESLint on changed JavaScript and TypeScript files
- `git diff --check`

The full repository suite was not run because the isolated checkout encountered disk pressure during dependency installation; the targeted suite and changed-file lint pass using the repository dependency set.

## AI assistance

This PR was prepared with AI assistance. The source change, regression tests, and changelog entry were reviewed against the existing export-map documentation contract.
