### PR TITLE
[Fix] `no-duplicates`: do not splice a bare comma from a trailing comma

### DIFF
--- a/src/rules/no-duplicates.js
+++ b/src/rules/no-duplicates.js
@@ -172,6 +172,11 @@ function getFix(first, rest, sourceCode, context) {
         // Add *only* the new identifiers that don't already exist, and track any new identifiers so we don't add them again in the next loop
         const [specifierText, updatedExistingIdentifiers] = specifier.identifiers.reduce(([text, set], cur) => {
           const trimmed = cur.trim(); // Trim whitespace before/after to compare to our set of existing identifiers
+          if (trimmed.length === 0) {
+            // A whitespace-only segment comes from a trailing comma; emitting it
+            // would splice a bare comma into the merged specifier list (#2757).
+            return [text, set];
+          }
           const hasLineComment = (/\/\/[^\n]*$/).test(trimmed);
           let curWithType;
           if (trimmed.length > 0 && preferInline && isTypeSpecifier) {

--- a/tests/src/rules/no-duplicates.js
+++ b/tests/src/rules/no-duplicates.js
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { expect } from 'chai';
 import { test as testUtil, getNonDefaultParsers, parsers, tsVersionSatisfies, typescriptEslintParserSatisfies } from '../utils';
 import jsxConfig from '../../../config/react';
 
@@ -483,6 +484,29 @@ import {x,y} from './foo'
       ],
       ...jsxConfig,
     }),
+
+    // #2757: a trailing comma in a merged import must not become a bare comma
+    // in the merged specifier list, which does not parse.
+    test({
+      code: `
+import { Foo } from "someImport";
+import {
+  BarLongNameToEnsureLineBreak,
+  BazManLongNameToEnsureLineBreak,
+} from "someImport";
+import { Qux } from "someImport";
+`,
+      output: `
+import { Foo,
+  BarLongNameToEnsureLineBreak,
+  BazManLongNameToEnsureLineBreak,Qux } from "someImport";
+`,
+      errors: [
+        "'someImport' imported multiple times.",
+        "'someImport' imported multiple times.",
+        "'someImport' imported multiple times.",
+      ],
+    }),
   ],
 });
 
@@ -815,4 +839,48 @@ context('TypeScript', function () {
         invalid,
       });
     });
+});
+
+context('fixer output re-parses', function () {
+  // An `output` assertion compares strings and cannot tell that the string is
+  // not valid JavaScript, which is how a fixer emitting unparseable source
+  // survived (#2757). Run the fixer for real and re-parse what it produced.
+  const fixAndReparse = (code) => {
+    const { Linter } = require('eslint');
+    const linter = new Linter();
+    let config;
+    if (semver.major(eslintPkg.version) >= 9) {
+      config = {
+        languageOptions: { ecmaVersion: 2018, sourceType: 'module' },
+        plugins: { import: { rules: { 'no-duplicates': rule } } },
+        rules: { 'import/no-duplicates': 'error' },
+      };
+    } else {
+      linter.defineRule('import/no-duplicates', rule);
+      config = {
+        // eslint 4/5 (espree <6) reject ecmaVersion values above 2018/2019
+        parserOptions: { ecmaVersion: 2018, sourceType: 'module' },
+        rules: { 'import/no-duplicates': 'error' },
+      };
+    }
+    const { output } = linter.verifyAndFix(code, config);
+    const parseOnly = semver.major(eslintPkg.version) >= 9
+      ? { languageOptions: config.languageOptions, plugins: config.plugins }
+      : { parserOptions: config.parserOptions };
+    const fatal = linter.verify(output, parseOnly).filter((m) => m.fatal);
+    return { output, fatal };
+  };
+
+  it('#2757: merged import with a trailing comma', function () {
+    // autofix needs eslint 4+
+    if (semver.satisfies(eslintPkg.version, '< 4')) { this.skip(); }
+    const { output, fatal } = fixAndReparse(`import { Foo } from "someImport";
+import {
+  BarLongNameToEnsureLineBreak,
+  BazManLongNameToEnsureLineBreak,
+} from "someImport";
+import { Qux } from "someImport";
+`);
+    expect(fatal, `fixed output does not parse:\n${output}`).to.deep.equal([]);
+  });
 });

--- a/tests/src/rules/no-unused-modules.js
+++ b/tests/src/rules/no-unused-modules.js
@@ -1372,35 +1372,39 @@ describe('support (nested) destructuring assignment', () => {
   });
 });
 
