### PR TITLE
[Fix] `no-cycle`: don't throw when the linted path is not on disk

### DIFF
--- a/src/rules/no-cycle.js
+++ b/src/rules/no-cycle.js
@@ -70,7 +70,13 @@ module.exports = {
       context,
     );
 
-    const scc = options.disableScc ? {} : StronglyConnectedComponentsBuilder.get(myPath, context);
+    // `StronglyConnectedComponentsBuilder.get` returns null when `myPath` does not
+    // resolve, which happens whenever the linted text has no file on disk — e.g.
+    // `eslint --stdin --stdin-filename=not-yet-written.js`, or `ESLint#lintText`.
+    // The SCC map is only an optimisation for skipping unreachable imports, so an
+    // empty one is the correct fallback: every lookup is `undefined`, which makes
+    // each pair compare equal and traverses everything, exactly as `disableScc` does.
+    const scc = options.disableScc ? {} : StronglyConnectedComponentsBuilder.get(myPath, context) || {};
 
     function checkSourceValue(sourceNode, importer, moduleSystem) {
       if (ignoreModule(sourceNode.value, moduleSystem)) {

--- a/tests/src/rules/no-cycle.js
+++ b/tests/src/rules/no-cycle.js
@@ -39,6 +39,15 @@ const cases = {
       code: 'var bar = require("./bar")',
       filename: '<text>',
     }),
+    // A filename that does not resolve to a file on disk, which is the normal
+    // case for `eslint --stdin --stdin-filename=not-yet-written.js` and for
+    // `ESLint#lintText`. `<text>` above only covers the eslintrc sentinel; flat
+    // config passes the given name through, so this used to throw a TypeError
+    // out of the rule and abort the whole run.
+    test({
+      code: 'import { foo } from "./es6/depth-one"',
+      filename: testFilePath('./cycles/does-not-exist-on-disk.js'),
+    }),
     test({
       code: 'import { foo } from "cycles/external/depth-one"',
       options: [{ ignoreExternal: true }],


### PR DESCRIPTION
Fixes #3286.

`import/no-cycle` threw a `TypeError` and aborted the whole lint run whenever the linted path did
not exist on disk:

```
$ cat src/foo.js | eslint --stdin --stdin-filename=src/new-file.js
TypeError: Cannot read properties of null (reading '/…/src/new-file.js')
Rule: "import/no-cycle"
```

Exit code 2, and no results for any file. That is the normal case for an unsaved buffer, generated
code, or `ESLint#lintText`.

## Cause

`StronglyConnectedComponentsBuilder.get` returns `null` when the path does not resolve
(`src/scc.js:16`), and `scc[myPath]` at `no-cycle.js:116` dereferenced it.

Two conditions are needed together, which is why it has gone unnoticed: the linted path must not
resolve, **and** at least one import must resolve — otherwise `checkSourceValue` returns at the
`imported == null` check before line 116 is reached.

The `<text>` guard at line 63 anticipated non-file input, but that is the eslintrc sentinel; under
flat config the buffer keeps whatever `--stdin-filename` supplies, so it no longer covers this.

## Why `{}` is the right default

It restores exactly the `disableScc` semantics. Every lookup is `undefined`, so
`scc[myPath] === scc[imported.path]` is true and the `continue` at line 130 never fires — the rule
traverses everything, as it already does when the optimisation is switched off by config. The SCC
map only skips imports that cannot reach the current file, so an empty one is conservative rather
than merely non-crashing.

Behaviour for paths that do resolve is unchanged.

## Tests

One valid case added, using `./es6/depth-one` because both conditions above must hold — a fixture
that does not resolve, or one with no exports, returns before the crash site and would pass either
way.

Verified it genuinely catches the bug:

```
without the fix:  141 passing, 1 failing
                  TypeError: Cannot read properties of null (reading '…/does-not-exist-on-disk.js')
with the fix:     142 passing
```

Full rule suite: **2877 passing**. `eslint` clean on both changed files.

## Note

#3221 reports the same crash site with a resolver-specific trigger, attributed there to
`eslint-import-resolver-exports`. This reproduction uses the default resolver and no extra plugins,
so the root cause may be shared — worth a look when triaging that one.