-describe('support ES2022 Arbitrary module namespace identifier names', () => {
-  ruleTester.run('no-unused-module', rule, {
-    valid: [].concat(
-      testVersion('>= 8.7', () => ({
-        options: unusedExportsOptions,
-        code: `import { "foo" as foo } from "./arbitrary-module-namespace-identifier-name-a"`,
-        parserOptions: { ecmaVersion: 2022 },
-        filename: testFilePath('./no-unused-modules/arbitrary-module-namespace-identifier-name-b.js'),
-      })),
-      testVersion('>= 8.7', () => ({
-        options: unusedExportsOptions,
-        code: 'const foo = 333;\nexport { foo as "foo" }',
-        parserOptions: { ecmaVersion: 2022 },
-        filename: testFilePath('./no-unused-modules/arbitrary-module-namespace-identifier-name-a.js'),
-      })),
-    ),
-    invalid: [].concat(
-      testVersion('>= 8.7', () => ({
-        options: unusedExportsOptions,
-        code: 'const foo = 333\nexport { foo as "foo" }',
-        parserOptions: { ecmaVersion: 2022 },
-        filename: testFilePath('./no-unused-modules/arbitrary-module-namespace-identifier-name-c.js'),
-        errors: [
-          error(`exported declaration 'foo' not used within other modules`),
-        ],
-      })),
-    ),
-  });
-});
+describe(
+  'support ES2022 Arbitrary module namespace identifier names',
+  { skip: !semver.satisfies(eslintPkg.version, '>=8.7') },
+  () => {
+    ruleTester.run('no-unused-module', rule, {
+      valid: [].concat(
+        testVersion('>= 8.7', () => ({
+          options: unusedExportsOptions,
+          code: `import { "foo" as foo } from "./arbitrary-module-namespace-identifier-name-a"`,
+          parserOptions: { ecmaVersion: 2022 },
+          filename: testFilePath('./no-unused-modules/arbitrary-module-namespace-identifier-name-b.js'),
+        })),
+        testVersion('>= 8.7', () => ({
+          options: unusedExportsOptions,
+          code: 'const foo = 333;\nexport { foo as "foo" }',
+          parserOptions: { ecmaVersion: 2022 },
+          filename: testFilePath('./no-unused-modules/arbitrary-module-namespace-identifier-name-a.js'),
+        })),
+      ),
+      invalid: [].concat(
+        testVersion('>= 8.7', () => ({
+          options: unusedExportsOptions,
+          code: 'const foo = 333\nexport { foo as "foo" }',
+          parserOptions: { ecmaVersion: 2022 },
+          filename: testFilePath('./no-unused-modules/arbitrary-module-namespace-identifier-name-c.js'),
+          errors: [
+            error(`exported declaration 'foo' not used within other modules`),
+          ],
+        })),
+      ),
+    });
+  },
+);
 
 describe('parser ignores prefixes like BOM and hashbang', () => {
   // bom, hashbang


### PR DESCRIPTION
Fixes #2757.

The no-duplicates fixer splits the text between an import's braces on commas to get the specifiers. When a merged import has a trailing comma, the last segment is whitespace only, and the fixer still emits it, splicing a bare comma into the merged list. With a multiline import in the middle, `eslint --fix` produces

```js
import { Foo,
  BarLongNameToEnsureLineBreak,
  BazManLongNameToEnsureLineBreak,,Qux } from "someImport";
```

That output is a syntax error, so the autofix breaks the file it was asked to fix. The change here skips whitespace-only segments.

The existing trailing comma tests still pass on the old code because they put the trailing comma in the first import, which happens to add an empty string to the set of seen identifiers, so later empty segments get skipped as duplicates. The bug needs a trailing comma in a later import only.

Tested with the exact case from the issue, pinned as an output assertion, plus a test that runs the fixer and re-parses what it emitted. RuleTester already fails an autofix that does not parse, so that one is belt and braces and easy to drop if you would rather not carry it. Ran the full no-duplicates suite on eslint 8.57 and 9.39: 105 passing before the change and 107 after. Both new tests fail if the src change is reverted. Lint is clean.

Not a security issue, and no behavior change for merges without trailing commas. #1838 is a different defect in the same fixer (the default import name is harvested from a comment-bearing import the fixer then refuses to remove) and is not fixed here.
